### PR TITLE
Clean up logging with BOOST_LOG_TRIVIAL

### DIFF
--- a/debug_recorder.cc
+++ b/debug_recorder.cc
@@ -95,7 +95,7 @@ void debug_recorder::tune_offset(double f) {
 	prefilter->set_center_freq(offset_amount); // have to flip this for 3.7
 }
 void debug_recorder::deactivate() {
-	BOOST_LOG_TRIVIAL(info) << "debug_recorder.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ] " << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "debug_recorder.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 
 	raw_sink->close();
@@ -118,7 +118,7 @@ void debug_recorder::activate( long t, double f, int n) {
 	freq = f;
 
 	tm *ltm = localtime(&starttime);
-	BOOST_LOG_TRIVIAL(info) << "debug_recorder.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]  "  <<std::endl;
+	BOOST_LOG_TRIVIAL(info) << "debug_recorder.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 
 	prefilter->set_center_freq(f - center); // have to flip for 3.7

--- a/dsd_recorder.cc
+++ b/dsd_recorder.cc
@@ -108,7 +108,7 @@ void dsd_recorder::tune_offset(double f) {
 	prefilter->set_center_freq(offset_amount); // have to flip this for 3.7
 }
 void dsd_recorder::deactivate() {
-	BOOST_LOG_TRIVIAL(info) << "dsd_recorder.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ] " << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "dsd_recorder.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 	//lock();
 
@@ -179,7 +179,7 @@ void dsd_recorder::activate( long t, double f, int n) {
 	freq = f;
 
 	tm *ltm = localtime(&starttime);
-	BOOST_LOG_TRIVIAL(info) << "dsd_recorder.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]  "  <<std::endl;
+	BOOST_LOG_TRIVIAL(info) << "dsd_recorder.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 
 	prefilter->set_center_freq(f - center); // have to flip for 3.7

--- a/main.cc
+++ b/main.cc
@@ -143,22 +143,22 @@ void load_config()
             std::string driver = node.second.get<std::string>("driver","");
             std::string device = node.second.get<std::string>("device","");
 
-            BOOST_LOG_TRIVIAL(info) << "Center: " << node.second.get<double>("center",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "Rate: " << node.second.get<double>("rate",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "Error: " << node.second.get<double>("error",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "Gain: " << node.second.get<int>("gain",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "IF Gain: " << node.second.get<int>("ifGain",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "BB Gain: " << node.second.get<int>("bbGain",0) << std::endl;
+            BOOST_LOG_TRIVIAL(info) << "Center: " << node.second.get<double>("center",0);
+            BOOST_LOG_TRIVIAL(info) << "Rate: " << node.second.get<double>("rate",0);
+            BOOST_LOG_TRIVIAL(info) << "Error: " << node.second.get<double>("error",0);
+            BOOST_LOG_TRIVIAL(info) << "Gain: " << node.second.get<int>("gain",0);
+            BOOST_LOG_TRIVIAL(info) << "IF Gain: " << node.second.get<int>("ifGain",0);
+            BOOST_LOG_TRIVIAL(info) << "BB Gain: " << node.second.get<int>("bbGain",0);
 
-            BOOST_LOG_TRIVIAL(info) << "Digital Recorders: " << node.second.get<int>("digitalRecorders",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "Debug Recorders: " << node.second.get<int>("debugRecorders",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "Analog Recorders: " << node.second.get<int>("analogRecorders",0) << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "driver: " << node.second.get<std::string>("driver","") << std::endl;
+            BOOST_LOG_TRIVIAL(info) << "Digital Recorders: " << node.second.get<int>("digitalRecorders",0);
+            BOOST_LOG_TRIVIAL(info) << "Debug Recorders: " << node.second.get<int>("debugRecorders",0);
+            BOOST_LOG_TRIVIAL(info) << "Analog Recorders: " << node.second.get<int>("analogRecorders",0);
+            BOOST_LOG_TRIVIAL(info) << "driver: " << node.second.get<std::string>("driver","");
 
 
             Source *source = new Source(center,rate,error,driver,device);
-            BOOST_LOG_TRIVIAL(info) << "Max HZ: " << source->get_max_hz() << std::endl;
-            BOOST_LOG_TRIVIAL(info) << "Min HZ: " << source->get_min_hz() << std::endl;
+            BOOST_LOG_TRIVIAL(info) << "Max HZ: " << source->get_max_hz();
+            BOOST_LOG_TRIVIAL(info) << "Min HZ: " << source->get_min_hz();
             source->set_if_gain(if_gain);
             source->set_bb_gain(bb_gain);
             source->set_gain(gain);
@@ -176,16 +176,16 @@ void load_config()
             control_channels.push_back(control_channel);
             BOOST_LOG_TRIVIAL(info) << node.second.get<double>("",0) << " ";
         }
-        BOOST_LOG_TRIVIAL(info) << std::endl;
+        BOOST_LOG_TRIVIAL(info);
 
         talkgroups_file = pt.get<std::string>("talkgroupsFile","");
-        BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << talkgroups_file << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << talkgroups_file;
         system_type = pt.get<std::string>("system.type");
 
     }
     catch (std::exception const& e)
     {
-        BOOST_LOG_TRIVIAL(error) << e.what() << std::endl;
+        BOOST_LOG_TRIVIAL(error) << e.what();
     }
 
 }
@@ -206,7 +206,7 @@ void start_recorder(TrunkMessage message) {
 
 
     if (message.encrypted == false) {
-    //BOOST_LOG_TRIVIAL(error) << "\tCall created for: " << call->get_talkgroup() << "\tTDMA: " << call->get_tdma() <<  "\tEncrypted: " << call->get_encrypted() << std::endl;
+        //BOOST_LOG_TRIVIAL(error) << "\tCall created for: " << call->get_talkgroup() << "\tTDMA: " << call->get_tdma() <<  "\tEncrypted: " << call->get_encrypted();
 
         for(vector<Source *>::iterator it = sources.begin(); it != sources.end(); it++) {
             Source * source = *it;
@@ -215,7 +215,7 @@ void start_recorder(TrunkMessage message) {
                 source_found = true;
 
                  if (call->get_tdma()) {
-                    BOOST_LOG_TRIVIAL(error) << "\tTrying to record TDMA: " << message.freq << " For TG: " << message.talkgroup << std::endl;
+                    BOOST_LOG_TRIVIAL(error) << "\tTrying to record TDMA: " << message.freq << " For TG: " << message.talkgroup;
                  }
 
                 if (talkgroup)
@@ -226,7 +226,7 @@ void start_recorder(TrunkMessage message) {
                         recorder = source->get_digital_recorder(talkgroup->get_priority());
                     }
                 } else {
-                    BOOST_LOG_TRIVIAL(error) << "\tTalkgroup not found: " << message.freq << " For TG: " << message.talkgroup << std::endl;
+                    BOOST_LOG_TRIVIAL(error) << "\tTalkgroup not found: " << message.freq << " For TG: " << message.talkgroup;
 
                     recorder = source->get_digital_recorder(3);
                 }
@@ -235,7 +235,7 @@ void start_recorder(TrunkMessage message) {
                     call->set_recorder(recorder);
                     call->set_recording(true);
                 } else {
-                    //BOOST_LOG_TRIVIAL(error) << "\tNot recording call" << std::endl;
+                    BOOST_LOG_TRIVIAL(error) << "\tNot recording call";
                 }
 
                 debug_recorder = source->get_debug_recorder();
@@ -244,14 +244,14 @@ void start_recorder(TrunkMessage message) {
                     call->set_recorder(debug_recorder);
                     call->set_recording(true);
                 } else {
-                    BOOST_LOG_TRIVIAL(trace) << "\tNot debug recording call" << std::endl;
+                    BOOST_LOG_TRIVIAL(trace) << "\tNot debug recording call";
                 }
 
             }
 
         }
         if (!source_found) {
-            BOOST_LOG_TRIVIAL(error) << "\tRecording not started because there was no source covering: " << message.freq << " For TG: " << message.talkgroup << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "\tRecording not started because there was no source covering: " << message.freq << " For TG: " << message.talkgroup;
         }
     }
 
@@ -271,12 +271,12 @@ void stop_inactive_recorders() {
                 call->get_recorder()->deactivate();
                 system(shell_command);
                 //BOOST_LOG_TRIVIAL(info) << "\tRemoving TG: " << call->get_talkgroup() << "\tElapsed: " << call->elapsed() << std::endl;
- 
             }
             if (call->get_debug_recording() == true) {
                 call->get_debug_recorder()->deactivate();
             }
 
+            //BOOST_LOG_TRIVIAL(trace) << "\tRemoving TG: " << call->get_talkgroup() << "\tElapsed: " << call->elapsed();
             it = calls.erase(it);
         } else {
             ++it;
@@ -294,6 +294,7 @@ void assign_recorder(TrunkMessage message) {
 
         if (call->get_talkgroup() == message.talkgroup) {
             if (call->get_freq() != message.freq) {
+                BOOST_LOG_TRIVIAL(trace) << "\tRetune - Total calls: " << calls.size() << "\tTalkgroup: " << message.talkgroup << "\tOld Freq: " << call->get_freq() << "\tNew Freq: " << message.freq;
                 // not sure what to do here; looks like we should retune
                 if (call->get_recording() == true) {
                     BOOST_LOG_TRIVIAL(info) << "\tAssign Retune - Elapsed: " << call->elapsed() << "s \tSince update: " << call->since_last_update() << "s \tTalkgroup: " << message.talkgroup << "\tOld Freq: " << call->get_freq() << "\tNew Freq: " << message.freq << std::endl;
@@ -315,9 +316,8 @@ void assign_recorder(TrunkMessage message) {
             if ((call->get_freq() == message.freq) && (call->get_tdma() == message.tdma)) {
                 //call_found = true;
 
-                
                 if (call->get_recording() == true) {
-                    BOOST_LOG_TRIVIAL(info) << "\tFreq in use -  TG: " << message.talkgroup << "\tFreq: " << message.freq << "\tTDMA: " << message.tdma << "\t Ending Existing call\tTG: " << call->get_talkgroup() << "\tTMDA: " << call->get_tdma() << "\tElapsed: " << call->elapsed() << "s \tSince update: " << call->since_last_update() << std::endl;
+                    BOOST_LOG_TRIVIAL(info) << "\tFreq in use -  TG: " << message.talkgroup << "\tFreq: " << message.freq << "\tTDMA: " << message.tdma << "\t Ending Existing call\tTG: " << call->get_talkgroup() << "\tTMDA: " << call->get_tdma() << "\tElapsed: " << call->elapsed() << "s \tSince update: " << call->since_last_update();
                 //different talkgroups on the same freq, that is trouble
 
                     sprintf(shell_command,"./encode-upload.sh %s > /dev/null 2>&1 &", call->get_recorder()->get_filename());
@@ -375,7 +375,7 @@ void update_recorder(TrunkMessage message) {
 
         if (call->get_talkgroup() == message.talkgroup) {
             if (call->get_freq() != message.freq) {
-                    
+                //BOOST_LOG_TRIVIAL(trace) << "\tUpdate Retune - Total calls: " << calls.size() << "\tTalkgroup: " << message.talkgroup << "\tOld Freq: " << call->get_freq() << "\tNew Freq: " << message.freq;
                 // not sure what to do here; looks like we should retune
 
                 if (call->get_recording() == true) {
@@ -494,7 +494,7 @@ void monitor_messages() {
             trunk_messages = p25_parser->parse_message(msg);
         }
         else {
-            BOOST_LOG_TRIVIAL(error) << msg->to_string() << std::endl;
+            BOOST_LOG_TRIVIAL(error) << msg->to_string();
         }
         handle_message(trunk_messages);
 
@@ -504,7 +504,7 @@ void monitor_messages() {
             messagesDecodedSinceLastReport = 0;
             lastMsgCountTime = currentTime;
             if (msgs_decoded_per_second < 10 ) {
-                BOOST_LOG_TRIVIAL(error) << "\tControl Channel Message Decode Rate: " << msgs_decoded_per_second << "/sec" << std::endl;
+                BOOST_LOG_TRIVIAL(error) << "\tControl Channel Message Decode Rate: " << msgs_decoded_per_second << "/sec";
             }
         }
 
@@ -583,7 +583,7 @@ int main(void)
         //------------------------------------------------------------------
         //-- stop flow graph execution
         //------------------------------------------------------------------
-        BOOST_LOG_TRIVIAL(info) << "stopping flow graph" << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "stopping flow graph";
         tb->stop();
         tb->wait();
     } else {

--- a/p25_parser.cc
+++ b/p25_parser.cc
@@ -63,7 +63,7 @@ double P25Parser::channel_id_to_frequency(int chan_id) {
 			return temp_chan.frequency + temp_chan.step * int(channel / temp_chan.tdma);
 		}
 	}
-	BOOST_LOG_TRIVIAL(info) << "\tFind - ChanId " << chan_id << " map id " << id  << "Channel " << channel << " size " << channels.size() << " ! Not Found ! " << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "\tFind - ChanId " << chan_id << " map id " << id  << "Channel " << channel << " size " << channels.size() << " ! Not Found !";
 	return  0;
 }
 
@@ -103,7 +103,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
                 unsigned long ga1   = bitset_shift_mask(tsbk, 48, 0xffff);
                 unsigned long ga2   = bitset_shift_mask(tsbk, 32, 0xffff);
                 unsigned long ga3   = bitset_shift_mask(tsbk, 16, 0xffff);
-                BOOST_LOG_TRIVIAL(trace) << "tsbk00\tMoto Patch Add \tsg: " << sg << "\tga1: " << ga1 << "\tga2: " << ga2 << "\tga3: " << ga3 << std::endl;
+                BOOST_LOG_TRIVIAL(trace) << "tsbk00\tMoto Patch Add \tsg: " << sg << "\tga1: " << ga1 << "\tga2: " << ga2 << "\tga3: " << ga3;
 
 
 		} else {
@@ -121,7 +121,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 				message.tdma = false;
 			}
 
-			BOOST_LOG_TRIVIAL(trace) << "tsbk00\tChan Grant\tChannel ID: " << std::setw(5) << ch << "\tFreq: "<< f1/1000000.0 << "\tga " << std::setw(7) << ga  << "\tTDMA " << get_tdma_slot(ch) << "\tsa " << sa << "\tEncrypt " << encrypted << "\tBandwidth: " << get_bandwidth(ch) << std::endl;
+			BOOST_LOG_TRIVIAL(trace) << "tsbk00\tChan Grant\tChannel ID: " << std::setw(5) << ch << "\tFreq: "<< f1/1000000.0 << "\tga " << std::setw(7) << ga  << "\tTDMA " << get_tdma_slot(ch) << "\tsa " << sa << "\tEncrypt " << encrypted << "\tBandwidth: " << get_bandwidth(ch);
 		}
 
 	} else if (opcode == 0x02) {  // group voice chan grant update
@@ -148,7 +148,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 
 
 
-            BOOST_LOG_TRIVIAL(error) << "tbsk02\tMoto Patch Grant\tChannel ID: " << std::setw(5) << ch << "\tFreq: "<< f/1000000.0 << "\tsg " << std::setw(7) << sg  << "\tTDMA " << get_tdma_slot(ch) << "\tsa " << sa << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "tbsk02\tMoto Patch Grant\tChannel ID: " << std::setw(5) << ch << "\tFreq: "<< f/1000000.0 << "\tsg " << std::setw(7) << sg  << "\tTDMA " << get_tdma_slot(ch) << "\tsa " << sa;
 
 
 		}
@@ -177,10 +177,10 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 				message.freq = f2;
 				message.talkgroup = ga2;
 				message.tdma = get_tdma_slot(ch2);
-				BOOST_LOG_TRIVIAL(trace) << "tsbk02\tGrant Update\tChannel ID: " << std::setw(5) << ch2 << "\tFreq: " << f2 / 1000000.0 << "\tga " << std::setw(7) << ga2 << "\tTDMA " << get_tdma_slot(ch2) << std::endl;
+				BOOST_LOG_TRIVIAL(trace) << "tsbk02\tGrant Update\tChannel ID: " << std::setw(5) << ch2 << "\tFreq: " << f2 / 1000000.0 << "\tga " << std::setw(7) << ga2 << "\tTDMA " << get_tdma_slot(ch2);
 			}
 
-			BOOST_LOG_TRIVIAL(trace) << "tsbk02\tGrant Update\tChannel ID: " << std::setw(5) << ch1 << "\tFreq: " << f1 / 1000000.0 << "\tga " << std::setw(7) << ga1 << "\tTDMA " << get_tdma_slot(ch1) << std::endl;
+			BOOST_LOG_TRIVIAL(trace) << "tsbk02\tGrant Update\tChannel ID: " << std::setw(5) << ch1 << "\tFreq: " << f1 / 1000000.0 << "\tga " << std::setw(7) << ga1 << "\tTDMA " << get_tdma_slot(ch1);
 		}
 	} else if ( opcode == 0x03 ) {
 
@@ -203,16 +203,16 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 				message.freq = f2;
 				message.talkgroup = sg2;
 				message.tdma = get_tdma_slot(ch2);
-	         	BOOST_LOG_TRIVIAL(trace) << "MOT_GRG_CN_GRANT_UPDT(0x03): \tChannel ID: "<< std::setw(5) << ch2 << "\tFreq: " << f2 / 1000000.0 << "\tsg " << std::setw(7) << sg2 << "\tTDMA " << get_tdma_slot(ch2) << std::endl;
+	         	BOOST_LOG_TRIVIAL(trace) << "MOT_GRG_CN_GRANT_UPDT(0x03): \tChannel ID: "<< std::setw(5) << ch2 << "\tFreq: " << f2 / 1000000.0 << "\tsg " << std::setw(7) << sg2 << "\tTDMA " << get_tdma_slot(ch2);
 			}
 
-            BOOST_LOG_TRIVIAL(trace) << "MOT_GRG_CN_GRANT_UPDT(0x03): \tChannel ID: "<< std::setw(5) << ch1 << "\tFreq: " << f1 / 1000000.0 << "\tsg " << std::setw(7) << sg1 << "\tTDMA " << get_tdma_slot(ch1) << std::endl;
+            BOOST_LOG_TRIVIAL(trace) << "MOT_GRG_CN_GRANT_UPDT(0x03): \tChannel ID: "<< std::setw(5) << ch1 << "\tFreq: " << f1 / 1000000.0 << "\tsg " << std::setw(7) << sg1 << "\tTDMA " << get_tdma_slot(ch1);
 
         }
 	} else if ( opcode == 0x16 ) {   // sndcp data ch
 		unsigned long ch1  = bitset_shift_mask(tsbk, 48, 0xffff);
 		unsigned long ch2  = bitset_shift_mask(tsbk, 32, 0xffff);
-		BOOST_LOG_TRIVIAL(trace) << "tsbk16 sndcp data ch: chan " << ch1 << " "  << ch2 << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk16 sndcp data ch: chan " << ch1 << " "  << ch2;
 	} else if (opcode == 0x34 ) {  // iden_up vhf uhf
 		unsigned long iden = bitset_shift_mask(tsbk, 76, 0xf);
 		unsigned long bwvu = bitset_shift_mask(tsbk, 72, 0xf);
@@ -240,7 +240,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 			bandwidth
 		};
 		add_channel(iden, temp_chan);
-		BOOST_LOG_TRIVIAL(trace) << "tsbk34 iden vhf/uhf id " << std::dec << iden << " toff " << toff * spac * 0.125 * 1e-3 << " spac " << spac * 0.125 << " freq " << freq * 0.000005 << " [ " << txt[toff_sign] << "]" << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk34 iden vhf/uhf id " << std::dec << iden << " toff " << toff * spac * 0.125 * 1e-3 << " spac " << spac * 0.125 << " freq " << freq * 0.000005 << " [ " << txt[toff_sign] << "]";
 	} else if (opcode == 0x33 ) {  // iden_up_tdma
 		unsigned long mfrid  = bitset_shift_mask(tsbk, 80, 0xff);
 		if (mfrid == 0) {
@@ -264,7 +264,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 				6.25
 			};
 			add_channel(iden,temp_chan);
-			BOOST_LOG_TRIVIAL(trace) << "tsbk33 iden up tdma id " << std::dec << iden << " f " <<  temp_chan.frequency << " offset " << temp_chan.offset << " spacing " << temp_chan.step << " slots/carrier " << temp_chan.tdma << std::endl;
+			BOOST_LOG_TRIVIAL(trace) << "tsbk33 iden up tdma id " << std::dec << iden << " f " <<  temp_chan.frequency << " offset " << temp_chan.offset << " spacing " << temp_chan.step << " slots/carrier " << temp_chan.tdma;
 		}
 	} else if (opcode == 0x3d)  {  // iden_up
 		unsigned long iden = bitset_shift_mask(tsbk, 76, 0xf);
@@ -287,7 +287,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 			bw * .125
 		};
 		add_channel(iden,temp_chan);
-		BOOST_LOG_TRIVIAL(trace) << "tsbk3d iden id "<< std::dec << iden <<" toff "<< toff * 0.25 << " spac " << spac * 0.125 << " freq " << freq * 0.000005 << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk3d iden id "<< std::dec << iden <<" toff "<< toff * 0.25 << " spac " << spac * 0.125 << " freq " << freq * 0.000005;
 	} else if (opcode == 0x3a)  {  // rfss status
 		unsigned long syid = bitset_shift_mask(tsbk, 56, 0xfff);
 		unsigned long rfid = bitset_shift_mask(tsbk, 48, 0xff);
@@ -313,7 +313,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 
 		}
 
-		BOOST_LOG_TRIVIAL(trace) << "tsbk39 secondary cc: rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1) << ") ch2 " << ch2 << "(" << channel_id_to_string(ch2) << ") " << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk39 secondary cc: rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1) << ") ch2 " << ch2 << "(" << channel_id_to_string(ch2) << ") ";
 	} else if (opcode == 0x3b) {  // network status
 		unsigned long wacn = bitset_shift_mask(tsbk, 52, 0xfffff);
 		unsigned long syid = bitset_shift_mask(tsbk, 40, 0xfff);
@@ -325,13 +325,13 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 			self.ns_wacn = wacn
 			self.ns_chan = f1*/
 		}
-		BOOST_LOG_TRIVIAL(trace) << "tsbk3b net stat: wacn " << std::dec << wacn << " syid " << syid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1) << ") " << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk3b net stat: wacn " << std::dec << wacn << " syid " << syid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1) << ") ";
 	} else if (opcode == 0x3c) {  // adjacent status
 		unsigned long rfid = bitset_shift_mask(tsbk, 48, 0xff);
 		unsigned long stid = bitset_shift_mask(tsbk, 40, 0xff);
 		unsigned long ch1  = bitset_shift_mask(tsbk, 24, 0xffff);
 		unsigned long f1 = channel_id_to_frequency(ch1);
-		BOOST_LOG_TRIVIAL(trace) << "tsbk3c\tAdjacent Status\t rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1) << ") " << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk3c\tAdjacent Status\t rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1) << ") ";
 
 		if (f1 ) {
 			it = channels.find((ch1 >> 12) & 0xf);
@@ -339,7 +339,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 			if (it != channels.end()) {
 				Channel temp_chan = it->second;
 				//			self.adjacent[f1] = 'rfid: %d stid:%d uplink:%f tbl:%d' % (rfid, stid, (f1 + self.freq_table[table]['offset']) / 1000000.0, table)
-				BOOST_LOG_TRIVIAL(trace) << "\ttsbk3c Chan " << temp_chan.frequency << "  " << temp_chan.step << std::endl;
+				BOOST_LOG_TRIVIAL(trace) << "\ttsbk3c Chan " << temp_chan.frequency << "  " << temp_chan.step;
 			}
 		}
 	} else if (opcode == 0x20) { //Acknowledge response
@@ -351,7 +351,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 		message.talkgroup = ga;
 		message.source = sa;
 
-		BOOST_LOG_TRIVIAL(trace) << "tsbk20\tAcknowledge Response\tga " << std::setw(7) << ga  <<"\tsa " << sa << "\tReserved: " << op << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk20\tAcknowledge Response\tga " << std::setw(7) << ga  <<"\tsa " << sa << "\tReserved: " << op;
 
 	} else if (opcode == 0x2c) { // Unit Registration Response
 		unsigned long mfrid  = bitset_shift_mask(tsbk,80,0xff);
@@ -367,7 +367,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 
 
 
-		BOOST_LOG_TRIVIAL(trace) << "tsbk2c\tUnit Registration Response\tsa " << std::setw(7) << sa << " Source ID: " << si << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk2c\tUnit Registration Response\tsa " << std::setw(7) << sa << " Source ID: " << si;
 	} else if (opcode == 0x2f) { // Unit DeRegistration Ack
 		unsigned long mfrid  = bitset_shift_mask(tsbk,80,0xff);
 		unsigned long opts  = bitset_shift_mask(tsbk,72,0xff);
@@ -395,7 +395,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 
 
 
-		BOOST_LOG_TRIVIAL(trace) << "tsbk2f\tUnit Group Affiliation\tSource ID: " << std::setw(7) << ta << "\tGroup Address: " << ga << "\tAnouncement Goup: " << aga << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "tsbk2f\tUnit Group Affiliation\tSource ID: " << std::setw(7) << ta << "\tGroup Address: " << ga << "\tAnouncement Goup: " << aga;
 	} else {
 		//std::cout << "tsbk other " << std::hex << opcode << std::endl;
 	}
