### PR TITLE
clean up CMakeLists.txt and op25_repeat includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ ChanList.csv
 .DS_Store
 .idea/
 cmake-build-debug/
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Project setup
 ########################################################################
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 project(Trunk-Recorder CXX C)
 
 #set(CMAKE_BUILD_TYPE Debug)
@@ -109,6 +109,11 @@ find_package(LibHackRF)
 find_package(UHD)
 find_package(OpenSSL REQUIRED)
 
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+
+find_package(Threads REQUIRED)
+
 if(NOT GNURADIO_RUNTIME_FOUND)
     message(FATAL_ERROR "GnuRadio Runtime required to build " ${CMAKE_PROJECT_NAME})
 endif()
@@ -175,9 +180,7 @@ link_directories(
 )
 
 #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall")
-set(CMAKE_CXX_FLAGS_DEBUG "-pthread -Wall -Wno-error=deprecated-declarations -g")
-
-
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g")
 
 #include(CheckCXXCompilerFlag)
 #CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
@@ -192,7 +195,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-pthread -Wall -Wno-error=deprecated-declarations -g"
 
 SET(CMAKE_CXX_STANDARD 98)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wno-narrowing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing -Wno-deprecated-declarations -Wno-return-type")
 
 
 add_subdirectory(op25_repeater)
@@ -220,4 +223,4 @@ list(APPEND trunk_recorder_sources
 
 add_executable(recorder ${trunk_recorder_sources})
 
-target_link_libraries(recorder ssl crypto ${GNURADIO_PMT_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_FILTER_LIBRARIES} ${GNURADIO_DIGITAL_LIBRARIES} ${GNURADIO_ANALOG_LIBRARIES} ${GNURADIO_AUDIO_LIBRARIES} ${GNURADIO_UHD_LIBRARIES} ${UHD_LIBRARIES} ${GNURADIO_BLOCKS_LIBRARIES} ${GROSMOSDR_LIBRARIES} ${Boost_LIBRARIES} ${LIBOP25_REPEATER_LIBRARIES} gnuradio-op25_repeater imbe_vocoder)
+target_link_libraries(recorder ssl crypto Threads::Threads ${GNURADIO_PMT_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_FILTER_LIBRARIES} ${GNURADIO_DIGITAL_LIBRARIES} ${GNURADIO_ANALOG_LIBRARIES} ${GNURADIO_AUDIO_LIBRARIES} ${GNURADIO_UHD_LIBRARIES} ${UHD_LIBRARIES} ${GNURADIO_BLOCKS_LIBRARIES} ${GROSMOSDR_LIBRARIES} ${Boost_LIBRARIES} ${LIBOP25_REPEATER_LIBRARIES} gnuradio-op25_repeater imbe_vocoder)

--- a/trunk-recorder/recorders/debug_recorder.h
+++ b/trunk-recorder/recorders/debug_recorder.h
@@ -53,11 +53,12 @@
 #include <gnuradio/blocks/short_to_float.h>
 #include <gnuradio/blocks/char_to_float.h>
 
-#include <op25_repeater/fsk4_demod_ff.h>
-#include <op25_repeater/fsk4_slicer_fb.h>
-#include <op25_repeater/p25_frame_assembler.h>
-#include <op25_repeater/gardner_costas_cc.h>
-#include <op25_repeater/vocoder.h>
+#include "../../op25_repeater/include/op25_repeater/fsk4_demod_ff.h"
+#include "../../op25_repeater/include/op25_repeater/fsk4_slicer_fb.h"
+#include "../../op25_repeater/include/op25_repeater/p25_frame_assembler.h"
+#include "../../op25_repeater/include/op25_repeater/gardner_costas_cc.h"
+#include "../../op25_repeater/include/op25_repeater/vocoder.h"
+
 #include <gnuradio/msg_queue.h>
 #include <gnuradio/message.h>
 #include <gnuradio/blocks/head.h>

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -37,11 +37,11 @@
 #include <gnuradio/blocks/complex_to_arg.h>
 
 #include "../../op25_repeater/include/op25_repeater/fsk4_demod_ff.h"
-#include <op25_repeater/fsk4_slicer_fb.h>
+#include "../../op25_repeater/include/op25_repeater/fsk4_slicer_fb.h"
 #include "../../op25_repeater/include/op25_repeater/p25_frame_assembler.h"
 #include "../../op25_repeater/include/op25_repeater/rx_status.h"
-#include <op25_repeater/gardner_costas_cc.h>
-#include <op25_repeater/vocoder.h>
+#include "../../op25_repeater/include/op25_repeater/gardner_costas_cc.h"
+#include "../../op25_repeater/include/op25_repeater/vocoder.h"
 
 #include <gnuradio/msg_queue.h>
 #include <gnuradio/message.h>

--- a/trunk-recorder/systems/p25_trunking.h
+++ b/trunk-recorder/systems/p25_trunking.h
@@ -35,10 +35,10 @@
 
 #include <gnuradio/digital/diff_phasor_cc.h>
 
-#include <op25_repeater/fsk4_demod_ff.h>
-#include <op25_repeater/fsk4_slicer_fb.h>
+#include "../../op25_repeater/include/op25_repeater/fsk4_demod_ff.h"
+#include "../../op25_repeater/include/op25_repeater/fsk4_slicer_fb.h"
 #include "../../op25_repeater/include/op25_repeater/p25_frame_assembler.h"
-#include <op25_repeater/gardner_costas_cc.h>
+#include "../../op25_repeater/include/op25_repeater/gardner_costas_cc.h"
 
 #include <gnuradio/msg_queue.h>
 #include <gnuradio/message.h>


### PR DESCRIPTION
- previous fix for Arch linux forced pthreads flag, this lets CMake handle it as needed
- if op25 was installed on system, trunk-recorder headers would pickup system version rather than local and compile would fail if versions were different
- also adds .vscode to .gitignore