### PR TITLE
Default smartnet messages to not-encrypted, fixes smartnet recording

### DIFF
--- a/smartnet_parser.cc
+++ b/smartnet_parser.cc
@@ -26,7 +26,7 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s) {
 
 
 	message.message_type = UNKNOWN;
-
+	message.encrypted = false;
 
 	std::vector<std::string> x;
 	boost::split(x, s, boost::is_any_of(","), boost::token_compress_on);


### PR DESCRIPTION
Calls derived from a smartnet `TrunkMessage` without `.encrypted` explicitly set to `false` may fail the `get_encrypted() == false` test in [main.cc](c810272fcdea2cd15f870eecd7f0995c8b542fe8), and recording becomes a no-op. 

(Undefined behavior of an uninitialized boolean in the struct?)

With this change locally, recording works as expected. (KCERS Type II Smartnet, in Seattle.) 