### PR TITLE
add limesdr-specific gain options

### DIFF
--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -138,6 +138,8 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       int    bb_gain        = node.second.get<double>("bbGain", 0);
       int    mix_gain       = node.second.get<double>("mixGain", 0);
       int    lna_gain       = node.second.get<double>("lnaGain", 0);
+      int    pga_gain       = node.second.get<double>("pgaGain", 0);
+      int    tia_gain       = node.second.get<double>("tiaGain", 0);
       int    vga1_gain      = node.second.get<double>("vga1Gain", 0);
       int    vga2_gain      = node.second.get<double>("vga2Gain", 0);
       double fsk_gain       = node.second.get<double>("fskGain", 1.0);
@@ -165,6 +167,8 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       BOOST_LOG_TRIVIAL(info) << "IF Gain: " << node.second.get<double>("ifGain", 0);
       BOOST_LOG_TRIVIAL(info) << "BB Gain: " << node.second.get<double>("bbGain", 0);
       BOOST_LOG_TRIVIAL(info) << "LNA Gain: " << node.second.get<double>("lnaGain", 0);
+      BOOST_LOG_TRIVIAL(info) << "PGA Gain: " << node.second.get<double>("pgaGain", 0);
+      BOOST_LOG_TRIVIAL(info) << "TIA Gain: " << node.second.get<double>("tiaGain", 0);
       BOOST_LOG_TRIVIAL(info) << "MIX Gain: " << node.second.get<double>("mixGain", 0);
       BOOST_LOG_TRIVIAL(info) << "VGA1 Gain: " << node.second.get<double>("vga1Gain", 0);
       BOOST_LOG_TRIVIAL(info) << "VGA2 Gain: " << node.second.get<double>("vga2Gain", 0);
@@ -215,10 +219,12 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       if (mix_gain != 0) {
         source->set_mix_gain(mix_gain);
       }
+      
+      source->set_lna_gain(lna_gain);
 
-      if (lna_gain != 0) {
-        source->set_lna_gain(lna_gain);
-      }
+      source->set_tia_gain(tia_gain);
+
+      source->set_pga_gain(pga_gain);
 
       if (vga1_gain != 0) {
         source->set_vga1_gain(vga1_gain);

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -302,6 +302,8 @@ void load_config(string config_file)
       int    bb_gain        = node.second.get<double>("bbGain", 0);
       int    mix_gain       = node.second.get<double>("mixGain", 0);
       int    lna_gain       = node.second.get<double>("lnaGain", 0);
+      int    pga_gain       = node.second.get<double>("pgaGain", 0);
+      int    tia_gain       = node.second.get<double>("tiaGain", 0);
       int    vga1_gain      = node.second.get<double>("vga1Gain", 0);
       int    vga2_gain      = node.second.get<double>("vga2Gain", 0);
       double fsk_gain       = node.second.get<double>("fskGain", 1.0);
@@ -330,6 +332,8 @@ void load_config(string config_file)
       BOOST_LOG_TRIVIAL(info) << "IF Gain: " << node.second.get<double>("ifGain", 0);
       BOOST_LOG_TRIVIAL(info) << "BB Gain: " << node.second.get<double>("bbGain", 0);
       BOOST_LOG_TRIVIAL(info) << "LNA Gain: " << node.second.get<double>("lnaGain", 0);
+      BOOST_LOG_TRIVIAL(info) << "PGA Gain: " << node.second.get<double>("pgaGain", 0);
+      BOOST_LOG_TRIVIAL(info) << "TIA Gain: " << node.second.get<double>("tiaGain", 0);
       BOOST_LOG_TRIVIAL(info) << "MIX Gain: " << node.second.get<double>("mixGain", 0);
       BOOST_LOG_TRIVIAL(info) << "VGA1 Gain: " << node.second.get<double>("vga1Gain", 0);
       BOOST_LOG_TRIVIAL(info) << "VGA2 Gain: " << node.second.get<double>("vga2Gain", 0);
@@ -381,9 +385,12 @@ void load_config(string config_file)
         source->set_mix_gain(mix_gain);
       }
 