@@ -405,7 +405,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk) 
 void P25Parser::print_bitset(boost::dynamic_bitset<> &tsbk) {
 	boost::dynamic_bitset<> bitmask(tsbk.size(), 0x3f);
 	unsigned long result = (tsbk & bitmask).to_ulong();
-	BOOST_LOG_TRIVIAL(trace) << tsbk << " = " << std::hex << result << std::endl;
+	BOOST_LOG_TRIVIAL(trace) << tsbk << " = " << std::hex << result;
 }
 void printbincharpad(char c)
 {
@@ -430,17 +430,17 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg) {
 	if (type == -2 ) {	 // # request from gui
 		std::string cmd = msg->to_string();
 
-		BOOST_LOG_TRIVIAL(trace) << "process_qmsg: command: " << cmd << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "process_qmsg: command: " << cmd;
 		//self.update_state(cmd, curr_time)
 		messages.push_back(message);
 		return messages;
 	} else if ( type == -1 ) {  //	# timeout
-		BOOST_LOG_TRIVIAL(trace) << "process_data_unit timeout" << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "process_data_unit timeout";
 		//self.update_state('timeout', curr_time)
 		messages.push_back(message);
 		return messages;
 	} else if ( type < 0 ) {
-		BOOST_LOG_TRIVIAL(trace) << "unknown message type " << type << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "unknown message type " << type;
 		messages.push_back(message);
 		return messages;
 	}
@@ -498,7 +498,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg) {
 		}
 		long opcode = (header >> 16) & 0x3f;
 
