### PR TITLE
Adding the ability to set a minimum call duration, so very short calls are deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Here are the different arguments:
    - **uploadScript** - this script is called after each recording has finished. Checkout *encode-upload.sh.sample* as an example. The script should be located in the same directory as the trunk-recorder executable.
    - **audioArchive** - should the recorded audio files be kept after successfully uploading them. The options are *true* and *false* (without quotes). The default is *true*.
    - **callLog** - should a json file with the call details be generated. The options are *true* and *false* (without quotes). The default is *true*.
+   - **minDuration** - the minimum call (transmission) duration in seconds (decimals allowed), calls below this number will have recordings deleted and will not be uploaded. The default is *0* (no minimum duration).
    - **bandplan** - [SmartNet only] this is the SmartNet bandplan that will be used. The options are *800_standard*, *800_reband*, *800_splinter*, and *400_custom*. *800_standard* is the default.
    - **bandplanBase** - [SmartNet, 400_custom only] this is for the *400_custom* bandplan only. This is the base frequency, specified in Hz.
    - **bandplanHigh** - [SmartNet, 400_custom only] this is the highest channel in the system, specified in Hz.

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -75,8 +75,10 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       BOOST_LOG_TRIVIAL(info) << "Audio Archive: " << system->get_audio_archive();
       system->set_talkgroups_file(node.second.get<std::string>("talkgroupsFile", ""));
       BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << system->get_talkgroups_file();
-      system->set_record_unknown(node.second.get<bool>("recordUnknown",true));
-      BOOST_LOG_TRIVIAL(info) << "Record Unkown Talkgroups: " << system->get_record_unknown();
+      system->set_record_unknown(node.second.get<bool>("recordUnknown", true));
+      BOOST_LOG_TRIVIAL(info) << "Record Unknown Talkgroups: " << system->get_record_unknown();
+      system->set_min_duration(node.second.get<double>("minDuration", 0));
+      BOOST_LOG_TRIVIAL(info) << "Minimum Call Duration (in seconds): " << system->get_min_duration();
       systems.push_back(system);
 
       system->set_bandplan(node.second.get<std::string>("bandplan", "800_standard"));
@@ -219,7 +221,7 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       if (mix_gain != 0) {
         source->set_mix_gain(mix_gain);
       }
-      
+
       source->set_lna_gain(lna_gain);
 
       source->set_tia_gain(tia_gain);

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -240,7 +240,7 @@ void load_config(string config_file)
       system->set_talkgroups_file(node.second.get<std::string>("talkgroupsFile", ""));
       BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << system->get_talkgroups_file();
       system->set_record_unknown(node.second.get<bool>("recordUnknown", true));
-      BOOST_LOG_TRIVIAL(info) << "Record Unkown Talkgroups: " << system->get_record_unknown();
+      BOOST_LOG_TRIVIAL(info) << "Record Unknown Talkgroups: " << system->get_record_unknown();
       std::string talkgroup_display_format_string = node.second.get<std::string>("talkgroupDisplayFormat", "Id");
       if (boost::iequals(talkgroup_display_format_string, "id_tag")){
         system->set_talkgroup_display_format(System::talkGroupDisplayFormat_id_tag);
@@ -281,7 +281,9 @@ void load_config(string config_file)
       system->set_hideEncrypted(node.second.get<bool>("hideEncrypted", system->get_hideEncrypted()));
       BOOST_LOG_TRIVIAL(info) << "Hide Encrypted Talkgroups: " << system->get_hideEncrypted();
       system->set_hideUnknown(node.second.get<bool>("hideUnknownTalkgroups", system->get_hideUnknown()));
-      BOOST_LOG_TRIVIAL(info) << "Hide Unkown Talkgroups: " << system->get_hideUnknown();
+      BOOST_LOG_TRIVIAL(info) << "Hide Unknown Talkgroups: " << system->get_hideUnknown();
+      system->set_min_duration(node.second.get<double>("minDuration", 0));
+      BOOST_LOG_TRIVIAL(info) << "Minimum Call Duration (in seconds): " << system->get_min_duration();
 
       systems.push_back(system);
       BOOST_LOG_TRIVIAL(info);
@@ -386,11 +388,11 @@ void load_config(string config_file)
       }
 
       source->set_lna_gain(lna_gain);
-    
+
       source->set_tia_gain(tia_gain);
-    
+
       source->set_pga_gain(pga_gain);
-      
+
 
       if (vga1_gain != 0) {
         source->set_vga1_gain(vga1_gain);
@@ -948,7 +950,6 @@ void check_message_count(float timeDiff) {
 
     if ((sys->system_type != "conventional") && (sys->system_type != "conventionalP25")) {
       float msgs_decoded_per_second = sys->message_count / timeDiff;
-
 
       if (msgs_decoded_per_second < 2) {
         if (sys->system_type == "smartnet") {

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -25,6 +25,13 @@ void System::set_upload_script(std::string script) {
   this->upload_script = script;
 }
 
+double System::get_min_duration() {
+  return this->min_call_duration;
+}
+
+void System::set_min_duration(double duration) {
+  this->min_call_duration = duration;
+}
 
 
 System::System(int sys_num) {

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -59,6 +59,7 @@ public:
         double bandplan_high;
         double bandplan_spacing;
         int bandplan_offset;
+        double min_call_duration;
 
         unsigned xor_mask_len;
         const char *xor_mask;
@@ -81,6 +82,8 @@ public:
         void set_upload_script(std::string script);
         std::string get_api_key();
         void set_api_key(std::string api_key);
+        double get_min_duration();
+        void set_min_duration(double duration);
         bool get_audio_archive();
         void set_audio_archive(bool);
         bool get_record_unknown();


### PR DESCRIPTION
As brought up by issue #209, there are some cases where it is useful to delete/not upload calls shorter than some duration. I've experienced this myself on an analog system where there's a lot of half-second pops that get recorded.

To address this so only real calls can be uploaded to something like OpenMHz, I have added a new config param that is set per-system, `minDuration` - this means that calls need to be this duration (in seconds) or higher to be uploaded. Below it, both the recording file and the associated call metadata JSON will be deleted.

It uses the GNURadio wav sink to get the duration of the audio file, via the recorder's `get_current_length()` method.

Also, besides implementing this new feature, I fixed a couple typos.