### PR TITLE
Basic SmartNet unit ID fix

### DIFF
--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -220,15 +220,18 @@ if (x.size()<3) {
     message.talkgroup = stack[0].full_address;
     message.freq      = getfreq(stack[0].cmd, system);
 
-    if (((stack[2].cmd == 0x308) || (stack[2].cmd == 0x321) || (stack[2].cmd == 0x320))) {
+    if ((stack[1].cmd == 0x308) || (stack[1].cmd == 0x321)) {
       //cout << "NEW GRANT!! CMD1: " << fixed << hex << stack[1].cmd << " 0add: " << dec <<  stack[0].address << " 0full_add: " << stack[0].full_address  << " 1add: " << stack[1].address << " 1full_add: " << stack[1].full_address  << endl;
       message.message_type = GRANT;
       message.source       = stack[1].full_address;
-    } else     if (((stack[1].cmd == 0x308) || (stack[1].cmd == 0x321) || (stack[1].cmd == 0x320))) {
-      //cout << "NEW GRANT!! CMD1: " << fixed << hex << stack[1].cmd << " 0add: " << dec <<  stack[0].address << " 0full_add: " << stack[0].full_address  << " 1add: " << stack[1].address << " 1full_add: " << stack[1].full_address  << endl;
-      message.message_type = GRANT;
-      message.source       = stack[1].full_address;
-    } else  {
+    } else  if (stack[1].cmd == 0x320) {
+      BOOST_LOG_TRIVIAL(info) << "Non-Grant with source 0x" << stack[1].full_address << " " << std::dec << stack[1].full_address << 
+                             " on TG 0x" << std::hex << stack[0].full_address << " " << std::dec << stack[0].full_address;
+      message.message_type = UNKNOWN;
+      message.source       = 0;
+      return messages;
+      }        
+    else {
       message.message_type = UPDATE;
       //cout << "NEW UPDATE [ Freq: " << fixed << getfreq(stack[0].cmd) << " CMD0: " << hex << stack[0].cmd << " CMD1: " << hex << stack[1].cmd << " CMD2: " << hex << stack[2].cmd   << " ] " << " Grp: " << stack[0].grp << " Grp1: " << stack[1].grp << endl;
     }


### PR DESCRIPTION
Initial fix for the most common cause of bogus Unit IDs in SmartNet systems.  Accepts 308 and 321 OSW only in position 1, does not process 320 as a voice grant.