-		BOOST_LOG_TRIVIAL(trace) << "type " << type << " len " << s1.length() << "/"<< s2.length() << " opcode " << opcode << "[" << header << "/" << mbt_data << "]" << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "type " << type << " len " << s1.length() << "/"<< s2.length() << " opcode " << opcode << "[" << header << "/" << mbt_data << "]";
 		//self.trunked_systems[nac].decode_mbt_data(opcode, header << 16, mbt_data << 32)
 	}
 	/*

--- a/p25_recorder.cc
+++ b/p25_recorder.cc
@@ -1,5 +1,6 @@
 
 #include "p25_recorder.h"
+#include <boost/log/trivial.hpp>
 
 
 p25_recorder_sptr make_p25_recorder(double freq, double center, long s, long t, int n)
@@ -111,7 +112,7 @@ p25_recorder::p25_recorder(double f, double c, long s, long t, int n)
                 arb_taps = gr::filter::firdes::low_pass_2(arb_size, arb_size, bw, tb, arb_atten,
                                                       gr::filter::firdes::WIN_BLACKMAN_HARRIS);
             } else {
-            	std::cout << " CRAP!! " << std::endl;
+                BOOST_LOG_TRIVIAL(error) << "CRAP! Computer over!";
             	/*
                 float halfband = 0.5;
                 float bw = percent*halfband;
@@ -131,7 +132,7 @@ p25_recorder::p25_recorder(double f, double c, long s, long t, int n)
                         # Build in an exit strategy; if we've come this far, it ain't working.
                         if(ripple >= 1.0):
                             raise RuntimeError("optfir could not generate an appropriate filter.")*/
