### PR TITLE
Adds try/catch around get_mix_gain and get_lna_gain omsosdr calls

### DIFF
--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -103,7 +103,11 @@ void Source::set_mix_gain(int b)
 
 int Source::get_mix_gain() {
   if (driver == "osmosdr") {
-    mix_gain = cast_to_osmo_sptr(source_block)->get_gain("MIX", 0);
+    try {
+      mix_gain = cast_to_osmo_sptr(source_block)->get_gain("MIX", 0);
+    } catch(std::exception& e) {
+      BOOST_LOG_TRIVIAL(error) << "MIX Gain unsupported or other error: " << e.what();
+    }
   }
   return mix_gain;
 }
@@ -119,7 +123,11 @@ void Source::set_lna_gain(int b)
 
 int Source::get_lna_gain() {
   if (driver == "osmosdr") {
-    lna_gain = cast_to_osmo_sptr(source_block)->get_gain("LNA", 0);
+    try {
+      lna_gain = cast_to_osmo_sptr(source_block)->get_gain("LNA", 0);
+    } catch(std::exception& e) {
+      BOOST_LOG_TRIVIAL(error) << "LNA Gain unsupported or other error: " << e.what();
+    }
   }
   return lna_gain;
 }


### PR DESCRIPTION
Some drivers, such as the lime, may not support all gains and throw
errors when called. As of now only the stat_socket uploader calls
these functions.