### PR TITLE
New config for control channel rate warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Here are the different arguments:
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.
  - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently.
+ - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.
 
 **talkgroupsFile**
 

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -120,6 +120,8 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;
     config.log_file = pt.get<bool>("logFile", false);
     BOOST_LOG_TRIVIAL(info) << "Log to File: " << config.log_file;
+    config.control_message_warn_rate = pt.get<int>("controlWarnRate", 10);
+    BOOST_LOG_TRIVIAL(info) << "Control channel rate warning: " << config.control_message_warn_rate;
 
 
     BOOST_FOREACH(boost::property_tree::ptree::value_type  & node,

--- a/trunk-recorder/config.h
+++ b/trunk-recorder/config.h
@@ -21,6 +21,7 @@ struct Config {
         std::string capture_dir;
         int call_timeout;
         bool log_file;
+        int control_message_warn_rate;
 };
 
 //Config load_config(std::string config_file, std::vector<Source *> &sources, std::vector<System *> &systems);

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -379,6 +379,8 @@ void load_config(string config_file)
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;
     config.log_file = pt.get<bool>("logFile", false);
     BOOST_LOG_TRIVIAL(info) << "Log to File: " << config.log_file;
+    config.control_message_warn_rate = pt.get<int>("controlWarnRate", 10);
+    BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
   }
   catch (std::exception const& e)
   {
@@ -858,7 +860,7 @@ void check_message_count(float timeDiff) {
         }
       }
 
-      if (msgs_decoded_per_second < 10) {
+      if (msgs_decoded_per_second < config.control_message_warn_rate || config.control_message_warn_rate == -1) {
         BOOST_LOG_TRIVIAL(error) << "[" << sys->get_short_name() << "]\t Control Channel Message Decode Rate: " <<  msgs_decoded_per_second << "/sec, count:  " << sys->message_count;
       }
       sys->message_count = 0;


### PR DESCRIPTION
I always seem to to change this and recompile trunk-recorder each time I pull it down..

New config option controlWarnRate to set the warning threshhold to log the control channel decode message.
Default is 10.
-1 will always log