### PR TITLE
Fix for potentially unsafe sys reference.

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1023,9 +1023,10 @@ void monitor_messages() {
     if (msg != 0) {
       sys_num = msg->arg1();
       sys     = find_system(sys_num);
-      sys->message_count++;
 
       if (sys) {
+        sys->message_count++;
+        
         if (sys->get_system_type() == "smartnet") {
           trunk_messages = smartnet_parser->parse_message(msg->to_string(), sys);
           handle_message(trunk_messages, sys);


### PR DESCRIPTION
Moved the sys->message_count++ inside the check to see if sys is valid. Potential access of uninitialized memory otherwise.