### PR TITLE
Fix p25 parsing when parsing more than one p25 system with different bandplan

### DIFF
--- a/trunk-recorder/systems/p25_parser.h
+++ b/trunk-recorder/systems/p25_parser.h
@@ -22,19 +22,19 @@ struct Channel {
 
 class P25Parser : public TrunkParser
 {
-								std::map<int,Channel> channels;
+								std::map<int, std::map<int, Channel>> channels;
 								std::map<int,Channel>::iterator it;
 public:
 								P25Parser();
-								long get_tdma_slot(int chan_id);
-								double get_bandwidth(int chan_id);
+								long get_tdma_slot(int chan_id, int sys_num);
+								double get_bandwidth(int chan_id, int sys_num);
 								std::vector<TrunkMessage> decode_mbt_data(unsigned long opcode, boost::dynamic_bitset<>& header, boost::dynamic_bitset<>& mbt_data,  unsigned long link_id,  unsigned long nac, int sys_num); 
 								std::vector<TrunkMessage> decode_tsbk(boost::dynamic_bitset<> &tsbk, unsigned long nac, int sys_num);
 								unsigned long bitset_shift_mask(boost::dynamic_bitset<> &tsbk, int shift, unsigned long long mask);
-								std::string  channel_id_to_string(int chan_id);
+								std::string  channel_id_to_string(int chan_id, int sys_num);
 								void print_bitset(boost::dynamic_bitset<> &tsbk);
-								void add_channel(int chan_id, Channel chan);
-								double channel_id_to_frequency(int chan_id);
+								void add_channel(int chan_id, Channel chan, int sys_num);
+								double channel_id_to_frequency(int chan_id, int sys_num);
 								std::vector<TrunkMessage> parse_message(gr::message::sptr msg);
 };
 


### PR DESCRIPTION
Working condition: trunk recording one P25 site.

Not working condition: trunk recording more than one P25 site.

Observation while non working condition: incorrect trunk frequencies and ultimately getting "Call: more than 50 Freq." error message.

Cause: p25_parser is used as a singleton within main.cc so p25_parser::channels is getting mixed up with different bandplan frequencies from different P25 sites.

Solution: make p25_parser::channels a two dimensional array [sys_num][chan_id] then change some p25_parser methods to pass sys_num along.