### PR TITLE
Several changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ list(APPEND trunk_recorder_sources
   trunk-recorder/systems/p25_parser.cc
   trunk-recorder/systems/smartnet_decode.cc
   trunk-recorder/systems/system.cc
+  trunk-recorder/recorders/recorder.cc  
   trunk-recorder/recorders/debug_recorder.cc
   trunk-recorder/recorders/analog_recorder.cc
   lib/gr_blocks/nonstop_wavfile_sink_impl.cc  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 cmake_minimum_required(VERSION 2.6)
 project(Trunk-Recorder CXX C)
 
-#set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE Debug)
 
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
@@ -218,13 +218,14 @@ list(APPEND trunk_recorder_sources
   trunk-recorder/systems/system.cc
   trunk-recorder/recorders/debug_recorder.cc
   trunk-recorder/recorders/analog_recorder.cc
+  lib/gr_blocks/nonstop_wavfile_sink_impl.cc  
+  trunk-recorder/gr_blocks/nonstop_wavfile_delayopen_sink_impl.cc
   trunk-recorder/recorders/p25conventional_recorder.cc
   trunk-recorder/recorders/p25_recorder.cc  
   trunk-recorder/talkgroup.cc
-  trunk-recorder/talkgroups.cc
-  lib/gr_blocks/nonstop_wavfile_sink_impl.cc
+  trunk-recorder/talkgroups.cc  
   lib/gr_blocks/freq_xlating_fft_filter.cc
-  lib/lfsr/lfsr.cxx
+  lib/lfsr/lfsr.cxx  
   )
 
 set_source_files_properties(lib/lfsr/lfsr.cxx COMPILE_FLAGS "-w")

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Here are the different arguments:
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.
  - **frequencyFormat** - the display format for frequencies to display in the console and log file. The options are *exp*, *mhz* & *hz*. The default is *exp*.
- - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently.
+ - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently. [JSON format of messages](STATUS-JSON.MD)
  - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.
  - **statusAsString** - Show status as strings instead of numeric values The options are *true* or *false*, without quotes. The default is *false*.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Here are the different arguments:
  - **systems** - An array of JSON objects that define the trunking systems that will be recorded. The following options are used to configure each System.
    - **control_channels** - *(For trunked systems)* an array of the control channel frequencies for the system, in Hz. The frequencies will automatically be cycled through if the system moves to an alternate channel.
    - **channels** - *(For conventional systems)* an array of the channel frequencies, in Hz, used for the system. The channels get assigned a virtual talkgroup number based upon their position in the array. Squelch levels need to be specified for the Source(s) being used.
+   - **alphatags** - *(Optional, For conventional systems)* an array of the alpha tags, these will be outputed to the logfiles *talkgroupDisplayFormat* is set to include tags. Alpha tags will be applied to the *channels* in the order the values appear in the array. 
    - **type** - the type of trunking system. The options are *smartnet*, *p25*,  *conventional* & *conventionalP25*.
    - **talkgroupsFile** - this is a CSV file that provides information about the talkgroups. It determines whether a talkgroup is analog or digital, and what priority it should have. This file should be located in the same directory as the trunk-recorder executable.
    - **recordUnknown** - record talkgroups if they are not listed in the Talkgroups File. The options are *true* and *false* (without quotes). The default is *true*.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Here are the different arguments:
    - **bandplanOffset** - [SmartNet, 400_custom only] this is the offset used to calculate frequencies.
    - **talkgroupDisplayFormat** - the display format for talkgroups in the console and log file. the options are *id*, *id_tag*, *tag_id*. The default is *id*. [*id_tag* and *tag_id* is only valid if **talkgroupsFile** is specified]
    - **delayCreateOutput** - [conventionalP25 only] this will delay the creation of the output file until there is activity, The options are *true* or *false*, without quotes. The default is *false*. 
+   - **hideEncrypted** - hide encrypted talkgroups log entries, The options are *true* or *false*, without quotes. The default is *false*. 
+   - **hideUnknownTalkgroups** - hide unknown talkgroups from log, The options are *true* or *false*, without quotes. The default is *false*. 
  - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile** the options are *digital* or *analog*.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Here are the different arguments:
  - **frequencyFormat** - the display format for frequencies to display in the console and log file. The options are *exp*, *mhz* & *hz*. The default is *exp*.
  - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently.
  - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.
+ - **statusAsString** - Show status as strings instead of numeric values The options are *true* or *false*, without quotes. The default is *false*.
 
 **talkgroupsFile**
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Here are the different arguments:
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.
  - **frequencyFormat** - the display format for frequencies to display in the console and log file. The options are *exp*, *mhz* & *hz*. The default is *exp*.
- - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently. [JSON format of messages](STATUS-JSON.MD)
+ - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently. [JSON format of messages](STATUS-JSON.md)
  - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.
  - **statusAsString** - Show status as strings instead of numeric values The options are *true* or *false*, without quotes. The default is *false*.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Here are the different arguments:
    - **bandplanSpacing** - [SmartNet, 400_custom only] this is the channel spacing, specified in Hz. Typically this is *25000*.
    - **bandplanOffset** - [SmartNet, 400_custom only] this is the offset used to calculate frequencies.
    - **talkgroupDisplayFormat** - the display format for talkgroups in the console and log file. the options are *id*, *id_tag*, *tag_id*. The default is *id*. [*id_tag* and *tag_id* is only valid if **talkgroupsFile** is specified]
+   - **delayCreateOutput** - [conventionalP25 only] this will delay the creation of the output file until there is activity, The options are *true* or *false*, without quotes. The default is *false*. 
  - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile** the options are *digital* or *analog*.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.

--- a/STATUS-JSON.md
+++ b/STATUS-JSON.md
@@ -85,7 +85,7 @@ The following message types are sent
 }
 ```
 
-* system
+## system
 ```json
 {
     "system": {
@@ -103,7 +103,7 @@ The following message types are sent
 
 ```
 
-* calls_active
+## calls_active
 ```json
 {
     "calls": [
@@ -167,7 +167,7 @@ The following message types are sent
 }
 ```
 
-* call_start
+## call_start
 ```json
 {
     "call": {
@@ -205,7 +205,7 @@ The following message types are sent
 }
 ```
 
-* call_end
+## call_end
 ```json
 {
     "call": {
@@ -244,7 +244,7 @@ The following message types are sent
 ```
 
 
-* recorders
+## recorders
 ```json
 {
     "recorders": [
@@ -363,7 +363,7 @@ The following message types are sent
 }
 ```
 
-* recorder
+## recorder
 ```json
 {
     "recorder": {

--- a/STATUS-JSON.md
+++ b/STATUS-JSON.md
@@ -2,47 +2,44 @@ Status json messages
 =======================
 
 
-The json message are sent over a websocket to the server specified by **statusServer**.
+The json message are sent over a websocket to the server specified by **statusServer** config entry.
 
 The following message types are sent 
-* config
+* **config**
   * Contains the config information
-  . Sent when the socket is first connected
-* rates
-  - Contains message decode rates for all systems, non trucked systems will have a zero value
+  * Sent when the socket is first connected
+* **rates**
+  * Contains message decode rates for all systems, non trucked systems will have a zero value
   * Sent every 3 seconds
+* **systems**
+  * Contains a array of systems 
+  * Sent when the socket is first connected
+* **system**
+  * Contains a single system
+  * Sent when a system changes, this happens when the sysid, wacn, or nac is first known
+* **calls_active**
+  * Contains an array of all calls that are currently active
+  * Sent when the socket is first connected, a call is started, or call is completed
+* **call_start**
+  * Contains a single call
+  * Sent when a call is started
+* **call_end**
+  * Contains a single call
+  * Sent when a call is completed
+* **recorders**
+  * Contains an array of all recorders
+  * Sent when he socket is first connected
+* **recorder**
+  * Contains a single recorder
+  * Sent when a record has changed
 
-* systems
-...Contains a array of systems 
-...Sent when he socket is first connected
-* system
-...Contains a single system
-...Sent when a system changes, this happens when the sysid, wacn, or nac is first known
-* calls_active
-...Contains an array of all calls that are currently active
-...Sent when a call is started ot completed
-* call_start
-...Contains a single call
-...Sent when a call is started
-* call_end
-...Contains a single call
-...Sent when a call is completed
-* recorders
-...Contains an array of all recorders
-...Sent when he socket is first connected
-* recorder
-...Contains a single recorder
-...Sent when a record has changed
 
-
- * **config**
+## config
  ```
  *not documented yet*
  ```
 
-
-
-* **rates**
+## rates
 ```json
 {
     "rates": [
@@ -61,7 +58,7 @@ The following message types are sent
 }
 ```
 
-* systems
+## systems
 ```json
 {
     "systems": [

--- a/STATUS-JSON.md
+++ b/STATUS-JSON.md
@@ -6,11 +6,11 @@ The json message are sent over a websocket to the server specified by **statusSe
 
 The following message types are sent 
 * config
-  -Contains the config information
-  -Sent when the socket is first connected
+  * Contains the config information
+  . Sent when the socket is first connected
 * rates
-  -Contains message decode rates for all systems, non trucked systems will have a zero value
-  .Sent every 3 seconds
+  - Contains message decode rates for all systems, non trucked systems will have a zero value
+  * Sent every 3 seconds
 
 * systems
 ...Contains a array of systems 

--- a/STATUS-JSON.md
+++ b/STATUS-JSON.md
@@ -1,0 +1,385 @@
+Status json messages
+=======================
+
+
+The json message are sent over a websocket to the server specified by **statusServer**.
+
+The following message types are sent 
+* config 
+...Contains the config information
+...Sent when the socket is first connected
+* rates
+...Contains message decode rates for all systems, non trucked systems will have a zero value
+...Sent every 3 seconds
+* systems
+...Contains a array of systems 
+...Sent when he socket is first connected
+* system
+...Contains a single system
+...Sent when a system changes, this happens when the sysid, wacn, or nac is first known
+* calls_active
+...Contains an array of all calls that are currently active
+...Sent when a call is started ot completed
+* call_start
+...Contains a single call
+...Sent when a call is started
+* call_end
+...Contains a single call
+...Sent when a call is completed
+* recorders
+...Contains an array of all recorders
+...Sent when he socket is first connected
+* recorder
+...Contains a single recorder
+...Sent when a record has changed
+
+
+ * config
+ ... *not documented yet*
+
+
+
+* rates
+```json
+{
+    "rates": [
+        {
+            "id": "0",
+            "decoderate": "39.333332"
+        },
+        {
+            "id": "1",
+            "decoderate": "0"
+        }
+    ],
+    "type": "rates",
+    "instanceId": "",
+    "instanceKey": ""
+}
+```
+
+* systems
+```json
+{
+    "systems": [
+        {
+            "id": "0",
+            "name": "SYS 1",
+            "type": "p25",
+            "sysid": "123",
+            "wacn": "456",
+            "nac": "789012"
+        },
+        {
+            "id": "1",
+            "name": "SYS 2",
+            "type": "conventionalP25",
+            "sysid": "0",
+            "wacn": "0",
+            "nac": "0"
+        }
+    ],
+    "type": "systems",
+    "instanceId": "",
+    "instanceKey": ""
+}
+```
+
+* system
+```json
+{
+    "system": {
+            "id": "0",
+            "name": "SYS 1",
+            "type": "p25",
+            "sysid": "123",
+            "wacn": "456",
+            "nac": "789012"
+        },
+    "type": "system",
+    "instanceId": "",
+    "instanceKey": ""
+}
+
+```
+
+* calls_active
+```json
+{
+    "calls": [
+        {
+            "id": "1_1_1515574626",
+            "freq": "410000000",
+            "sysNum": "1",
+            "shortName": "SYS 2",
+            "talkgroup": "1",
+            "talkgrouptag": "TG 05",
+            "elasped": "46",
+            "length": "25.632000000000001",
+            "state": "1",
+            "phase2": "false",
+            "conventional": "true",
+            "encrypted": "false",
+            "emergency": "false",
+            "startTime": "1515574626",
+            "stopTime": "1515574626",
+            "freqList": "",
+            "recNum": "8",
+            "srcNum": "0",
+            "recState": "3",
+            "analog": "false",
+            "filename": "\/home\/\/*****\/\/captures\/SYS 2\/2018\/1\/10\/1-1515574626_4.1e+08.wav",
+            "statusfilename": "\/home\/\/*****\/\/captures\/SYS 2\/2018\/1\/10\/1-1515574626_4.1e+08.json"
+        },
+        {
+            "id": "0_1001_1515574637",
+            "freq": "419000000",
+            "sysNum": "0",
+            "shortName": "SYS 1",
+            "talkgroup": "1001",
+            "talkgrouptag": "TG 77",
+            "elasped": "35",
+            "length": "25.091999999999999",
+            "state": "1",
+            "phase2": "false",
+            "conventional": "false",
+            "encrypted": "false",
+            "emergency": "false",
+            "startTime": "1515574637",
+            "stopTime": "1515574637",
+            "freqList": [
+                {
+                    "freq": "419000000",
+                    "time": "1515574637"
+                }
+            ],
+            "recNum": "0",
+            "srcNum": "0",
+            "recState": "3",
+            "analog": "false",
+            "filename": "\/home\/*****\/captures\/SYS 1\/2018\/1\/10\/1001-1515574637_4.19e+08.wav",
+            "statusfilename": "\/home\/****\/captures\/SYS 1\/2018\/1\/10\/1001-1515574637_4.19e+08.json"
+        }
+    ],
+    "type": "calls_active",
+    "instanceId": "",
+    "instanceKey": ""
+}
+```
+
+* call_start
+```json
+{
+    "call": {
+        "id": "0_1001_1515575009",
+        "freq": "419000000",
+        "sysNum": "0",
+        "shortName": "SYS 1",
+        "talkgroup": "1001",
+        "talkgrouptag": "TG 77",
+        "elasped": "0",
+        "length": "0",
+        "state": "1",
+        "phase2": "false",
+        "conventional": "false",
+        "encrypted": "false",
+        "emergency": "false",
+        "startTime": "1515575009",
+        "stopTime": "1515575009",
+        "freqList": [
+            {
+                "freq": "419000000",
+                "time": "1515575009"
+            }
+        ],
+        "recNum": "0",
+        "srcNum": "0",
+        "recState": "3",
+        "analog": "false",
+        "filename": "\/home\/*****\/captures\/SYS 1\/2018\/1\/10\/1001-1515575009_4.19e+08.wav",
+        "statusfilename": "\/home\/*****\/captures\/SYS 1\/2018\/1\/10\/1001-1515575009_4.19e+08.json"
+    },
+    "type": "call_start",
+    "instanceId": "",
+    "instanceKey": ""
+}
+```
+
+* call_end
+```json
+{
+    "call": {
+        "id": "0_1001_1515575009",
+        "freq": "419000000",
+        "sysNum": "0",
+        "shortName": "SYS 1",
+        "talkgroup": "1001",
+        "talkgrouptag": "TG 77",
+        "elasped": "9",
+        "length": "3.4199999999999999",
+        "state": "2",
+        "phase2": "false",
+        "conventional": "false",
+        "encrypted": "false",
+        "emergency": "false",
+        "startTime": "1515575009",
+        "stopTime": "1515575018",
+        "freqList": [
+            {
+                "freq": "419000000",
+                "time": "1515575009"
+            }
+        ],
+        "recNum": "0",
+        "srcNum": "0",
+        "recState": "2",
+        "analog": "false",
+        "filename": "\/home\/*****\/captures\/SYS 1\/2018\/1\/10\/1001-1515575009_4.19e+08.wav",
+        "statusfilename": "\/home\/*****\/captures\/SYS 1\/2018\/1\/10\/1001-1515575009_4.19e+08.json"
+    },
+    "type": "call_end",
+    "instanceId": "",
+    "instanceKey": ""
+}
+```
+
+
+* recorders
+```json
+{
+    "recorders": [
+        {
+            "id": "0_0",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "0",
+            "count": "6",
+            "duration": "76.859999999999999",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_1",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "1",
+            "count": "1",
+            "duration": "10.44",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_2",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "2",
+            "count": "0",
+            "duration": "1.5147569426240483e-314",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_3",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "3",
+            "count": "0",
+            "duration": "1.515774288511435e-314",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_4",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "4",
+            "count": "0",
+            "duration": "1.5147569426240483e-314",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_5",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "5",
+            "count": "0",
+            "duration": "1.5147569426240483e-314",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_6",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "6",
+            "count": "0",
+            "duration": "1.5147569426240483e-314",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_7",
+            "type": "P25",
+            "srcNum": "0",
+            "recNum": "7",
+            "count": "0",
+            "duration": "1.5147569426240483e-314",
+            "state": "2",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        },
+        {
+            "id": "0_8",
+            "type": "P25C",
+            "srcNum": "0",
+            "recNum": "8",
+            "count": "0",
+            "duration": "76.319999999999993",
+            "state": "3",
+            "status_len": "0",
+            "status_error": "0",
+            "status_spike": "0"
+        }
+    ],
+    "type": "recorders",
+    "instanceId": "",
+    "instanceKey": ""
+}
+```
+
+* recorder
+```json
+{
+    "recorder": {
+        "id": "0_0",
+        "type": "P25",
+        "srcNum": "0",
+        "recNum": "0",
+        "count": "5",
+        "duration": "48.600000000000001",
+        "state": "3",
+        "status_len": "0",
+        "status_error": "0",
+        "status_spike": "0"
+    },
+    "type": "recorder",
+    "instanceId": "",
+    "instanceKey": ""
+}
+```

--- a/STATUS-JSON.md
+++ b/STATUS-JSON.md
@@ -5,12 +5,19 @@ Status json messages
 The json message are sent over a websocket to the server specified by **statusServer**.
 
 The following message types are sent 
-* config 
+* config
+
 ...Contains the config information
+
 ...Sent when the socket is first connected
+
+
 * rates
+
 ...Contains message decode rates for all systems, non trucked systems will have a zero value
+
 ...Sent every 3 seconds
+
 * systems
 ...Contains a array of systems 
 ...Sent when he socket is first connected
@@ -34,7 +41,7 @@ The following message types are sent
 ...Sent when a record has changed
 
 
- * config
+ * ###config
  ... *not documented yet*
 
 

--- a/STATUS-JSON.md
+++ b/STATUS-JSON.md
@@ -6,17 +6,11 @@ The json message are sent over a websocket to the server specified by **statusSe
 
 The following message types are sent 
 * config
-
-...Contains the config information
-
-...Sent when the socket is first connected
-
-
+  -Contains the config information
+  -Sent when the socket is first connected
 * rates
-
-...Contains message decode rates for all systems, non trucked systems will have a zero value
-
-...Sent every 3 seconds
+  -Contains message decode rates for all systems, non trucked systems will have a zero value
+  .Sent every 3 seconds
 
 * systems
 ...Contains a array of systems 
@@ -41,12 +35,14 @@ The following message types are sent
 ...Sent when a record has changed
 
 
- * ###config
- ... *not documented yet*
+ * **config**
+ ```
+ *not documented yet*
+ ```
 
 
 
-* rates
+* **rates**
 ```json
 {
     "rates": [

--- a/lib/gr_blocks/nonstop_wavfile_sink.h
+++ b/lib/gr_blocks/nonstop_wavfile_sink.h
@@ -24,6 +24,7 @@
 #define INCLUDED_GR_NONSTOP_WAVFILE_SINK_H
 
 #include "../trunk-recorder/call.h"
+#include "../trunk-recorder/call_conventional.h"
 #include <boost/log/trivial.hpp>
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/sync_block.h>
@@ -44,17 +45,6 @@ class BLOCKS_API nonstop_wavfile_sink : virtual public sync_block
 public:
 	// gr::blocks::wavfile_sink::sptr
 	typedef boost::shared_ptr<nonstop_wavfile_sink> sptr;
-
-	/*
-	 * \param filename The .wav file to be opened
-	 * \param n_channels Number of channels (2 = stereo or I/Q output)
-	 * \param sample_rate Sample rate [S/s]
-	 * \param bits_per_sample 16 or 8 bit, default is 16
-	 */
-	static sptr make(int n_channels,
-	                 unsigned int sample_rate,
-	                 int bits_per_sample = 16,
-								 		bool use_float=true);
 
 	/*!
 	 * \brief Opens a new file and writes a WAV header. Thread-safe.

--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.h
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.h
@@ -35,21 +35,23 @@ class nonstop_wavfile_sink_impl : public nonstop_wavfile_sink
 {
 private:
 	unsigned d_sample_rate;
-	int d_nchans;
-	unsigned d_sample_count;
-	int d_bytes_per_sample;
+	int d_nchans;	
+	
 	int d_max_sample_val;
 	int d_min_sample_val;
 	int d_normalize_shift;
 	int d_normalize_fac;
 	bool d_use_float;
 
-  char current_filename[255];
+  	char current_filename[255];
 
+protected:
+	
+	unsigned d_sample_count;
+	int d_bytes_per_sample;
 	FILE *d_fp;
 	boost::mutex d_mutex;
-
-
+	virtual int dowork(int noutput_items,  gr_vector_const_void_star& input_items,  gr_vector_void_star& output_items);
 	/*!
 	 * \brief Convert a sample value within [-1;+1] to a corresponding
 	 *  short integer value
@@ -73,16 +75,30 @@ private:
 
 protected:
 	bool stop();
-
+	bool open_internal(const char *filename);
 public:
+
+	typedef boost::shared_ptr<nonstop_wavfile_sink_impl> sptr;
+
+	/*
+	 * \param filename The .wav file to be opened
+	 * \param n_channels Number of channels (2 = stereo or I/Q output)
+	 * \param sample_rate Sample rate [S/s]
+	 * \param bits_per_sample 16 or 8 bit, default is 16
+	 */
+	static sptr make(int n_channels,
+	                 unsigned int sample_rate,
+	                 int bits_per_sample = 16,
+								 		bool use_float=true);
+
 	nonstop_wavfile_sink_impl(int n_channels,
 	                          unsigned int sample_rate,
 	                          int bits_per_sample,
 													bool use_float);
-	~nonstop_wavfile_sink_impl();
-char *get_filename();
-	bool open(const char* filename);
-	void close();
+	virtual ~nonstop_wavfile_sink_impl();
+	char *get_filename();
+	virtual bool open(const char* filename);
+	virtual void close();
 
 	void set_sample_rate(unsigned int sample_rate);
 	void set_bits_per_sample(int bits_per_sample);
@@ -93,9 +109,10 @@ char *get_filename();
 	double length_in_seconds();
 	Call_Source * get_source_list();
 	int get_source_count();
-	int work(int noutput_items,
+	virtual int work(int noutput_items,
 	         gr_vector_const_void_star &input_items,
 	         gr_vector_void_star &output_items);
+
 };
 
 } /* namespace blocks */

--- a/trunk-recorder/call.cc
+++ b/trunk-recorder/call.cc
@@ -431,7 +431,7 @@ void Call::update_talkgroup_display(){
   if (this->sys->get_talkgroup_display_format() == System::talkGroupDisplayFormat_id_tag) {
     talkgroup_display = boost::lexical_cast<std::string>(talkgroup).append(" (").append(talkgroup_tag).append(")"); 
   } else if (this->sys->get_talkgroup_display_format() == System::talkGroupDisplayFormat_tag_id) {
-    talkgroup_display = talkgroup_tag.append(" (").append(boost::lexical_cast<std::string>(talkgroup)).append(")"); 
+    talkgroup_display = std::string("").append(talkgroup_tag).append(" (").append(boost::lexical_cast<std::string>(talkgroup)).append(")"); 
   } else{
     talkgroup_display = boost::lexical_cast<std::string>(talkgroup);
   }

--- a/trunk-recorder/call.h
+++ b/trunk-recorder/call.h
@@ -95,6 +95,10 @@ public:
 								std::string get_talkgroup_display();
 								void set_talkgroup_display_format(std::string format);
 								void set_talkgroup_tag(std::string tag);
+								boost::property_tree::ptree get_stats();
+								char * get_status_filename();
+								std::string get_talkgroup_tag();
+								double get_final_length();								
 protected:
 								State state;
 								long talkgroup;
@@ -120,6 +124,7 @@ protected:
 								char status_filename[255];
 								bool phase2_tdma;
 								int tdma_slot;
+								double _final_length;
 
 								Config config;
 								Recorder *recorder;

--- a/trunk-recorder/call.h
+++ b/trunk-recorder/call.h
@@ -31,7 +31,6 @@ class Recorder;
 #include "uploaders/call_uploader.h"
 #include "config.h"
 #include "state.h"
-#include "recorders/recorder.h"
 #include "systems/system.h"
 #include "systems/parser.h"
 #include <string>
@@ -45,12 +44,12 @@ public:
 
 								Call( long t, double f, System *s, Config c);
 								Call( TrunkMessage message, System *s, Config c);
-								~Call();
-								void restart_call();
+								virtual ~Call();
+								virtual void restart_call();
 								void end_call();
 								void set_debug_recorder(Recorder *r);
 								Recorder * get_debug_recorder();
-								void set_recorder(Recorder *r);
+								virtual void set_recorder(Recorder *r, std::string device);
 								Recorder * get_recorder();
 								double get_freq();
 
@@ -87,8 +86,8 @@ public:
 								void set_tdma_slot(int s);
 								int get_tdma_slot();
 								const char * get_xor_mask();
-								bool is_conventional();
-								void set_conventional(bool conv);
+								//virtual bool is_conventional() { return true;}
+								virtual bool is_conventional() { return false;}
 								void set_encrypted(bool m);
 								bool get_encrypted();
 								void set_emergency(bool m);
@@ -96,7 +95,7 @@ public:
 								std::string get_talkgroup_display();
 								void set_talkgroup_display_format(std::string format);
 								void set_talkgroup_tag(std::string tag);
-private:
+protected:
 								State state;
 								long talkgroup;
 								double curr_freq;
@@ -116,7 +115,6 @@ private:
 								bool debug_recording;
 								bool encrypted;
 								bool emergency;
-								bool conventional;
 								char filename[255];
 								char converted_filename[255];
 								char status_filename[255];

--- a/trunk-recorder/call_conventional.cc
+++ b/trunk-recorder/call_conventional.cc
@@ -1,8 +1,7 @@
 
 #include "formatter.h"
 #include <boost/algorithm/string.hpp>
-#include "call.h"
-#include "config.h"
+#include "recorders/recorder.h"
 #include "call_conventional.h"
 
 
@@ -10,5 +9,30 @@ Call_conventional::Call_conventional(long t, double f, System *s, Config c) : Ca
 }
 
 Call_conventional::~Call_conventional() {
-  //  BOOST_LOG_TRIVIAL(info) << " This call is over!!";
+}
+
+void Call_conventional::restart_call() {
+    idle_count       = 0;
+    freq_count       = 0;
+    src_count        = 0;
+    error_list_count = 0;
+    curr_src_id      = 0;
+    start_time       = time(NULL);
+    stop_time        = time(NULL);
+    last_update      = time(NULL);
+    state            = recording;
+    debug_recording  = false;
+    phase2_tdma      = false;
+    tdma_slot        = 0;
+    encrypted        = false;
+    emergency        = false;
+
+    this->create_filename();
+    this->update_talkgroup_display();
+    recorder->start(this);
+}
+
+void Call_conventional::set_recorder(Recorder *r, std::string device) {
+  recorder = r;
+  BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << this->get_talkgroup_display() << "\tFreq: " <<  FormatFreq(this->get_freq()) << "\tListening on Src: " << device;
 }

--- a/trunk-recorder/call_conventional.cc
+++ b/trunk-recorder/call_conventional.cc
@@ -3,9 +3,10 @@
 #include <boost/algorithm/string.hpp>
 #include "recorders/recorder.h"
 #include "call_conventional.h"
+#include "./uploaders/stat_socket.h"
 
-
-Call_conventional::Call_conventional(long t, double f, System *s, Config c) : Call(t,f,s,c) {
+Call_conventional::Call_conventional(long t, double f, System *s, Config c, stat_socket * stat_socket) : Call(t,f,s,c) {
+  d_stat_socket = stat_socket;
 }
 
 Call_conventional::~Call_conventional() {
@@ -35,4 +36,10 @@ void Call_conventional::restart_call() {
 void Call_conventional::set_recorder(Recorder *r, std::string device) {
   recorder = r;
   BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << this->get_talkgroup_display() << "\tFreq: " <<  FormatFreq(this->get_freq()) << "\tListening on Src: " << device;
+}
+
+void Call_conventional::recording_started()
+{
+  start_time = time(NULL);
+  d_stat_socket->send_call_start(this);
 }

--- a/trunk-recorder/call_conventional.h
+++ b/trunk-recorder/call_conventional.h
@@ -3,7 +3,7 @@
 class Config;
 class System;
 class Recorder;
-
+class stat_socket;
 
 #include <string>
 #include "call.h"
@@ -12,13 +12,16 @@ class Recorder;
 class Call_conventional : public Call {
 public:
 
-								Call_conventional( long t, double f, System *s, Config c);
+								Call_conventional( long t, double f, System *s, Config c, stat_socket * stat_socket);
 								~Call_conventional();
 
 								virtual bool is_conventional() { return true;}
 								void restart_call();
 								void set_recorder(Recorder *r, std::string device);
 								char * get_filename();
+								void recording_started();
+private:								
+								stat_socket * d_stat_socket;								
 };
 
 #endif

--- a/trunk-recorder/call_conventional.h
+++ b/trunk-recorder/call_conventional.h
@@ -1,16 +1,24 @@
 #ifndef CALL_CONVENTIONAL_H
 #define CALL_CONVENTIONAL_H
-
-class Call;
 class Config;
 class System;
+class Recorder;
 
-class Call_conventional : Call {
+
+#include <string>
+#include "call.h"
+
+
+class Call_conventional : public Call {
 public:
 
 								Call_conventional( long t, double f, System *s, Config c);
 								~Call_conventional();
 
+								virtual bool is_conventional() { return true;}
+								void restart_call();
+								void set_recorder(Recorder *r, std::string device);
+								char * get_filename();
 };
 
 #endif

--- a/trunk-recorder/formatter.cc
+++ b/trunk-recorder/formatter.cc
@@ -1,6 +1,8 @@
 #include "formatter.h"
+#include <boost/lexical_cast.hpp>
 
 int frequencyFormat = 0;
+bool statusAsString = false;
 
 boost::format FormatFreq(float f)
 {
@@ -17,3 +19,19 @@ boost::format FormatSamplingRate(float f)
 	return boost::format("%.0f")  % f;
 }
 
+std::string FormatState(State state)
+{
+	if (statusAsString)
+	{
+		if (state == monitoring)
+			return "monitoring";
+		else if (state == recording)
+			return "recording";
+		else if (state == inactive)
+			return "inactive";
+		else if (state == active)
+			return "active";
+		return "Unknown";
+	}
+	return boost::lexical_cast<std::string>(state);
+}

--- a/trunk-recorder/formatter.h
+++ b/trunk-recorder/formatter.h
@@ -2,10 +2,14 @@
 #define FORMATTER_H
 
 #include <boost/format.hpp>
+#include <string>
+#include "state.h"
 
 extern boost::format FormatFreq(float f);
 extern boost::format FormatSamplingRate(float f);
+extern std::string FormatState(State state);
 extern int frequencyFormat;
+extern bool statusAsString;
 
 #endif // FORMATTER_H
 

--- a/trunk-recorder/gr_blocks/nonstop_wavfile_delayopen_sink_impl.cc
+++ b/trunk-recorder/gr_blocks/nonstop_wavfile_delayopen_sink_impl.cc
@@ -1,0 +1,121 @@
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif // ifdef HAVE_CONFIG_H
+
+//#include "nonstop_wavfile_sink_impl.h"
+//#include "nonstop_wavfile_sink.h"
+#include <gnuradio/io_signature.h>
+
+#include "nonstop_wavfile_delayopen_sink_impl.h"
+#include "../recorders/p25conventional_recorder.h"
+
+namespace gr 
+{
+namespace blocks 
+{
+nonstop_wavfile_delayopen_sink_impl::sptr
+nonstop_wavfile_delayopen_sink_impl::make(int          n_channels,
+                           unsigned int sample_rate,
+                           int          bits_per_sample,
+                           bool         use_float)
+{
+  return gnuradio::get_initial_sptr
+           (new nonstop_wavfile_delayopen_sink_impl( n_channels,
+                                          sample_rate, bits_per_sample, use_float));
+}
+
+nonstop_wavfile_delayopen_sink_impl::nonstop_wavfile_delayopen_sink_impl(
+                                                     int          n_channels,
+                                                     unsigned int sample_rate,
+                                                     int          bits_per_sample,
+                                                     bool use_float)
+  :sync_block("nonstop_wavfile_sink",
+               io_signature::make(1, n_channels, (use_float) ? sizeof(float) : sizeof(int16_t)),
+               io_signature::make(0, 0, 0)),
+                nonstop_wavfile_sink_impl(n_channels, sample_rate, bits_per_sample, use_float)
+{
+    d_first_work = true;
+  d_sample_count = 0;
+}
+
+nonstop_wavfile_delayopen_sink_impl::~nonstop_wavfile_delayopen_sink_impl()
+{
+}
+
+void nonstop_wavfile_delayopen_sink_impl::reset()
+{
+  d_first_work = true;
+  d_sample_count = 0;
+}
+
+int nonstop_wavfile_delayopen_sink_impl::work(int noutput_items,  gr_vector_const_void_star& input_items,  gr_vector_void_star& output_items) {
+
+  gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this
+
+  bool was_first_work = d_first_work;
+  d_first_work = false;
+
+  if (!d_fp) // drop output on the floor
+  {
+    if (was_first_work) {
+      char * filename = recorder->get_filename();
+	    if (!open_internal(filename)) {
+          throw std::runtime_error("can't open file");    
+		  }
+    }
+	}
+
+  if (was_first_work){
+	  d_start_time = time(NULL);
+    recorder->recording_started();
+  }
+
+  // insert delay
+  /*
+  if (was_first_work == false) {
+	  if ((clock()- d_last_packet_clock) > 400)
+	  {
+		  int pad_ms = clock()- d_last_packet_clock;
+			
+	  }
+  }*/
+
+  int nwritten = dowork(noutput_items, input_items, output_items);
+
+  d_stop_time = time(NULL);
+  d_last_packet_clock = clock();
+
+  return nwritten;
+  //return 0;
+}
+
+time_t nonstop_wavfile_delayopen_sink_impl::get_start_time() {
+	return d_start_time;
+}
+
+time_t nonstop_wavfile_delayopen_sink_impl::get_stop_time() {
+	return d_stop_time;
+}
+
+void nonstop_wavfile_delayopen_sink_impl::set_recorder(p25conventional_recorder * recorder)
+{
+  this->recorder = recorder;
+}
+
+void
+nonstop_wavfile_delayopen_sink_impl::close()
+{
+  gr::thread::scoped_lock guard(d_mutex);
+
+  if (!d_fp) {
+      if (d_first_work == false){
+        BOOST_LOG_TRIVIAL(error) << "wav error closing file" << std::endl;
+      }
+      return;
+  }
+  close_wav();
+}
+
+} /* namespace blocks */
+} /* namespace gr */

--- a/trunk-recorder/gr_blocks/nonstop_wavfile_delayopen_sink_impl.h
+++ b/trunk-recorder/gr_blocks/nonstop_wavfile_delayopen_sink_impl.h
@@ -1,0 +1,59 @@
+#ifndef INCLUDED_NONSTOP_WAVFILE_DELAYOPEN_SINK_IMPL_H
+#define INCLUDED_NONSTOP_WAVFILE_DELAYOPEN_SINK_IMPL_H
+
+#include "../../lib/gr_blocks/nonstop_wavfile_sink_impl.h"
+#include "../../lib/gr_blocks/nonstop_wavfile_sink.h"
+
+class p25conventional_recorder;
+
+namespace gr {
+namespace blocks {
+
+class nonstop_wavfile_delayopen_sink_impl : public nonstop_wavfile_sink_impl
+{
+public:
+
+	typedef boost::shared_ptr<nonstop_wavfile_delayopen_sink_impl> sptr;
+
+	/*
+	 * \param filename The .wav file to be opened
+	 * \param n_channels Number of channels (2 = stereo or I/Q output)
+	 * \param sample_rate Sample rate [S/s]
+	 * \param bits_per_sample 16 or 8 bit, default is 16
+	 */
+	static sptr make(int n_channels,
+	                 unsigned int sample_rate,
+	                 int bits_per_sample = 16,
+								 		bool use_float=true);
+
+	nonstop_wavfile_delayopen_sink_impl(int n_channels,
+								unsigned int sample_rate,
+	                          	int bits_per_sample,
+								bool use_float);
+
+	virtual ~nonstop_wavfile_delayopen_sink_impl();
+
+	virtual void close();
+
+	int work(int noutput_items,  gr_vector_const_void_star& input_items,  gr_vector_void_star& output_items);
+
+	time_t get_start_time();
+	time_t get_stop_time();
+	void set_recorder(p25conventional_recorder * recorder);
+
+	void reset();
+
+private:
+	bool d_delay_file_creation;
+	bool d_first_work;
+	time_t d_start_time;
+	clock_t d_last_packet_clock;
+	time_t d_stop_time;
+	p25conventional_recorder * recorder;
+
+};
+
+} /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_NONSTOP_WAVFILE_DELAYOPEN_SINK_IMPL_H */

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1020,7 +1020,7 @@ void monitor_messages() {
 
     float statusTimeDiff = currentTime - lastStatusTime;
 
-    if (statusTimeDiff > 20) {
+    if (statusTimeDiff > 200) {
       lastStatusTime = currentTime;
       print_status();
     }

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -555,7 +555,7 @@ void stop_inactive_recorders() {
 
     if (call->is_conventional() && call->get_recorder()) {
       // if any recording has happened
-      if (call->get_current_length() > 1.0) {
+      if (call->get_current_length() > 0) {
         BOOST_LOG_TRIVIAL(trace) << "Recorder: " <<  call->get_current_length() << " Idle: " << call->get_recorder()->is_idle() << " Count: " << call->get_idle_count();
 
         // means that the squelch is on and it has stopped recording

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -174,6 +174,20 @@ void load_config(string config_file)
           BOOST_LOG_TRIVIAL(info) << sub_node.second.get<double>("", 0) << " ";
           system->add_channel(channel);
         }
+
+        BOOST_LOG_TRIVIAL(info) << "Alpha Tags: ";
+        if (node.second.count("alphatags") != 0)
+        {
+          int alphaIndex = 1;
+          BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("alphatags"))
+          {
+            std::string alphaTag = sub_node.second.get<std::string>("", "");
+            BOOST_LOG_TRIVIAL(info) << alphaTag << " ";
+            system->talkgroups->add(alphaIndex, alphaTag);
+            alphaIndex++;
+          }
+        }        
+        
       }  else if (system->get_system_type() == "conventionalP25") {
         BOOST_LOG_TRIVIAL(info) << "Conventional Channels: ";
         BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("channels"))
@@ -183,6 +197,20 @@ void load_config(string config_file)
           BOOST_LOG_TRIVIAL(info) << sub_node.second.get<double>("", 0) << " ";
           system->add_channel(channel);
         }
+
+        BOOST_LOG_TRIVIAL(info) << "Alpha Tags: ";
+        if (node.second.count("alphatags") != 0)
+        {
+          int alphaIndex = 1;
+          BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("alphatags"))
+          {
+            std::string alphaTag = sub_node.second.get<std::string>("", "");
+            BOOST_LOG_TRIVIAL(info) << alphaTag << " ";
+            system->talkgroups->add(alphaIndex, alphaTag);
+            alphaIndex++;
+          }
+        }
+
         system->set_delaycreateoutput(node.second.get<bool>("delayCreateOutput", false));
         BOOST_LOG_TRIVIAL(info) << "delayCreateOutput: " << system->get_delaycreateoutput();
 
@@ -1024,8 +1052,12 @@ bool monitor_system() {
 
             BOOST_LOG_TRIVIAL(info) << "[" << system->get_short_name() << "]\tMonitoring Conventional Channel: " <<  FormatFreq(channel) << " Talkgroup: " << talkgroup;
             Call_conventional *call = new Call_conventional(talkgroup, channel, system, config);
-            //Call *call = new Call(talkgroup, channel, system, config);
             talkgroup++;
+            Talkgroup *talkgroup = system->find_talkgroup(call->get_talkgroup());
+
+            if (talkgroup) {
+              call->set_talkgroup_tag(talkgroup->alpha_tag);
+            }
 
             if (system->get_system_type() == "conventional") {
               analog_recorder_sptr rec;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -273,6 +273,9 @@ void load_config(string config_file)
 
     BOOST_LOG_TRIVIAL(info) << "Frequency format: " << frequencyFormat;
 
+    statusAsString = pt.get<bool>("statusAsString", statusAsString);
+    BOOST_LOG_TRIVIAL(info) << "Status as String: " << statusAsString;
+
     BOOST_FOREACH(boost::property_tree::ptree::value_type  & node,
                   pt.get_child("sources"))
     {
@@ -604,10 +607,10 @@ void print_status() {
   for (vector<Call *>::iterator it = calls.begin(); it != calls.end(); it++) {
     Call *call         = *it;
     Recorder *recorder = call->get_recorder();
-    BOOST_LOG_TRIVIAL(info) << "TG: " << call->get_talkgroup() << " Freq: " << FormatFreq(call->get_freq()) << " Elapsed: " << call->elapsed() << " State: " << call->get_state();
+    BOOST_LOG_TRIVIAL(info) << "TG: " << call->get_talkgroup() << " Freq: " << FormatFreq(call->get_freq()) << " Elapsed: " << call->elapsed() << " State: " << FormatState(call->get_state());
 
     if (recorder) {
-      BOOST_LOG_TRIVIAL(info) << "\t[ " << recorder->get_num() << " ] State: " << recorder->get_state();
+      BOOST_LOG_TRIVIAL(info) << "\t[ " << recorder->get_num() << " ] State: " << FormatState(recorder->get_state());
     }
   }
 
@@ -980,7 +983,7 @@ void monitor_messages() {
 
     float statusTimeDiff = currentTime - lastStatusTime;
 
-    if (statusTimeDiff > 300) {
+    if (statusTimeDiff > 20) {
       lastStatusTime = currentTime;
       print_status();
     }

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -41,7 +41,7 @@ void analog_recorder::calculate_iir_taps(double tau)
 analog_recorder::analog_recorder(Source *src)
   : gr::hier_block2("analog_recorder",
                     gr::io_signature::make(1, 1, sizeof(gr_complex)),
-                    gr::io_signature::make(0, 0, sizeof(float)))
+                    gr::io_signature::make(0, 0, sizeof(float))), Recorder("A")
 {
   //int nchars;
 
@@ -207,6 +207,7 @@ int analog_recorder::get_num() {
 
 void analog_recorder::stop() {
   if (state == active) {
+    recording_duration += wav_sink->length_in_seconds();
     state = inactive;
     valve->set_enabled(false);
     wav_sink->close();

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -1,6 +1,7 @@
 
 #include "analog_recorder.h"
 #include "../formatter.h"
+#include "../../lib/gr_blocks/nonstop_wavfile_sink_impl.h"
 using namespace std;
 
 bool analog_recorder::logging = false;
@@ -160,7 +161,7 @@ analog_recorder::analog_recorder(Source *src)
 
   //tm *ltm = localtime(&starttime);
 
-  wav_sink = gr::blocks::nonstop_wavfile_sink::make(1, 8000, 16, true);
+  wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, 8000, 16, true);
 
   // Try and get rid of the FSK wobble
   high_f_taps =  gr::filter::firdes::high_pass(1, 8000, 300, 50, gr::filter::firdes::WIN_HANN);

--- a/trunk-recorder/recorders/debug_recorder.cc
+++ b/trunk-recorder/recorders/debug_recorder.cc
@@ -12,7 +12,7 @@ debug_recorder_sptr make_debug_recorder(Source *src)
 debug_recorder::debug_recorder(Source *src)
   : gr::hier_block2("debug_recorder",
                     gr::io_signature::make(1, 1, sizeof(gr_complex)),
-                    gr::io_signature::make(0, 0, sizeof(float)))
+                    gr::io_signature::make(0, 0, sizeof(float))), Recorder("D")
 {
   source = src;
   freq   = source->get_center();
@@ -208,6 +208,7 @@ State debug_recorder::get_state() {
 
 void debug_recorder::stop() {
   if (state == active) {
+    recording_duration += wav_sink->length_in_seconds();
     BOOST_LOG_TRIVIAL(error) << "p25_recorder.cc: Stopping Logger \t[ " << rec_num << " ] - freq[ " << freq << "] \t talkgroup[ " << talkgroup << " ]";
     state = inactive;
     valve->set_enabled(false);

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -45,10 +45,16 @@ if (arb_rate <= 1) {
 p25_recorder::p25_recorder()
   : gr::hier_block2("p25_recorder",
                     gr::io_signature::make(1, 1, sizeof(gr_complex)),
-                    gr::io_signature::make(0, 0, sizeof(float)))
+                    gr::io_signature::make(0, 0, sizeof(float))), Recorder("P25")
 {
 }
 
+p25_recorder::p25_recorder(std::string type)
+  : gr::hier_block2("p25_recorder",
+                    gr::io_signature::make(1, 1, sizeof(gr_complex)),
+                    gr::io_signature::make(0, 0, sizeof(float))), Recorder(type)
+{
+}
 
 
 void p25_recorder::initialize(Source *src, gr::blocks::nonstop_wavfile_sink::sptr wav_sink)
@@ -363,7 +369,7 @@ Rx_Status p25_recorder::get_rx_status() {
 }
 void p25_recorder::stop() {
   if (state == active) {
-
+    recording_duration += wav_sink->length_in_seconds();
     clear();
     BOOST_LOG_TRIVIAL(info) << "\t- Stopping P25 Recorder Num [" << rec_num << "]\tTG: " << this->call->get_talkgroup_display() << "\tFreq: " << FormatFreq(chan_freq) << " \tTDMA: " << d_phase2_tdma << "\tSlot: " << tdma_slot;
 
@@ -436,6 +442,7 @@ void p25_recorder::start(Call *call) {
     wav_sink->open(call->get_filename());
     state = active;
     valve->set_enabled(true);
+    recording_count++;
   } else {
     BOOST_LOG_TRIVIAL(error) << "p25_recorder.cc: Trying to Start an already Active Logger!!!";
   }

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -8,7 +8,7 @@
 p25_recorder_sptr make_p25_recorder(Source * src)
 {
   p25_recorder * recorder = new p25_recorder();
-  recorder->initialize(src, gr::blocks::nonstop_wavfile_delayopen_sink_impl::make(1, 8000, 16, false));
+  recorder->initialize(src, gr::blocks::nonstop_wavfile_sink_impl::make(1, 8000, 16, false));
   return gnuradio::get_initial_sptr(recorder);
 }
 

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -66,6 +66,7 @@ class p25_recorder : public gr::hier_block2, public Recorder {
 
 protected:
   p25_recorder();
+  p25_recorder(std::string type);
   virtual void initialize(Source *src, gr::blocks::nonstop_wavfile_sink::sptr wav_sink);
 
 public:  

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -58,23 +58,22 @@
 class Source;
 class p25_recorder;
 typedef boost::shared_ptr<p25_recorder>p25_recorder_sptr;
-p25_recorder_sptr make_p25_recorder(Source *src);
+p25_recorder_sptr make_p25_recorder(Source * src);
 #include "../source.h"
 
 class p25_recorder : public gr::hier_block2, public Recorder {
-  friend p25_recorder_sptr make_p25_recorder(Source *src);
+  friend p25_recorder_sptr make_p25_recorder(Source * src);
 
 protected:
+  p25_recorder();
+  virtual void initialize(Source *src, gr::blocks::nonstop_wavfile_sink::sptr wav_sink);
 
-  p25_recorder(Source *src);
-
-public:
-
-  ~p25_recorder();
+public:  
+  virtual ~p25_recorder();
 
   void    tune_offset(double f);
-  void    start(Call *call);
-  void    stop();
+  virtual void    start(Call *call);
+  virtual void    stop();
   void    clear();
   double  get_freq();
   int     get_num();
@@ -96,9 +95,29 @@ public:
   gr::msg_queue::sptr traffic_queue;
   gr::msg_queue::sptr rx_queue;
 
+protected:
+
+  State state;
+  time_t timestamp;
+  time_t starttime;
+  long   talkgroup;
+  std::string short_name;
+  Call *call;
+  Config *config;
+  Source *source;
+  double chan_freq;
+  double center_freq;
+  bool   qpsk_mod;
+
+  gr::op25_repeater::p25_frame_assembler::sptr op25_frame_assembler;
+  freq_xlating_fft_filter_sptr prefilter;
+  gr::blocks::nonstop_wavfile_sink::sptr wav_sink;
+  gr::blocks::copy::sptr valve;
+  gr::blocks::multiply_const_ss::sptr levels;
+
 private:
 
-  double center_freq, chan_freq;
+  
   double system_channel_rate;
   double arb_rate;
   double samples_per_symbol;
@@ -106,22 +125,17 @@ private:
   double initial_rate;
   int decim;
   double resampled_rate;
-  bool   qpsk_mod;
+  
   double squelch_db;
   int    silence_frames;
   int    tdma_slot;
-  long   talkgroup;
+  
   bool   d_phase2_tdma;
-  std::string short_name;
-  time_t timestamp;
-  time_t starttime;
-  Call *call;
-  Config *config;
-  Source *source;
+  
+  
+  
   char    filename[160];
   char    raw_filename[160];
-
-  State state;
 
   std::vector<float> inital_lpf_taps;
   std::vector<float> channel_lpf_taps;
@@ -129,7 +143,7 @@ private:
   std::vector<float> sym_taps;
   std::vector<float> baseband_noise_filter_taps;
 
-  freq_xlating_fft_filter_sptr prefilter;
+  
 
   /* GR blocks */
   gr::filter::fft_filter_ccf::sptr channel_lpf;
@@ -144,18 +158,18 @@ private:
   gr::analog::feedforward_agc_cc::sptr   agc;
   gr::analog::pll_freqdet_cf::sptr       pll_freq_lock;
   gr::analog::pwr_squelch_cc::sptr       squelch;
-  gr::blocks::nonstop_wavfile_sink::sptr wav_sink;
+  
 
-  gr::blocks::copy::sptr valve;
+  
 
-  gr::blocks::multiply_const_ss::sptr levels;
+  
   gr::blocks::multiply_const_ff::sptr rescale;
   gr::blocks::multiply_const_ff::sptr baseband_amp;
   gr::blocks::multiply_const_ff::sptr pll_amp;
   gr::blocks::complex_to_arg::sptr    to_float;
 
   gr::op25_repeater::fsk4_demod_ff::sptr fsk4_demod;
-  gr::op25_repeater::p25_frame_assembler::sptr op25_frame_assembler;
+  
   gr::op25_repeater::fsk4_slicer_fb::sptr slicer;
   gr::op25_repeater::vocoder::sptr op25_vocoder;
   gr::op25_repeater::gardner_costas_cc::sptr costas_clock;

--- a/trunk-recorder/recorders/p25conventional_recorder.cc
+++ b/trunk-recorder/recorders/p25conventional_recorder.cc
@@ -20,7 +20,7 @@ p25conventional_recorder_sptr make_p25conventional_recorder(Source * src, bool d
   return gnuradio::get_initial_sptr<p25conventional_recorder>(recorder);
 }
 
-p25conventional_recorder::p25conventional_recorder(bool delayopen) : p25_recorder() 
+p25conventional_recorder::p25conventional_recorder(bool delayopen) : p25_recorder("P25C") 
 {
   d_delayopen = delayopen;
 }

--- a/trunk-recorder/recorders/p25conventional_recorder.cc
+++ b/trunk-recorder/recorders/p25conventional_recorder.cc
@@ -1,15 +1,94 @@
 #include "p25_recorder.h"
 #include "p25conventional_recorder.h"
+#include "../gr_blocks/nonstop_wavfile_delayopen_sink_impl.h"
+#include "../formatter.h"
 
-
-p25conventional_recorder_sptr make_p25conventional_recorder(Source *src)
+p25conventional_recorder_sptr make_p25conventional_recorder(Source * src, bool delayopen)
 {
-  return gnuradio::get_initial_sptr(new p25conventional_recorder(src));
+  p25conventional_recorder * recorder = new p25conventional_recorder(delayopen);
+  if (delayopen)
+  {
+    boost::shared_ptr<gr::blocks::nonstop_wavfile_delayopen_sink_impl> w = gr::blocks::nonstop_wavfile_delayopen_sink_impl::make(1, 8000, 16, false);
+    w->set_recorder(recorder);
+    recorder->initialize(src, w);
+  }
+  else
+  {
+    boost::shared_ptr<gr::blocks::nonstop_wavfile_sink_impl> w = gr::blocks::nonstop_wavfile_sink_impl::make(1, 8000, 16, false);
+    recorder->initialize(src, w);
+  }
+  return gnuradio::get_initial_sptr<p25conventional_recorder>(recorder);
 }
 
-p25conventional_recorder::p25conventional_recorder(Source *src) : p25_recorder(src)  
+p25conventional_recorder::p25conventional_recorder(bool delayopen) : p25_recorder() 
 {
-  
+  d_delayopen = delayopen;
 }
 
-p25conventional_recorder::~p25conventional_recorder() {}
+p25conventional_recorder::~p25conventional_recorder() 
+{
+
+}
+
+void p25conventional_recorder::start(Call *call) {
+  if (state == inactive) {
+    timestamp = time(NULL);
+    starttime = time(NULL);
+
+    talkgroup = call->get_talkgroup();
+    short_name = call->get_short_name();
+    chan_freq      = call->get_freq();
+    this->call = call;
+
+    if (d_delayopen) {
+      boost::static_pointer_cast<gr::blocks::nonstop_wavfile_delayopen_sink_impl>(this->wav_sink)->reset();
+    }
+
+    //((gr::blocks::nonstop_wavfile_delayopen_sink_impl *)this->wav_sink)->reset();
+
+    set_tdma(call->get_phase2_tdma());
+
+    if (call->get_phase2_tdma()) {
+
+      set_tdma_slot(call->get_tdma_slot());
+
+      if (call->get_xor_mask()) {
+        op25_frame_assembler->set_xormask(call->get_xor_mask());
+      } else {
+          BOOST_LOG_TRIVIAL(info) << "Error - can't set XOR Mask for TDMA";
+      }
+    } else {
+      set_tdma_slot(0);
+    }
+
+    if (!qpsk_mod) {
+      reset();
+    }
+    if (d_delayopen) {
+      BOOST_LOG_TRIVIAL(info) << "\t- Listening P25 Recorder Num [" << rec_num << "]\tTG: " << this->call->get_talkgroup_display() << "\tFreq: " << FormatFreq(chan_freq) << " \tTDMA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot();
+    } else {
+      recording_started();
+    }
+
+
+    int offset_amount = (chan_freq - center_freq);
+    prefilter->set_center_freq(offset_amount);
+    if (d_delayopen == false) {
+      wav_sink->open(call->get_filename());
+    }
+    state = active;
+    valve->set_enabled(true);
+  } else {
+    BOOST_LOG_TRIVIAL(error) << "p25conventional_recorder.cc: Trying to Start an already Active Logger!!!";
+  }
+}
+
+void p25conventional_recorder::recording_started()
+{
+    BOOST_LOG_TRIVIAL(info) << "\t- Started P25 Recorder Num [" << rec_num << "]\tTG: " << this->call->get_talkgroup_display() << "\tFreq: " << FormatFreq(chan_freq) << " \tTDMA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot();
+}
+
+char * p25conventional_recorder::get_filename() {
+  this->call->create_filename();
+  return this->call->get_filename();
+}

--- a/trunk-recorder/recorders/p25conventional_recorder.h
+++ b/trunk-recorder/recorders/p25conventional_recorder.h
@@ -2,29 +2,35 @@
 #define P25CONVENTIONAL_RECORDER_H
 
 #define _USE_MATH_DEFINES
+#include <boost/shared_ptr.hpp>
 
 class p25_recorder;
 class Source;
 class p25conventional_recorder;
+class nonstop_wavfile_delayopen_sink_impl;
 
 typedef boost::shared_ptr<p25conventional_recorder>p25conventional_recorder_sptr;
-p25conventional_recorder_sptr make_p25conventional_recorder(Source *src);
+p25conventional_recorder_sptr make_p25conventional_recorder(Source * src, bool delayopen);
 
 #include "p25_recorder.h"
 
 class p25conventional_recorder : public p25_recorder {
-  friend p25conventional_recorder_sptr make_p25conventional_recorder(Source *src);
+  friend p25conventional_recorder_sptr make_p25conventional_recorder(Source * src, bool delayopen);
 
 protected:
 
-  p25conventional_recorder(Source *src);
+  p25conventional_recorder(bool delayopen);
 
 public:
 
   ~p25conventional_recorder();
 
-private:
+  void start(Call *call);
+  void recording_started();
+  char * get_filename();
 
+private:
+  bool d_delayopen;
 };
 
 

--- a/trunk-recorder/recorders/recorder.cc
+++ b/trunk-recorder/recorders/recorder.cc
@@ -1,0 +1,28 @@
+#include "recorder.h"
+#include "../source.h"
+#include <boost/algorithm/string.hpp>
+
+
+Recorder::Recorder(std::string type)
+{
+	this->type = type;
+}
+
+boost::property_tree::ptree Recorder::get_stats()
+{
+  	boost::property_tree::ptree node;
+  	node.put("id",           	boost::lexical_cast<std::string>(get_source()->get_num()) + "_" + boost::lexical_cast<std::string>(get_num()));
+	node.put("type",       		type);
+  	node.put("srcNum",       	get_source()->get_num());
+  	node.put("recNum",			get_num());
+  	node.put("count", 	   		recording_count);
+  	node.put("duration",    	recording_duration);
+  	node.put("state",    		get_state());
+
+	Rx_Status status = get_rx_status();
+  	node.put("status_len",    	status.total_len);
+	node.put("status_error", 	status.error_count);
+	node.put("status_spike", 	status.spike_count);
+
+  	return node;
+}

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -54,12 +54,13 @@ class Recorder
 {
 
 public:
+	Recorder(std::string type);
 	virtual void tune_offset(double f) {};
 	virtual void start( Call *call) {};
 	virtual void stop() {};
-  virtual void set_tdma_slot(int slot) {};
+  	virtual void set_tdma_slot(int slot) {};
 	virtual double get_freq() {return 0;};
-  virtual Source *get_source() {return NULL;};
+  	virtual Source *get_source() {return NULL;};
 	virtual Call_Source *get_source_list() {return NULL;};
 	virtual int get_num() {return -1;};
 	virtual long get_source_count() {return 0;};
@@ -73,7 +74,12 @@ public:
 	virtual void clear(){};
 	int rec_num;
 	static int rec_counter;
+	virtual boost::property_tree::ptree get_stats();
 
+protected:
+	int 	recording_count;
+	double	recording_duration;
+	std::string type;
 };
 
 

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -280,7 +280,7 @@ void Source::print_recorders() {
        it != digital_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "[ " << rx->get_num() << " ] State: " << rx->get_state();
+    BOOST_LOG_TRIVIAL(info) << "[ " << rx->get_num() << " ] State: " << FormatState(rx->get_state());
   }
 }
 
@@ -355,7 +355,7 @@ Recorder * Source::get_digital_recorder(int priority)
   for (std::vector<p25_recorder_sptr>::iterator it = digital_recorders.begin();
        it != digital_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
-    BOOST_LOG_TRIVIAL(info) << "[ " << rx->get_num() << " ] State: " << rx->get_state() << " Freq: " << rx->get_freq();
+    BOOST_LOG_TRIVIAL(info) << "[ " << rx->get_num() << " ] State: " << FormatState(rx->get_state()) << " Freq: " << rx->get_freq();
   }
   return NULL;
 }

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -453,3 +453,25 @@ Source::Source(double c, double r, double e, std::string drv, std::string dev, C
     source_block = usrp_src;
   }
 }
+
+std::vector<Recorder *> Source::get_recorders()
+{
+
+  std::vector<Recorder *> recorders;
+
+   for (std::vector<p25_recorder_sptr>::iterator it = digital_recorders.begin(); it != digital_recorders.end(); it++) {
+      p25_recorder_sptr rx = *it;
+      recorders.push_back((Recorder *)rx.get());
+    }
+
+    for (std::vector<analog_recorder_sptr>::iterator it = analog_recorders.begin(); it != analog_recorders.end(); it++) {
+      analog_recorder_sptr rx = *it;
+      recorders.push_back((Recorder *)rx.get());
+    }
+
+    for (std::vector<debug_recorder_sptr>::iterator it = debug_recorders.begin(); it != debug_recorders.end(); it++) {
+      debug_recorder_sptr rx = *it;
+      recorders.push_back((Recorder *)rx.get());
+    }
+  return recorders;
+}

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -195,9 +195,9 @@ analog_recorder_sptr Source::create_conventional_recorder(gr::top_block_sptr tb)
     return log;
 }
 
-p25conventional_recorder_sptr Source::create_conventionalP25_recorder(gr::top_block_sptr tb) {
+p25conventional_recorder_sptr Source::create_conventionalP25_recorder(gr::top_block_sptr tb, bool delayopen) {
 
-    p25conventional_recorder_sptr log = make_p25conventional_recorder(this);
+    p25conventional_recorder_sptr log = make_p25conventional_recorder(this, delayopen);
 
     digital_recorders.push_back(log);
     tb->connect(source_block, 0, log, 0);

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -107,5 +107,7 @@ public:
 								{
 																return boost::dynamic_pointer_cast<gr::uhd::usrp_source, gr::basic_block>(p);
 								}
+
+								std::vector<Recorder *> get_recorders();
 };
 #endif

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -91,7 +91,7 @@ public:
 								int analog_recorder_count();
 								Config * get_config();
 								analog_recorder_sptr create_conventional_recorder(gr::top_block_sptr tb);
-								p25conventional_recorder_sptr create_conventionalP25_recorder(gr::top_block_sptr tb);
+								p25conventional_recorder_sptr create_conventionalP25_recorder(gr::top_block_sptr tb, bool delayopen);
 								void create_analog_recorders(gr::top_block_sptr tb, int r);
 								Recorder * get_analog_recorder(int priority);
 								void create_digital_recorders(gr::top_block_sptr tb, int r);

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -37,6 +37,7 @@ System::System(int sys_num) {
   xor_mask = NULL;
   // Setup the talkgroups from the CSV file
   talkgroups = new Talkgroups();
+  d_delaycreateoutput = false;
 }
 
 void System::set_xor_mask(unsigned long sys_id,  unsigned long wacn,  unsigned long nac){
@@ -273,4 +274,12 @@ void System::set_talkgroup_display_format(TalkgroupDisplayFormat format){
 
 System::TalkgroupDisplayFormat System::get_talkgroup_display_format(){
   return talkgroup_display_format;
+}
+
+bool System::get_delaycreateoutput(){
+  return d_delaycreateoutput;
+}
+
+void System::set_delaycreateoutput(bool delaycreateoutput){
+  d_delaycreateoutput = delaycreateoutput;
 }

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -40,6 +40,8 @@ System::System(int sys_num) {
   d_delaycreateoutput = false;
   d_hideEncrypted = false;
   d_hideUnknown = false;
+
+  message_count = 0;
 }
 
 void System::set_xor_mask(unsigned long sys_id,  unsigned long wacn,  unsigned long nac){
@@ -60,7 +62,7 @@ void System::set_xor_mask(unsigned long sys_id,  unsigned long wacn,  unsigned l
   }
 
 }
-void System::update_status(TrunkMessage message) {
+bool System::update_status(TrunkMessage message) {
  if(!sys_id || !wacn || !nac) {
    sys_id = message.sys_id;
    wacn = message.wacn;
@@ -77,7 +79,9 @@ void System::update_status(TrunkMessage message) {
        std::cout << (short)xor_mask[i] << ", ";
      }*/
    }
+  return true;
  }
+ return false;
 }
 
 const char * System::get_xor_mask(){
@@ -299,4 +303,26 @@ bool System::get_hideUnknown(){
 
 void System::set_hideUnknown(bool hideUnknown){
   d_hideUnknown = hideUnknown;
+}
+
+boost::property_tree::ptree System::get_stats()
+{
+  boost::property_tree::ptree system_node;
+  system_node.put("id",           this->get_sys_num());
+  system_node.put("name",         this->get_short_name());
+  system_node.put("type",         this->get_system_type());
+  system_node.put("sysid",        this->get_sys_id());
+  system_node.put("wacn",         this->get_wacn());
+  system_node.put("nac",          this->get_nac());
+
+  return system_node;
+}
+
+boost::property_tree::ptree System::get_stats_current(float timeDiff)
+{
+  boost::property_tree::ptree system_node;
+  system_node.put("id",           this->get_sys_num());
+  system_node.put("decoderate",   this->message_count / timeDiff);
+
+  return system_node;
 }

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -38,6 +38,8 @@ System::System(int sys_num) {
   // Setup the talkgroups from the CSV file
   talkgroups = new Talkgroups();
   d_delaycreateoutput = false;
+  d_hideEncrypted = false;
+  d_hideUnknown = false;
 }
 
 void System::set_xor_mask(unsigned long sys_id,  unsigned long wacn,  unsigned long nac){
@@ -282,4 +284,19 @@ bool System::get_delaycreateoutput(){
 
 void System::set_delaycreateoutput(bool delaycreateoutput){
   d_delaycreateoutput = delaycreateoutput;
+}
+
+bool System::get_hideEncrypted(){
+  return d_hideEncrypted;
+}
+void System::set_hideEncrypted(bool hideEncrypted){
+  d_hideEncrypted = hideEncrypted;
+}
+
+bool System::get_hideUnknown(){
+  return d_hideUnknown;
+}
+
+void System::set_hideUnknown(bool hideUnknown){
+  d_hideUnknown = hideUnknown;
 }

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -129,8 +129,16 @@ public:
         bool get_delaycreateoutput();
         void set_delaycreateoutput(bool delaycreateoutput);
 
+        bool get_hideEncrypted();
+        void set_hideEncrypted(bool hideEncrypted);
+
+        bool get_hideUnknown();
+        void set_hideUnknown(bool hideUnknown);
+
 private:
         TalkgroupDisplayFormat talkgroup_display_format;
         bool d_delaycreateoutput;
+        bool d_hideEncrypted;
+        bool d_hideUnknown;
 };
 #endif

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -8,10 +8,16 @@
 #include "p25_trunking.h"
 #include "parser.h"
 
-//#pragma GCC diagnostic push
-//#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#endif
+
 #include <lfsr/lfsr.h>
-//#pragma GCC diagnostic pop
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 class Source;
 class analog_recorder;
@@ -119,7 +125,12 @@ public:
         int get_bandplan_offset();
         void set_talkgroup_display_format(TalkgroupDisplayFormat format);
         TalkgroupDisplayFormat get_talkgroup_display_format();
+
+        bool get_delaycreateoutput();
+        void set_delaycreateoutput(bool delaycreateoutput);
+
 private:
         TalkgroupDisplayFormat talkgroup_display_format;
+        bool d_delaycreateoutput;
 };
 #endif

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -19,6 +19,8 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include <boost/property_tree/ptree.hpp>
+
 class Source;
 class analog_recorder;
 typedef boost::shared_ptr<analog_recorder> analog_recorder_sptr;
@@ -90,7 +92,7 @@ public:
         unsigned long get_nac();
         void set_xor_mask(unsigned long sys_id,  unsigned long wacn,  unsigned long nac);
         const char * get_xor_mask();
-        void update_status(TrunkMessage message);
+        bool update_status(TrunkMessage message);
         int get_sys_num();
         void set_system_type(std::string);
         std::string get_talkgroups_file();
@@ -134,6 +136,9 @@ public:
 
         bool get_hideUnknown();
         void set_hideUnknown(bool hideUnknown);
+
+        boost::property_tree::ptree get_stats();
+        boost::property_tree::ptree get_stats_current(float timeDiff);
 
 private:
         TalkgroupDisplayFormat talkgroup_display_format;

--- a/trunk-recorder/talkgroups.cc
+++ b/trunk-recorder/talkgroups.cc
@@ -141,3 +141,9 @@ Talkgroup *Talkgroups::find_talkgroup(long tg_number) {
   }
   return tg_match;
 }
+
+void Talkgroups::add(long num, std::string alphaTag)
+{
+    Talkgroup *tg = new Talkgroup(num, 'X', alphaTag, "", "", "", 0);
+    talkgroups.push_back(tg);
+}

--- a/trunk-recorder/talkgroups.h
+++ b/trunk-recorder/talkgroups.h
@@ -13,5 +13,6 @@ public:
   Talkgroups();
   void load_talkgroups(std::string filename);
   Talkgroup *find_talkgroup(long tg);
+  void add(long num, std::string alphaTag);
 };
 #endif // TALKGROUPS_H

--- a/trunk-recorder/uploaders/stat_socket.h
+++ b/trunk-recorder/uploaders/stat_socket.h
@@ -29,25 +29,34 @@ class stat_socket {
   void on_fail(websocketpp::connection_hdl);
   void on_close(websocketpp::connection_hdl);
   void on_open(websocketpp::connection_hdl);
-  void open_stat(const std::string & uri);
+  void open_stat();
   bool is_open();
   bool config_sent();
-  void send_status(std::vector<Call *>calls, Config config);
-  void send_config(std::vector<Source *> sources, std::vector<System *> systems, Config config);
-  void send_sys_rates(std::vector<System *>systems, float timeDiff, Config config) ;
+  void send_calls_active(std::vector<Call *>calls);
+  void send_config(std::vector<Source *> sources, std::vector<System *> systems);
+  void send_sys_rates(std::vector<System *>systems, float timeDiff);
+  void send_call_start(Call * call);
+  void send_call_end(Call * call);
+  void send_recorder(Recorder * recorder);
+  void initialize(Config * config, void (*callback)(void));
+  void send_recorders(std::vector<Recorder *>recorders);
+  void send_systems(std::vector<System *> systems);
+  void send_system(System * systems);
 
 private:
     void reopen_stat();
     client m_client;
     websocketpp::connection_hdl m_hdl;
     websocketpp::lib::mutex m_lock;
-    std::string remote_uri;
     int retry_attempt;
     time_t reconnect_time;
     bool m_reconnect;
     bool m_open;
     bool m_done;
     bool m_config_sent;
+    Config * m_config;
+    void (*m_callback)(void);
+    void send_object(boost::property_tree::ptree data, std::string name, std::string type);
 };
 
 #endif


### PR DESCRIPTION
You can see all the changes in the individual commits, but the highlevel changes are

- Separated P25 and P25 Conventional call and recorders and 
- optionally hide unknown talkgroups from logs
- optionally hide encrypted talkgroups from logs
- optionally output status as text
- fixed issue with conventional recordings < 1 sec in length form completing
- added talkgroup tags to conventional channels
- udpated the status socket, and documented the new json
