### PR TITLE
Add some logging to talkgroups.cc

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -5,7 +5,6 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/log/trivial.hpp>
-#include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/program_options.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/talkgroups.cc
+++ b/talkgroups.cc
@@ -1,4 +1,41 @@
 #include "talkgroups.h"
+#include <boost/log/trivial.hpp>
+
+
+// Retrieved from https://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
+std::istream& safeGetline(std::istream& is, std::string& t)
+{
+	t.clear();
+
+	// The characters in the stream are read one-by-one using a std::streambuf.
+	// That is faster than reading them one-by-one using the std::istream.
+	// Code that uses streambuf this way must be guarded by a sentry object.
+	// The sentry object performs various tasks,
+	// such as thread synchronization and updating the stream state.
+
+	std::istream::sentry se(is, true);
+	std::streambuf* sb = is.rdbuf();
+
+	for(;;) {
+		int c = sb->sbumpc();
+		switch (c) {
+		case '\n':
+			return is;
+		case '\r':
+			if(sb->sgetc() == '\n')
+				sb->sbumpc();
+			return is;
+		case EOF:
+			// Also handle the case when the last line has no line ending
+			if(t.empty())
+				is.setstate(std::ios::eofbit);
+			return is;
+		default:
+			t += (char)c;
+		}
+	}
+}
+
 
 Talkgroups::Talkgroups() {
 
@@ -7,7 +44,7 @@ Talkgroups::Talkgroups() {
 void Talkgroups::load_talkgroups(std::string filename) {
 	std::ifstream in(filename.c_str());
 	if (!in.is_open()) {
-		std::cout << "Error Opening TG File: " << filename << std::endl;
+		BOOST_LOG_TRIVIAL(error) << "Error Opening TG File: " << filename << std::endl;
 		return;
 	}
 	boost::char_separator<char> sep(",");
@@ -16,17 +53,39 @@ void Talkgroups::load_talkgroups(std::string filename) {
 	std::vector< std::string > vec;
 	std::string line;
 
-	while (getline(in,line, '\r'))  // this works with the CSV files from Excel, it might be a different new line charecter for other programs
+	int lines_read = 0;
+	int lines_pushed = 0;
+	while (safeGetline(in, line))  // this works with \r, \n, or \r\n
 	{
+		if (line.size() && line[line.size() - 1] == '\r') {
+			line = line.substr(0, line.size() - 1);
+		}
+
+		if (line == "") {
+			continue;
+		}
+
+		lines_read++;
 		t_tokenizer tok(line, sep);
 
 		vec.assign(tok.begin(),tok.end());
-		if (vec.size() < 8) continue;
+		if (vec.size() < 8) continue;  // yuck
 
 		Talkgroup *tg = new Talkgroup(atoi( vec[0].c_str()), vec[2].at(0),vec[3].c_str(),vec[4].c_str(),vec[5].c_str() ,vec[6].c_str(),atoi(vec[7].c_str()) );
 
 		talkgroups.push_back(tg);
+		lines_pushed++;
 	}
+
+	if (lines_pushed != lines_read) {
+		// The parser above is pretty brittle. This will help with debugging it, for now.
+		BOOST_LOG_TRIVIAL(error) << "Warning: skipped " << lines_read - lines_pushed << " of " << lines_read << " talkgroup entries! Invalid format?";
+		BOOST_LOG_TRIVIAL(error) << "The format is very particular. See https://github.com/robotastic/trunk-recorder for example input.";
+	}
+	else {
+		BOOST_LOG_TRIVIAL(info) << "Read " << lines_pushed << " talkgroups.";
+	}
+
 }
 
 Talkgroup *Talkgroups::find_talkgroup(long tg_number) {


### PR DESCRIPTION
The ChanList.csv parser is pretty brittle. This at least adds some logging to help troubleshoot why talkgroups are not found, and also makes it work correctly with all the standard line ending formats.