### PR TITLE
Logging Fixes

### DIFF
--- a/trunk-recorder/call.cc
+++ b/trunk-recorder/call.cc
@@ -310,14 +310,14 @@ long Call::get_freq_count() {
 }
 
 Call_Source * Call::get_source_list() {
-  if (!recorder) {
+  if ((state == recording) && !recorder) {
     BOOST_LOG_TRIVIAL(error) << "Call::get_source_list State is recording, but no recorder assigned!";
   }
   return src_list;
 }
 
 long Call::get_source_count() {
-  if (!recorder) {
+  if ((state == recording) && !recorder) {
     BOOST_LOG_TRIVIAL(error) << "Call::get_source_count State is recording, but no recorder assigned!";
   }
   return src_count;

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -109,7 +109,7 @@ analog_recorder::analog_recorder(Source *src)
     arb_taps = gr::filter::firdes::low_pass_2(arb_size, arb_size, bw, tb, arb_atten,
                                               gr::filter::firdes::WIN_BLACKMAN_HARRIS);
     double tap_total = inital_lpf_taps.size() + channel_lpf_taps.size() + arb_taps.size();
-    BOOST_LOG_TRIVIAL(info) << "P25 Recorder Taps - initial: " << inital_lpf_taps.size() << " channel: " << channel_lpf_taps.size() << " ARB: " << arb_taps.size() << " Total: " << tap_total;
+    BOOST_LOG_TRIVIAL(info) << "Analog Recorder Taps - initial: " << inital_lpf_taps.size() << " channel: " << channel_lpf_taps.size() << " ARB: " << arb_taps.size() << " Total: " << tap_total;
   } else {
     BOOST_LOG_TRIVIAL(error) << "Something is probably wrong! Resampling rate too low";
     exit(0);

--- a/trunk-recorder/recorders/debug_recorder.cc
+++ b/trunk-recorder/recorders/debug_recorder.cc
@@ -129,7 +129,7 @@ debug_recorder::debug_recorder(Source *src)
   //tm *ltm = localtime(&starttime);
 
 
-  int nchars = snprintf(filename, 160, "%s/%ld-%ld_%g.raw",talkgroup,starttime,freq);
+  int nchars = snprintf(filename, 160, "%ld-%ld_%g.raw", talkgroup, starttime, freq);
 
   if (nchars >= 160) {
     BOOST_LOG_TRIVIAL(error) << "Analog Recorder: Path longer than 160 charecters";

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -325,7 +325,7 @@ Recorder * Source::get_analog_recorder(int priority)
       break;
     }
   }
-  BOOST_LOG_TRIVIAL(info) << "[ " << driver << " ] No Analog Recorders Available";
+  BOOST_LOG_TRIVIAL(info) << "[ " << device << " ] No Analog Recorders Available";
   return NULL;
 }
 
@@ -467,7 +467,7 @@ Recorder * Source::get_digital_recorder(int priority)
   if (priority > 99) { // num_available_recorders) { // a low priority is bad.
                        // You need atleast the number of availalbe recorders to
                        // your priority
-    // BOOST_LOG_TRIVIAL(info) << "Not recording because of priority";
+    BOOST_LOG_TRIVIAL(info) << "Not recording because of priority";
     return NULL;
   }
 

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -401,7 +401,14 @@ void Source::print_recorders() {
        it != digital_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "[ " << rx->get_num() << " ] State: " << FormatState(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "[ D" << rx->get_num() << " ] State: " << FormatState(rx->get_state());
+  }
+
+  for (std::vector<analog_recorder_sptr>::iterator it = analog_recorders.begin();
+       it != analog_recorders.end(); it++) {
+    analog_recorder_sptr rx = *it;
+
+    BOOST_LOG_TRIVIAL(info) << "[ A" << rx->get_num() << " ] State: " << FormatState(rx->get_state());
   }
 }
 

--- a/trunk-recorder/systems/p25_trunking.cc
+++ b/trunk-recorder/systems/p25_trunking.cc
@@ -55,7 +55,7 @@ p25_trunking::p25_trunking(double f, double c, long s, gr::msg_queue::sptr queue
   double arb_size  = 32;
   double arb_atten = 100;
   BOOST_LOG_TRIVIAL(info) <<  "\t P25 Trunking - SysNum: " << sys_num;
-  BOOST_LOG_TRIVIAL(info) << "\t P25 Recorder Initial Rate: "<< initial_rate << " Resampled Rate: " << resampled_rate  << " Initial Decimation: " << initial_decim << " Decimation: " << decim << " System Rate: " << system_channel_rate << " ARB Rate: " << arb_rate;
+  BOOST_LOG_TRIVIAL(info) << "\t P25 Trunking Initial Rate: "<< initial_rate << " Resampled Rate: " << resampled_rate  << " Initial Decimation: " << initial_decim << " Decimation: " << decim << " System Rate: " << system_channel_rate << " ARB Rate: " << arb_rate;
 
   // Create a filter that covers the full bandwidth of the output signal
 
@@ -77,7 +77,7 @@ p25_trunking::p25_trunking(double f, double c, long s, gr::msg_queue::sptr queue
     arb_taps = gr::filter::firdes::low_pass_2(arb_size, arb_size, bw, tb, arb_atten,
                                               gr::filter::firdes::WIN_BLACKMAN_HARRIS);
     double tap_total = inital_lpf_taps.size() + channel_lpf_taps.size() + arb_taps.size();
-    BOOST_LOG_TRIVIAL(info) << "P25 Recorder Taps - initial: " << inital_lpf_taps.size() << " channel: " << channel_lpf_taps.size() << " ARB: " << arb_taps.size() << " Total: " << tap_total;
+    BOOST_LOG_TRIVIAL(info) << "P25 Trunking Taps - initial: " << inital_lpf_taps.size() << " channel: " << channel_lpf_taps.size() << " ARB: " << arb_taps.size() << " Total: " << tap_total;
   } else {
     BOOST_LOG_TRIVIAL(error) << "Something is probably wrong! Resampling rate too low";
     exit(0);

--- a/trunk-recorder/systems/smartnet_trunking.cc
+++ b/trunk-recorder/systems/smartnet_trunking.cc
@@ -82,7 +82,7 @@ smartnet_trunking::smartnet_trunking(float               f,
     arb_taps = gr::filter::firdes::low_pass_2(arb_size, arb_size, bw, tb, arb_atten,
                                               gr::filter::firdes::WIN_BLACKMAN_HARRIS);
     //double tap_total = inital_lpf_taps.size() + channel_lpf_taps.size() + arb_taps.size();
-    BOOST_LOG_TRIVIAL(info) << "\t P25 Recorder Initial Rate: "<< initial_rate << " Resampled Rate: " << resampled_rate  << " Initial Decimation: " << initial_decim << " Decimation: " << decim << " System Rate: " << system_channel_rate << " ARB Rate: " << arb_rate;
+    BOOST_LOG_TRIVIAL(info) << "\t SmartNet Recorder Initial Rate: "<< initial_rate << " Resampled Rate: " << resampled_rate  << " Initial Decimation: " << initial_decim << " Decimation: " << decim << " System Rate: " << system_channel_rate << " ARB Rate: " << arb_rate;
   } else {
     BOOST_LOG_TRIVIAL(error) << "Something is probably wrong! Resampling rate too low";
     exit(0);

--- a/trunk-recorder/systems/smartnet_trunking.cc
+++ b/trunk-recorder/systems/smartnet_trunking.cc
@@ -45,7 +45,7 @@ smartnet_trunking::smartnet_trunking(float               f,
   const double pi = boost::math::constants::pi<double>();
   BOOST_LOG_TRIVIAL(info) <<  "SmartNet Trunking - SysNum: " << sys_num;
 
-  BOOST_LOG_TRIVIAL(info) <<  "Control channel: " << chan_freq;
+  BOOST_LOG_TRIVIAL(info) <<  "Control channel: " << FormatFreq(chan_freq);
 
   inital_lpf_taps  = gr::filter::firdes::low_pass_2(1.0, samp_rate, 96000, 30000, 100, gr::filter::firdes::WIN_HANN);
   channel_lpf_taps = gr::filter::firdes::low_pass_2(1.0, initial_rate, 7250, 2000, 100, gr::filter::firdes::WIN_HANN);


### PR DESCRIPTION
A handful of logging fixes/improvements, almost entirely cosmetic, and largely bringing consistency between recorders/systems.

The biggest visual change is to also output the status of analog recorders along with digital, and prefix them in the list with "A" or "D" for analog or digital.