### PR TITLE
get_wacn() and get_nac() fix

### DIFF
--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -98,11 +98,11 @@ unsigned long System::get_sys_id() {
 }
 
 unsigned long System::get_nac() {
-  return this->wacn;
+  return this->nac;
 }
 
 unsigned long System::get_wacn() {
-  return this->nac;
+  return this->wacn;
 }
 
 bool System::get_call_log() {


### PR DESCRIPTION
For some reason the implementation of `get_wacn()` and `get_nac()` was flipped.