### PR TITLE
Save all 4 bytes from the address into last address

### DIFF
--- a/smartnet_parser.cc
+++ b/smartnet_parser.cc
@@ -46,7 +46,8 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s) {
 	std::vector<std::string> x;
 	boost::split(x, s, boost::is_any_of(","), boost::token_compress_on);
 
-	long address = atoi( x[0].c_str() ) & 0xFFF0;
+	int full_address = atoi( x[0].c_str() );
+	long address = full_address & 0xFFF0;
 	//int groupflag = atoi( x[1].c_str() );
 	int command = atoi( x[2].c_str() );
 
@@ -73,7 +74,7 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s) {
 		//parse_status(command, address,groupflag);
 	}
 
-	lastaddress = address;
+	lastaddress = full_address;
 	lastcmd = command;
 	messages.push_back(message);
 	return messages;


### PR DESCRIPTION
We were setting the last byte to a 0, the last byte when we get a talkgroup
is the type of call. But when its a radio ID all 4 bytes are used.

This will correct issue #53