-                    }
+            }
 
 
 
@@ -176,7 +177,7 @@ p25_recorder::p25_recorder(double f, double c, long s, long t, int n)
 	valve = gr::blocks::copy::make(sizeof(gr_complex));
 	valve->set_enabled(false);
 
-	std::cout << " FM Gain: " << fm_demod_gain << " PI: " << pi << " Samples per sym: " << samples_per_symbol <<  std::endl;
+	BOOST_LOG_TRIVIAL(info) << " FM Gain: " << fm_demod_gain << " PI: " << pi << " Samples per sym: " << samples_per_symbol;
 
 	for (int i=0; i < samples_per_symbol; i++) {
 		sym_taps.push_back(1.0 / samples_per_symbol);
@@ -286,11 +287,11 @@ void p25_recorder::tune_offset(double f) {
 	int offset_amount = (f - center);
 	lo->set_frequency(-offset_amount);
 	//prefilter->set_center_freq(offset_amount); // have to flip this for 3.7
-	//std::cout << "Offset set to: " << offset_amount << " Freq: "  << freq << std::endl;
+	//BOOST_LOG_TRIVIAL(info) << "Offset set to: " << offset_amount << " Freq: "  << freq;
 }
 
 void p25_recorder::deactivate() {
-	std::cout<< "logging_receiver_dsd.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ] " << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "p25_recorder.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 	active = false;
 	valve->set_enabled(false);
@@ -306,7 +307,7 @@ void p25_recorder::activate(long t, double f, int n) {
 	freq = f;
 
 	tm *ltm = localtime(&starttime);
-	std::cout<< "logging_receiver_dsd.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]  "  <<std::endl;
+	BOOST_LOG_TRIVIAL(info) << "p25_recorder.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 	int offset_amount = (f - center);
 	lo->set_frequency(-offset_amount);

--- a/p25_trunking.cc
+++ b/p25_trunking.cc
@@ -1,5 +1,6 @@
 
 #include "p25_trunking.h"
+#include <boost/log/trivial.hpp>
 
 
 p25_trunking_sptr make_p25_trunking(double freq, double center, long s,  gr::msg_queue::sptr queue)
@@ -75,12 +76,12 @@ p25_trunking::p25_trunking(double f, double c, long s, gr::msg_queue::sptr queue
 
 	//int squelch_db = 40;
 	// squelch = gr::analog::pwr_squelch_cc::make(squelch_db, 0.001, 0, true);
-	std::cout << "Prechannel Decim: " << floor(capture_rate / system_channel_rate) << " Rate: " << prechannel_rate << " system_channel_rate: " << system_channel_rate << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "Prechannel Decim: " << floor(capture_rate / system_channel_rate) << " Rate: " << prechannel_rate << " system_channel_rate: " << system_channel_rate;
 
 	unsigned int d = GCD(prechannel_rate, system_channel_rate);
 	double small_system_channel_rate = floor(system_channel_rate  / d);
 	double small_prechannel_rate = floor(prechannel_rate / d);
-	std::cout << "After GCD - Prechannel Decim: " << prechannel_decim << " Rate: " << small_prechannel_rate << " system_channel_rate: " << small_system_channel_rate << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "After GCD - Prechannel Decim: " << prechannel_decim << " Rate: " << small_prechannel_rate << " system_channel_rate: " << small_system_channel_rate;
 
 
 	resampler_taps = design_filter(small_system_channel_rate, small_prechannel_rate);
@@ -96,7 +97,7 @@ p25_trunking::p25_trunking(double f, double c, long s, gr::msg_queue::sptr queue
 
 	double symbol_decim = 1;
 
-	std::cout << " FM Gain: " << fm_demod_gain << " PI: " << pi << " Samples per sym: " << samples_per_symbol <<  std::endl;
+	BOOST_LOG_TRIVIAL(info) << " FM Gain: " << fm_demod_gain << " PI: " << pi << " Samples per sym: " << samples_per_symbol;
 
 	for (int i=0; i < samples_per_symbol; i++) {
 		sym_taps.push_back(1.0 / samples_per_symbol);
@@ -170,11 +171,11 @@ void p25_trunking::tune_offset(double f) {
 	freq = f;
 	int offset_amount = (f - center);
 	prefilter->set_center_freq(offset_amount); // have to flip this for 3.7
-	//std::cout << "Offset set to: " << offset_amount << " Freq: "  << freq << std::endl;
+	//BOOST_LOG_TRIVIAL(info) << "Offset set to: " << offset_amount << " Freq: "  << freq;
 }
 
 void p25_trunking::deactivate() {
-	std::cout<< "logging_receiver_dsd.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ] " << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "logging_receiver_dsd.cc: Deactivating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 	active = false;
 	valve->set_enabled(false);
@@ -191,7 +192,7 @@ void p25_trunking::activate(long t, double f, int n) {
 	freq = f;
 
 	tm *ltm = localtime(&starttime);
-	std::cout<< "logging_receiver_dsd.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]  "  <<std::endl;
+	BOOST_LOG_TRIVIAL(info) << "logging_receiver_dsd.cc: Activating Logger [ " << num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
 
 	prefilter->set_center_freq(f - center); // have to flip for 3.7
 

--- a/smartnet_deinterleave.cc
+++ b/smartnet_deinterleave.cc
@@ -28,6 +28,7 @@
 #include "smartnet_deinterleave.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/tags.h>
+#include <boost/log/trivial.hpp>
 
 #define VERBOSE 0
 
@@ -92,7 +93,7 @@ smartnet_deinterleave::general_work (int noutput_items,
 	const char *in = (const char *) input_items[0];
 	char *out = (char *) output_items[0];
 
-	if(VERBOSE) std::cout << "Deinterleave called with " << noutput_items << " outputs" << std::endl;
+	if(VERBOSE) BOOST_LOG_TRIVIAL(info) << "Deinterleave called with " << noutput_items << " outputs";
 
 	//you will need to look ahead 84 bits to post 76 bits of data
 	//TODO this needs to be able to handle shorter frames while keeping state in order to end gracefully
@@ -118,7 +119,7 @@ smartnet_deinterleave::general_work (int noutput_items,
 		uint64_t mark = tag_iter->offset - abs_sample_cnt;
 
 		if(VERBOSE)
-			std::cout << "found a preamble at " << tag_iter->offset << std::endl;
+			BOOST_LOG_TRIVIAL(info) << "found a preamble at " << tag_iter->offset;
 
 		for(int k=0; k<76/4; k++) {
 			for(int l=0; l<4; l++) {
@@ -136,7 +137,7 @@ smartnet_deinterleave::general_work (int noutput_items,
 		outlen += 76;
 	}
 
-	if(VERBOSE) std::cout << "consumed " << size << ", produced " << outlen << std::endl;
+	if(VERBOSE) BOOST_LOG_TRIVIAL(info) << "consumed " << size << ", produced " << outlen;
 	consume_each(preamble_tags.back().offset - abs_sample_cnt + 84);
 	return outlen;
 }

--- a/source.cc
+++ b/source.cc
@@ -6,7 +6,7 @@ void Source::set_antenna(std::string ant)
 {
 	antenna = ant;
 	if (driver == "usrp") {
-		std::cout << "Setting antenna to [" << antenna << "]" << std::endl;
+		BOOST_LOG_TRIVIAL(info) << "Setting antenna to [" << antenna << "]";
 		cast_to_usrp_sptr(source_block)->set_antenna(antenna,0);
 	}
 }
@@ -90,7 +90,7 @@ Recorder * Source::get_analog_recorder(int priority)
 			break;
 		}
 	}
-	std::cout << "[ " << driver << " ] No Analog Recorders Available" << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "[ " << driver << " ] No Analog Recorders Available";
 	return NULL;
 
 }
@@ -129,7 +129,7 @@ Recorder * Source::get_debug_recorder()
 			break;
 		}
 	}
-	//std::cout << "[ " << driver << " ] No Debug Recorders Available" << std::endl;
+	//BOOST_LOG_TRIVIAL(info) << "[ " << driver << " ] No Debug Recorders Available";
 	return NULL;
 
 }
@@ -154,10 +154,10 @@ int Source::get_num_available_recorders() {
 Recorder * Source::get_digital_recorder(int priority)
 {
 	int num_available_recorders = get_num_available_recorders();
-	//std::cout << "\tTG Priority: "<< priority << " Available Digital Recorders: " <<num_available_recorders <<std::endl;
+	//BOOST_LOG_TRIVIAL(info) << "\tTG Priority: "<< priority << " Available Digital Recorders: " <<num_available_recorders;
 
 	if (priority> num_available_recorders) { // a low priority is bad. You need atleast the number of availalbe recorders to your priority
-		//std::cout << " Not recording because of priority" << std::endl;
+		//BOOST_LOG_TRIVIAL(info) << "Not recording because of priority";
 		return NULL;
 	}
 
@@ -174,7 +174,7 @@ Recorder * Source::get_digital_recorder(int priority)
 			break;
 		}
 	}
-	std::cout << "[ " << driver << " ] No Digital Recorders Available" << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "[ " << driver << " ] No Digital Recorders Available";
 	return NULL;
 
 }
@@ -197,10 +197,10 @@ Source::Source(double c, double r, double e, std::string drv, std::string dev)
 		} else {
 			osmo_src = osmosdr::source::make(dev);
 		}
-		std::cout << "SOURCE TYPE OSMOSDR (osmosdr)" << std::endl;
-		std::cout << "Setting sample rate to: " << rate << std::endl;
+		BOOST_LOG_TRIVIAL(info) << "SOURCE TYPE OSMOSDR (osmosdr)";
+		BOOST_LOG_TRIVIAL(info) << "Setting sample rate to: " << rate;
 		osmo_src->set_sample_rate(rate);
-		std::cout << "Tunning to " << center + error << "hz" << std::endl;
+		BOOST_LOG_TRIVIAL(info) << "Tunning to " << center + error << "hz";
 		osmo_src->set_center_freq(center + error,0);
 		source_block = osmo_src;
 	}
@@ -208,13 +208,13 @@ Source::Source(double c, double r, double e, std::string drv, std::string dev)
 		gr::uhd::usrp_source::sptr usrp_src;
 		usrp_src = gr::uhd::usrp_source::make(device,uhd::stream_args_t("fc32"));
 
-		std::cout << "SOURCE TYPE USRP (UHD)" << std::endl;
+		BOOST_LOG_TRIVIAL(info) << "SOURCE TYPE USRP (UHD)";
 
-		std::cout << "Setting sample rate to: " << rate << std::endl;
+		BOOST_LOG_TRIVIAL(info) << "Setting sample rate to: " << rate;
 		usrp_src->set_samp_rate(rate);
 		double actual_samp_rate = usrp_src->get_samp_rate();
-		std::cout << "Actual sample rate: " << actual_samp_rate << std::endl;
-		std::cout << "Tunning to " << center + error << "hz" << std::endl;
+		BOOST_LOG_TRIVIAL(info) << "Actual sample rate: " << actual_samp_rate;
+		BOOST_LOG_TRIVIAL(info) << "Tunning to " << center + error << "hz";
 		usrp_src->set_center_freq(center + error,0);
 
 


### PR DESCRIPTION
I replaced (most) instances of std::cout with BOOST_LOG_TRIVIAL.

I also removed the unneeded std::endl from these calls. There is probably
still some work to be done to clean up logging, but this is a good
start.