-      if (lna_gain != 0) {
-        source->set_lna_gain(lna_gain);
-      }
+      source->set_lna_gain(lna_gain);
+    
+      source->set_tia_gain(tia_gain);
+    
+      source->set_pga_gain(pga_gain);
+      
 
       if (vga1_gain != 0) {
         source->set_vga1_gain(vga1_gain);

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -137,6 +137,46 @@ int Source::get_lna_gain() {
   return lna_gain;
 }
 
+void Source::set_tia_gain(int b)
+{
+  if (driver == "osmosdr") {
+    tia_gain = b;
+    cast_to_osmo_sptr(source_block)->set_gain(tia_gain, "TIA", 0);
+    BOOST_LOG_TRIVIAL(info) << "TIA Gain set to: " << cast_to_osmo_sptr(source_block)->get_gain("TIA");
+  }
+}
+
+int Source::get_tia_gain() {
+  if (driver == "osmosdr") {
+    try {
+      tia_gain = cast_to_osmo_sptr(source_block)->get_gain("TIA", 0);
+    } catch(std::exception& e) {
+      BOOST_LOG_TRIVIAL(error) << "TIA Gain unsupported or other error: " << e.what();
+    }
+  }
+  return tia_gain;
+}
+
+void Source::set_pga_gain(int b)
+{
+  if (driver == "osmosdr") {
+    pga_gain = b;
+    cast_to_osmo_sptr(source_block)->set_gain(pga_gain, "PGA", 0);
+    BOOST_LOG_TRIVIAL(info) << "PGA Gain set to: " << cast_to_osmo_sptr(source_block)->get_gain("PGA");
+  }
+}
+
+int Source::get_pga_gain() {
+  if (driver == "osmosdr") {
+    try {
+      pga_gain = cast_to_osmo_sptr(source_block)->get_gain("PGA", 0);
+    } catch(std::exception& e) {
+      BOOST_LOG_TRIVIAL(error) << "PGA Gain unsupported or other error: " << e.what();
+    }
+  }
+  return pga_gain;
+}
+
 void Source::set_vga1_gain(int b)
 {
   if (driver == "osmosdr") {
@@ -433,6 +473,8 @@ Source::Source(double c, double r, double e, std::string drv, std::string dev, C
   config = cfg;
   gain = 0;
   lna_gain = 0;
+  tia_gain = 0;
+  pga_gain = 0;
   mix_gain = 0;
   if_gain = 0;
   src_num = src_counter++;

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -30,6 +30,8 @@ class Source
 								int bb_gain;
 								int if_gain;
 								int lna_gain;
+								int tia_gain;
+								int pga_gain;
 								int mix_gain;
 								int vga1_gain;
 								int vga2_gain;
@@ -85,6 +87,10 @@ public:
 								int get_mix_gain();
 								void set_lna_gain(int b);
 								int get_lna_gain();
+								void set_tia_gain(int b);
+								int get_tia_gain();
+								void set_pga_gain(int b);
+								int get_pga_gain();
 								void set_vga1_gain(int b);
 								int get_vga1_gain();
 								void set_vga2_gain(int b);


### PR DESCRIPTION
Using a LimeSDR and SoapySDRServer, it is possible to use the Lime as a source for Trunk Recorder. The config.json file should look like:
```
"tiaGain": 3,
"pgaGain": -3,
"lnaGain": 12,
"driver": "osmosdr",
"device": "soapy=0,driver=remote,remote=localhost",
"antenna": "LNAW"
```
After trying to set the gain values unsuccessfully using the device string, I added two LimeSDR-specific Gain settings ( TIA and PGA ) directly into the code, complimenting the existing LNA gain setting.