### PR TITLE
Update smartnet bandplans

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -179,6 +179,11 @@ void load_config()
       system->set_talkgroups_file(node.second.get<std::string>("talkgroupsFile", ""));
       BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << system->get_talkgroups_file();
       systems.push_back(system);
+
+      system->set_bandplan(node.second.get<std::string>("bandplan", "800_Reband"));
+      if(system->get_system_type() == "smartnet") {
+          BOOST_LOG_TRIVIAL(info) << "Smartnet bandplan: " << system->get_bandplan();
+      }
     }
     config.capture_dir = pt.get<std::string>("captureDir", boost::filesystem::current_path().string());
     size_t pos = config.capture_dir.find_last_of("/");
@@ -873,7 +878,7 @@ void monitor_messages() {
 
       if (sys) {
         if (sys->get_system_type() == "smartnet") {
-          trunk_messages = smartnet_parser->parse_message(msg->to_string());
+          trunk_messages = smartnet_parser->parse_message(msg->to_string(), sys->get_bandplan());
           handle_message(trunk_messages, sys);
         }
 

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -9,60 +9,46 @@ SmartnetParser::SmartnetParser() {
 }
 
 bool SmartnetParser::is_chan(int cmd) {
-  if (cmd < 0x2F8)
-  {
-    return true;
-  }
-
-  if (cmd < 0x32F)
-  {
+    if((cmd >= 0 && cmd <= 0x2F7) || (cmd >= 0x32f && cmd <= 0x33F) ||
+          (cmd >= 0x3c1 && cmd <= 0x3FE) ||cmd == 0x3BE ) {
+               return true;
+    }
     return false;
-  }
-
-  if (cmd < 0x340)
-  {
-    return true;
-  }
-
-  if (cmd == 0x3BE)
-  {
-    return true;
-  }
-
-  if ((cmd > 0x3C0) && (cmd <= 0x3FE))
-  {
-    return true;
-  }
-  return false;
 }
 
-double SmartnetParser::getfreq(int cmd) {
-  double freq;
+double SmartnetParser::getfreq(int cmd, std::string band) {
+    /*
+      BANDPLAN 800Mhz:
+      800_Standard * Is default base plan
+      800_Splinter
+      800_Reband
+    */
+    double freq = 0.0;
+    if(cmd < 0 || cmd > 0x3FE)
+        return freq;
+    if(cmd <= 0x2CF) {
+        if(band == "800_Reband" && cmd >= 0x1B8 && cmd <= 0x22F) { /* Re Banded Site */
+            freq = 851.0250 + (0.025 * ((double) (cmd-0x1B8)));
+        } else if(band == "800_Splinter" && cmd <= 0x257) { /* Splinter Site */
+            freq = 851.0 + (0.025 * ((double) cmd));
+        } else {
+            freq = 851.0125 + (0.025 * ((double) cmd));
+        }
+    } else if(cmd <= 0x2f7) {
+        freq = 866.0000 + (0.025 * ((double) (cmd-0x2D0)));
+    } else if(cmd >= 0x32F && cmd <= 0x33F ) {
+        freq = 867.0000 + (0.025 * ((double) (cmd-0x32F)));
+    } else if( cmd == 0x3BE) {
+        freq = 868.9750;
+    } else if (cmd >= 0x3C1 && cmd <= 0x3FE) {
+        freq = 867.4250 + (0.025 * ((double) (cmd-0x3C1)));
+    }
 
-
-  /* Different Systems will have different band plans. Below is the one for
-     WMATA which is a bit werid:*/
-
-/*
-  if ((cmd >= 0x17c) && (cmd < 0x2b0)) {
-    freq = ((cmd - 380) * 25000)  + 489087500;
-  } else {
-    freq = 0;
-  }
-*/
-
-          if (cmd < 0x1b8) {
-                  freq = float(cmd * 25000 + 851012500);
-          } else if (cmd < 0x230) {
-                  freq = float(cmd * 25000 + 851012500 - 10987500);
-          } else {
-                  freq = 0;
-          }
-
-  return freq;
+  return freq * 1000000;
 }
 
-std::vector<TrunkMessage>SmartnetParser::parse_message(std::string s) {
+
+std::vector<TrunkMessage>SmartnetParser::parse_message(std::string s, std::string bandplan) {
   std::vector<TrunkMessage> messages;
   TrunkMessage message;
 
@@ -196,9 +182,9 @@ std::vector<TrunkMessage>SmartnetParser::parse_message(std::string s) {
   }
 
 
-  if (is_chan(stack[0].cmd) && stack[0].grp && getfreq(stack[0].cmd)) {
+  if (is_chan(stack[0].cmd) && stack[0].grp && getfreq(stack[0].cmd,bandplan)) {
     message.talkgroup = stack[0].full_address;
-    message.freq      = getfreq(stack[0].cmd);
+    message.freq      = getfreq(stack[0].cmd,bandplan);
 
     if (((stack[2].cmd == 0x308) || (stack[2].cmd == 0x321) || (stack[2].cmd == 0x320))) {
       //cout << "NEW GRANT!! CMD1: " << fixed << hex << stack[1].cmd << " 0add: " << dec <<  stack[0].address << " 0full_add: " << stack[0].full_address  << " 1add: " << stack[1].address << " 1full_add: " << stack[1].full_address  << endl;
@@ -217,7 +203,7 @@ std::vector<TrunkMessage>SmartnetParser::parse_message(std::string s) {
     return messages;
   }
   message.talkgroup = address;
-  message.freq      = getfreq(command);
+  message.freq      = getfreq(command,bandplan);
 
   // cout << "Command: " << hex << command << " Last CMD: 0x" <<  hex <<
   // lastcmd << " Freq: " << message.freq << " Talkgroup: " << dec << address

--- a/trunk-recorder/systems/smartnet_parser.h
+++ b/trunk-recorder/systems/smartnet_parser.h
@@ -54,9 +54,9 @@ public:
 	short numStacked;
 	short numConsumed;
 	SmartnetParser();
-	double getfreq(int cmd);
+	double getfreq(int cmd, std::string band);
 	void print_osw(std::string s);
 	bool is_chan(int cmd);
-	std::vector<TrunkMessage> parse_message(std::string s);
+	std::vector<TrunkMessage> parse_message(std::string s, std::string bandplan);
 };
 #endif

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -127,3 +127,11 @@ double System::get_next_control_channel() {
   }
   return this->control_channels[current_control_channel];
 }
+
+void System::set_bandplan(std::string bandplan) {
+  this->bandplan = bandplan;
+}
+
+std::string System::get_bandplan() {
+  return this->bandplan;
+}

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -23,6 +23,7 @@ public:
         int message_count;
         int retune_attempts;
         time_t last_message_time;
+        std::string bandplan;
 
         std::vector<double> control_channels;
         int current_control_channel;
@@ -60,5 +61,7 @@ public:
         std::vector<p25_recorder_sptr> get_conventionalP25_recorders();
         std::vector<double> get_channels();
         System(int sys_id );
+        void set_bandplan(std::string);
+        std::string get_bandplan();
 };
 #endif


### PR DESCRIPTION
Add lookups for 800MHz Standard, Splinter and Rebanded sites

Add new config.json option under system named "bandplan":
800_Standard * This is the base plan if an invalid
             * plan is entered it will fall back to this one.
800_Splinter
800_Reband * This is the default if nothing is set in the config

Used https://github.com/ScanOC/Trunk-Channel-Check/raw/master/MO%20TRS%20Channels.pdf as my source of truth 