### PR TITLE
Fix for intermittent non-zero or NaN recording count or duration valu…

### DIFF
--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -5,7 +5,7 @@
 using namespace std;
 
 bool analog_recorder::logging = false;
-//static int rec_counter=0;
+//static int rec_counter = 0;
 
 analog_recorder_sptr make_analog_recorder(Source *src)
 {
@@ -51,7 +51,9 @@ analog_recorder::analog_recorder(Source *src)
   config      = source->get_config();
   samp_rate   = source->get_rate();
   talkgroup   = 0;
-
+  recording_count = 0;
+  recording_duration = 0;
+  
   rec_num = rec_counter++;
   state       = inactive;
 

--- a/trunk-recorder/recorders/debug_recorder.cc
+++ b/trunk-recorder/recorders/debug_recorder.cc
@@ -23,7 +23,8 @@ debug_recorder::debug_recorder(Source *src)
   silence_frames = source->get_silence_frames();
   talkgroup = 0;
   long capture_rate = samp_rate;
-
+  recording_count = 0;
+  recording_duration = 0;
 
   rec_num = rec_counter++;
 

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -70,6 +70,8 @@ void p25_recorder::initialize(Source *src, gr::blocks::nonstop_wavfile_sink::spt
   talkgroup      = 0;
   d_phase2_tdma = true;
   rec_num = rec_counter++;
+  recording_count = 0;
+  recording_duration = 0;
 
   state = inactive;
 

--- a/trunk-recorder/recorders/sigmf_recorder.cc
+++ b/trunk-recorder/recorders/sigmf_recorder.cc
@@ -21,7 +21,8 @@ sigmf_recorder::sigmf_recorder(Source *src)
   qpsk_mod  = source->get_qpsk_mod();
   silence_frames = source->get_silence_frames();
   talkgroup = 0;
-
+  recording_count = 0;
+  recording_duration = 0;
 
   rec_num = rec_counter++;
 


### PR DESCRIPTION
…es from JSON Status Socket upon initial launch of trunk-recorder.

Tested/verified with P25 recorder only.
This closes robotastic/trunk-recorder#252