### PR TITLE
Allow selecting the SDR device type for the osmosdr driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Here are the different arguments:
    - **digitalRecorders** - the number of Digital Recorders to have attached to this source. This is essentaully the number of simultanious call you can record at the same time in the frequency range that this SDR will be tuned to. It is limited by the CPU power of the machine. Some experimentation might be needed to find the appropriate number. It will use DSD or OP25 to decode the P25 CAI voice.
    - **analogRecorders** - the number of Analog Recorder to have attached to this source. This is the same as Digital Recorders except for Analog Voice channels.
    - **driver** - the GNURadio block you wish to use for the SDR. The options are *usrp* & *osmosdr*.
-   - **device** - the serial number for the device. You only need to do this if there are more than one.
+   - **device** - osmosdr device name and posiably serial number or index of the device, see [osmosdr page](http://sdr.osmocom.org/trac/wiki/GrOsmoSDR) for each device and parameters. You only need to do this if there are more than one. (bladerf=00001 for BladeRF with serial 00001 or rtl=00923838 for RTL-SDR with serial 00923838, just airspy for an airspy)
  - **system** - This object defines the trunking system that will be recorded
    - **control_channels** - an array of the control channel frequencies for the system, in Hz. Right now, only the first value is used.
    - **type** - the type of trunking system. The options are *smartnet* & *p25*.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Here are the different arguments:
    - **digitalRecorders** - the number of Digital Recorders to have attached to this source. This is essentaully the number of simultanious call you can record at the same time in the frequency range that this SDR will be tuned to. It is limited by the CPU power of the machine. Some experimentation might be needed to find the appropriate number. It will use DSD or OP25 to decode the P25 CAI voice.
    - **analogRecorders** - the number of Analog Recorder to have attached to this source. This is the same as Digital Recorders except for Analog Voice channels.
    - **driver** - the GNURadio block you wish to use for the SDR. The options are *usrp* & *osmosdr*.
-   - **device** - osmosdr device name and posiably serial number or index of the device, see [osmosdr page](http://sdr.osmocom.org/trac/wiki/GrOsmoSDR) for each device and parameters. You only need to do this if there are more than one. (bladerf=00001 for BladeRF with serial 00001 or rtl=00923838 for RTL-SDR with serial 00923838, just airspy for an airspy)
+   - **device** - osmosdr device name and possibly serial number or index of the device, see [osmosdr page](http://sdr.osmocom.org/trac/wiki/GrOsmoSDR) for each device and parameters. You only need to do this if there are more than one. (bladerf=00001 for BladeRF with serial 00001 or rtl=00923838 for RTL-SDR with serial 00923838, just airspy for an airspy)
  - **system** - This object defines the trunking system that will be recorded
    - **control_channels** - an array of the control channel frequencies for the system, in Hz. Right now, only the first value is used.
    - **type** - the type of trunking system. The options are *smartnet* & *p25*.

--- a/config-multi-rtl.json.sample
+++ b/config-multi-rtl.json.sample
@@ -6,7 +6,7 @@
 "gain": 42,
 "digitalRecorders": 4,
 "driver": "osmosdr",
-"device": "30"},
+"device": "rtl=30"},
 {"center": 855700000.0,
 "rate": 2048000.0,
 "error": 1900,
@@ -14,7 +14,7 @@
 "gain": 42,
 "digitalRecorders": 4,
 "driver": "osmosdr",
-"device": "31"},
+"device": "rtl=31"},
 {"center": 860000000.0,
 "rate": 2048000.0,
 "error": 1100,
@@ -22,7 +22,7 @@
 "gain": 42,
 "digitalRecorders": 4,
 "driver": "osmosdr",
-"device": "32"}
+"device": "rtl=32"}
 ],
 "system": {
 	"control_channels": [855462500],

--- a/config-smartnet.json
+++ b/config-smartnet.json
@@ -5,7 +5,7 @@
 "gain": 34,
 "digitalRecorders": 4,
 "driver": "osmosdr",
-"device": 40
+"device": "rtl=40"
 },
 {"center": 496300000.0,
 "rate": 2048000.0,
@@ -13,7 +13,7 @@
 "gain": 34,
 "digitalRecorders": 4,
 "driver": "osmosdr",
-"device": 42
+"device": "rtl=42"
 }
 ],
 "system": {

--- a/source.cc
+++ b/source.cc
@@ -208,12 +208,18 @@ Source::Source(double c, double r, double e, std::string drv, std::string dev)
 	if (driver == "osmosdr") {
 		osmosdr::source::sptr osmo_src;
 		if (dev == "") {
-            BOOST_LOG_TRIVIAL(info) << "Source Device not specified";
+			BOOST_LOG_TRIVIAL(info) << "Source Device not specified";
 			osmo_src = osmosdr::source::make();
 		} else {
-            std::ostringstream msg;
-            msg << "rtl=" << dev << ",buflen=16384,buffers=8";
-            BOOST_LOG_TRIVIAL(info) << "Source Device: " << msg.str();
+			std::ostringstream msg;
+			if(isdigit(dev[0])) {	// Assume this is a serial number and fail back
+						// to using rtl as default
+				msg << "rtl=" << dev << ",buflen=16384,buffers=8";
+				BOOST_LOG_TRIVIAL(info) << "Source device name missing, defaulting to rtl device";
+			} else {
+				msg << dev << ",buflen=16384,buffers=8";
+			}
+			BOOST_LOG_TRIVIAL(info) << "Source Device: " << msg.str();
 			osmo_src = osmosdr::source::make(msg.str());
 		}
 		BOOST_LOG_TRIVIAL(info) << "SOURCE TYPE OSMOSDR (osmosdr)";


### PR DESCRIPTION
  When using mutiple SDRs with the osmosdr driver allow user to explicitly select which model of SDR and serial number.
  For backward compatibility if the first part of device is numeric assume this is a serial number and fail back to using the rtl model.
  This corrects issue #55