### PR TITLE
Set to -std=gnu++98 to fix compiling with GCC 6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ set(CMAKE_CXX_FLAGS_DEBUG "-pthread -Wall -Wno-error=deprecated-declarations")
 #        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 #endif()
 
+SET(CMAKE_CXX_STANDARD 98)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing -g")
 
 


### PR DESCRIPTION
This should fix https://github.com/robotastic/trunk-recorder/issues/115 and https://github.com/robotastic/trunk-recorder/issues/81, but I have only tested on Ubuntu 16.10 and 17.04.