### PR TITLE
Stop a couple of warn_unused_result warnings

### DIFF
--- a/call.cc
+++ b/call.cc
@@ -72,7 +72,7 @@ void Call::end_call() {
                 }
                 sprintf(shell_command,"./encode-upload.sh %s > /dev/null 2>&1 &", this->get_filename());
                 this->get_recorder()->deactivate();
-                system(shell_command);
+                int rc = system(shell_command);
             }
             if (this->get_debug_recording() == true) {
                 this->get_debug_recorder()->deactivate();

--- a/main.cc
+++ b/main.cc
@@ -504,7 +504,7 @@ void unit_check() {
         }
         myfile << "\n}\n}\n";
         sprintf(shell_command,"./unit_check.sh %s > /dev/null 2>&1 &", unit_filename);
-        system(shell_command);
+        int rc = system(shell_command);
         myfile.close();
     }
 }


### PR DESCRIPTION
2 system calls did not have their return code assigned to anything. 

/home/dylan/radio/dylan-trunk-recorder/main.cc: In function ‘void unit_check()’:
/home/dylan/radio/dylan-trunk-recorder/main.cc:507:30: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
         system(shell_command);


/home/dylan/radio/dylan-trunk-recorder/call.cc: In member function ‘void Call::end_call()’:
/home/dylan/radio/dylan-trunk-recorder/call.cc:75:38: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
                 system(shell_command);