### PR TITLE
update talkgroups file loading and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ Here are the different arguments:
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
 
-**ChanList.csv**
+** talkgroupsFile **
 
-This file provides info on the different talkgroups in a trunking system. A lot of this info can be found on the Radio Reference website. You need to be a site member to download the table for your system. If you are not, try clicking on the "List All in one table" link, selecting everything in the table and copying it into Excel or a spreadsheet.
+This file provides info on the different talkgroups in a trunking system. A lot of this info can be found on the [Radio Reference](http://www.radioreference.com/) website. You need to be a Radio Reference member to download the table for your system preformatted as a CSV file. If you are not a Radio Reference member, try clicking on the "List All in one table" link, selecting everything in the table and copying it into Excel or a spreadsheet, and then exporting or saving as a CSV file. 
 
-You will have to add an additional column that adds a priority for each talkgroup. You need that number of recorders available to record a call at that priority. So, 1 is the highest, you would need 2 recorders available to record a priority 2, 3 record for a priority 3 and so on.
+**Note** - Fields in preformatted CSV downloads from Radio Reference are now in a different order than Trunk Recorder expects. See below for the correct field order. Additionally, Radio Reference inserts a header line at the tope of the CSV file which should be removed. 
+
+You may add an additional column that adds a priority for each talkgroup. The priority field specifies the number of recorders the system must have available to record a new call for the talkgroup. For example, a priority of 1, the highest means as long as at least a single recorder is available, the system will record the new call. If the priority is 2, the system would at least 2 free recorders to record the new call, and so on. If there is no priority set for a talkgroup entry, a prioity of 1 is assumed.
 
 The Trunk Record program really only uses the priority information and the Dec Talkgroup ID. The Website uses the same file though to help display information about each talkgroup.
 

--- a/trunk-recorder/talkgroups.cc
+++ b/trunk-recorder/talkgroups.cc
@@ -1,11 +1,19 @@
 #include "talkgroups.h"
-#include <boost/log/trivial.hpp>
 
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/tokenizer.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
 
 // Retrieved from
 // https://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
-std::istream& safeGetline(std::istream& is, std::string& t)
-{
+std::istream &safeGetline(std::istream &is, std::string &t) {
   t.clear();
 
   // The characters in the stream are read one-by-one using a std::streambuf.
@@ -26,13 +34,15 @@ std::istream& safeGetline(std::istream& is, std::string& t)
 
     case '\r':
 
-      if (sb->sgetc() == '\n') sb->sbumpc();
+      if (sb->sgetc() == '\n')
+        sb->sbumpc();
       return is;
 
     case EOF:
 
       // Also handle the case when the last line has no line ending
-      if (t.empty()) is.setstate(std::ios::eofbit);
+      if (t.empty())
+        is.setstate(std::ios::eofbit);
       return is;
 
     default:
@@ -47,48 +57,57 @@ void Talkgroups::load_talkgroups(std::string filename) {
   std::ifstream in(filename.c_str());
 
   if (!in.is_open()) {
-    BOOST_LOG_TRIVIAL(error) << "Error Opening TG File: " << filename <<
-      std::endl;
+    BOOST_LOG_TRIVIAL(error) << "Error Opening TG File: " << filename
+                             << std::endl;
     return;
   }
 
   boost::char_separator<char> sep(",\t");
-  typedef boost::tokenizer<boost::char_separator<char> >t_tokenizer;
+  typedef boost::tokenizer< boost::char_separator<char> > t_tokenizer;
 
   std::vector<std::string> vec;
   std::string line;
 
-  int lines_read   = 0;
+  int lines_read = 0;
   int lines_pushed = 0;
-  int priority;
+  int priority = 1;
 
-  while (safeGetline(in, line)) // this works with \r, \n, or \r\n
+  while (!safeGetline(in, line).eof()) // this works with \r, \n, or \r\n
   {
     if (line.size() && (line[line.size() - 1] == '\r')) {
       line = line.substr(0, line.size() - 1);
     }
 
-    if (line == "") {
-      continue;
-    }
-
     lines_read++;
+
+    if (line == "")
+      continue;
+    
     t_tokenizer tok(line, sep);
+
+    // Talkgroup configuration columns:
+    //
+    // [0] - talkgroup number
+    // [1] - unused
+    // [2] - mode
+    // [3] - alpha_tag
+    // [4] - description
+    // [5] - tag
+    // [6] - group
+    // [7] - priority
 
     vec.assign(tok.begin(), tok.end());
 
-    if (vec.size() < 7) continue;  // yuck
-
-    if (vec.size() < 6) {
-      priority = 1;
-    } else {
-      priority = atoi(vec[7].c_str());
+    if (!((vec.size() == 8) || (vec.size() == 7))) {
+      BOOST_LOG_TRIVIAL(error) << "Malformed talkgroup entry at line " << lines_read << ".";
+      continue;
     }
+    // TODO(nkw): more sanity checking here.
+    priority = (vec.size() == 8) ?  atoi(vec[7].c_str()) : 1;
 
-    Talkgroup *tg = new Talkgroup(atoi(vec[0].c_str()), vec[2].at(
-                                    0), vec[3].c_str(),
-                                  vec[4].c_str(), vec[5].c_str(), vec[6].c_str(),
-                                  priority);
+    Talkgroup *tg =
+        new Talkgroup(atoi(vec[0].c_str()), vec[2].at(0), vec[3].c_str(),
+                      vec[4].c_str(), vec[5].c_str(), vec[6].c_str(), priority);
 
     talkgroups.push_back(tg);
     lines_pushed++;
@@ -97,18 +116,18 @@ void Talkgroups::load_talkgroups(std::string filename) {
   if (lines_pushed != lines_read) {
     // The parser above is pretty brittle. This will help with debugging it, for
     // now.
-    BOOST_LOG_TRIVIAL(error) << "Warning: skipped " << lines_read -
-      lines_pushed << " of " << lines_read <<
-    " talkgroup entries! Invalid format?";
-    BOOST_LOG_TRIVIAL(error) <<
-      "The format is very particular. See https://github.com/robotastic/trunk-recorder for example input.";
-  }
-  else {
+    BOOST_LOG_TRIVIAL(error) << "Warning: skipped " << lines_read - lines_pushed
+                             << " of " << lines_read
+                             << " talkgroup entries! Invalid format?";
+    BOOST_LOG_TRIVIAL(error) << "The format is very particular. See "
+                                "https://github.com/robotastic/trunk-recorder "
+                                "for example input.";
+  } else {
     BOOST_LOG_TRIVIAL(info) << "Read " << lines_pushed << " talkgroups.";
   }
 }
 
-Talkgroup * Talkgroups::find_talkgroup(long tg_number) {
+Talkgroup *Talkgroups::find_talkgroup(long tg_number) {
   Talkgroup *tg_match = NULL;
 
   for (std::vector<Talkgroup *>::iterator it = talkgroups.begin();

--- a/trunk-recorder/talkgroups.h
+++ b/trunk-recorder/talkgroups.h
@@ -1,23 +1,17 @@
 #ifndef TALKGROUPS_H
 #define TALKGROUPS_H
+
 #include "talkgroup.h"
 
-#include <iostream>
-#include <fstream>
 #include <string>
-#include <stdio.h>
-#include <stdlib.h>
-
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/intrusive_ptr.hpp>
+#include <vector>
 
 class Talkgroups {
-								std::vector<Talkgroup *> talkgroups;
+  std::vector<Talkgroup *> talkgroups;
+
 public:
-								Talkgroups();
-								void load_talkgroups(std::string filename);
-								Talkgroup *find_talkgroup(long tg);
+  Talkgroups();
+  void load_talkgroups(std::string filename);
+  Talkgroup *find_talkgroup(long tg);
 };
-#endif
+#endif // TALKGROUPS_H


### PR DESCRIPTION
update talkgroups file loading
     - fix default priority handling
     - move includes into implementation file
     - adjust formatting and indentation
     - document talkgroup file columns
     - log error on malformed lines in talkgroup file
update readme with RR info and priority default