### PR TITLE
Only set tia, lna and ppa gains if defined in config

### DIFF
--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -224,11 +224,17 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
         source->set_mix_gain(mix_gain);
       }
 
-      source->set_lna_gain(lna_gain);
+      if (lna_gain != 0) {
+        source->set_lna_gain(lna_gain);
+      }
 
-      source->set_tia_gain(tia_gain);
+      if (tia_gain != 0) {
+        source->set_tia_gain(tia_gain);
+      }
 
-      source->set_pga_gain(pga_gain);
+      if (ppa_gain != 0) {
+        source->set_pga_gain(pga_gain);
+      }
 
       if (vga1_gain != 0) {
         source->set_vga1_gain(vga1_gain);


### PR DESCRIPTION
219779f9c24ce3e585df8173f6c921ad60a4308e breaks support for devices without the new gain settings.

cc: @jareklupinski 