### PR TITLE
comma missing from analog json output

### DIFF
--- a/analog_recorder.cc
+++ b/analog_recorder.cc
@@ -144,7 +144,7 @@ void analog_recorder::deactivate() {
 		myfile << "{\n";
 		myfile << "\"freq\": " << freq << ",\n";
 		myfile << "\"num\": " << num << ",\n";
-		myfile << "\"talkgroup\": " << talkgroup << "\n";
+		myfile << "\"talkgroup\": " << talkgroup << ",\n";
 		myfile << "\"mode\": \"analog\" \n";
 		myfile << "}\n";
 		myfile.close();


### PR DESCRIPTION
Add comma to json output.

Before:
```json
{
"freq": 8.53225e+08,
"num": 6,
"talkgroup": 12944
"mode": "analog"
}
```

After:
```json
{
"freq": 8.53225e+08,
"num": 6,
"talkgroup": 12944,
"mode": "analog"
}
```