### PR TITLE
MDC, FleetSync & Star signal decoding, plus Unit ID tagging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ ChanList.csv
 cmake-build-debug/
 *.code-workspace
 /.vscode/
+/.vs/
+/out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,10 +224,17 @@ list(APPEND trunk_recorder_sources
   lib/gr_blocks/nonstop_wavfile_delayopen_sink_impl.cc
   trunk-recorder/recorders/p25conventional_recorder.cc
   trunk-recorder/recorders/p25_recorder.cc
+  trunk-recorder/csv_helper.cc
   trunk-recorder/talkgroup.cc
   trunk-recorder/talkgroups.cc
+  trunk-recorder/unit_tag.cc
+  trunk-recorder/unit_tags.cc
   lib/gr_blocks/freq_xlating_fft_filter.cc
   lib/lfsr/lfsr.cxx
+  lib/gr_blocks/fsync_decode.cc
+  lib/gr_blocks/mdc_decode.cc
+  lib/gr_blocks/star_decode.cc
+  lib/gr_blocks/signal_decoder_sink_impl.cc
   )
 
 if(WEBSOCKET_STATUS)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ This file is used to configure how Trunk Recorder is setup. It defines the SDRs 
     "systems": [{
         "control_channels": [855462500],
         "type": "p25",
-        "talkgroupsFile": "ChanList.csv"
+        "talkgroupsFile": "ChanList.csv",
+        "unitTagsFile": "UnitTags.csv"
     }]
 }
 ```
@@ -107,6 +108,7 @@ Here are the different arguments:
    - **alphatags** - *(Optional, For conventional systems)* an array of the alpha tags, these will be outputed to the logfiles *talkgroupDisplayFormat* is set to include tags. Alpha tags will be applied to the *channels* in the order the values appear in the array. 
    - **type** - the type of trunking system. The options are *smartnet*, *p25*,  *conventional* & *conventionalP25*.
    - **talkgroupsFile** - this is a CSV file that provides information about the talkgroups. It determines whether a talkgroup is analog or digital, and what priority it should have. This file should be located in the same directory as the trunk-recorder executable.
+   - **unitTagsFile** - this is a CSV files that provides information about the unit tags. It allows a Unit ID to be assigned a name. This file should be located in the same directory as the trunk-recorder executable. The format is 2 columns, the first being the decimal number of the Unit ID, the second is the Unit Name,
    - **recordUnknown** - record talkgroups if they are not listed in the Talkgroups File. The options are *true* and *false* (without quotes). The default is *true*.
    - **shortName** - this is a nickname for the system. It is used to help name and organize the recordings from this system. It should be 4-6 letters with no spaces.
    - **uploadScript** - this script is called after each recording has finished. Checkout *encode-upload.sh.sample* as an example. The script should be located in the same directory as the trunk-recorder executable.
@@ -122,6 +124,9 @@ Here are the different arguments:
    - **delayCreateOutput** - [conventionalP25 only] this will delay the creation of the output file until there is activity, The options are *true* or *false*, without quotes. The default is *false*. 
    - **hideEncrypted** - hide encrypted talkgroups log entries, The options are *true* or *false*, without quotes. The default is *false*. 
    - **hideUnknownTalkgroups** - hide unknown talkgroups from log, The options are *true* or *false*, without quotes. The default is *false*. 
+   - **decodeMDC** - *(Optional, For conventional systems)* enable the MDC-1200 signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
+   - **decodeFSync** - *(Optional, For conventional systems)* enable the Fleet Sync signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
+   - **decodeStar** - *(Optional, For conventional systems)* enable the Star signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
  - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile** the options are *digital* or *analog*.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
@@ -147,6 +152,7 @@ Here are the column headers and some sample data:
 |-----|-----|------|-----------|-------------|-----|-------|----------|
 |101	| 065	| D	| DCFD 01 Disp	| 01 Dispatch |	Fire Dispatch |	Fire | 1 |
 |2227 |	8b3	| D	| DC StcarYard	| Streetcar Yard |	Transportation |	Services | 3 |
+
 
 ### Multiple SDR
 Most trunk systems use a wide range of spectrum. Often a more powerful SDR is needed to have enough bandwidth to capture all of the potential channels that a system may broadcast on. However it is possible to use multiple SDRs working together to cover all of the channels. This means that you can use a bunch of cheap RTL-SDR to capture an entire system.

--- a/lib/gr_blocks/fsync_decode.cc
+++ b/lib/gr_blocks/fsync_decode.cc
@@ -1,0 +1,671 @@
+/*-
+ * fsync_decode.c
+ *   Decodes a specific format of 1200 BPS MSK data burst
+ *   from input audio samples.
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2012, 2013, 2014  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's fsync Encoder/Decoder Library
+ *
+ *  The fsync Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The fsync Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#include <stdlib.h>
+#include "fsync_decode.h"
+
+static float _sintable[] = {
+	0.000000,  0.024541,  0.049068,  0.073565,  0.098017,  0.122411,  0.146730,  0.170962,
+	0.195090,  0.219101,  0.242980,  0.266713,  0.290285,  0.313682,  0.336890,  0.359895,
+	0.382683,  0.405241,  0.427555,  0.449611,  0.471397,  0.492898,  0.514103,  0.534998,
+	0.555570,  0.575808,  0.595699,  0.615232,  0.634393,  0.653173,  0.671559,  0.689541,
+	0.707107,  0.724247,  0.740951,  0.757209,  0.773010,  0.788346,  0.803208,  0.817585,
+	0.831470,  0.844854,  0.857729,  0.870087,  0.881921,  0.893224,  0.903989,  0.914210,
+	0.923880,  0.932993,  0.941544,  0.949528,  0.956940,  0.963776,  0.970031,  0.975702,
+	0.980785,  0.985278,  0.989177,  0.992480,  0.995185,  0.997290,  0.998795,  0.999699,
+	1.000000,  0.999699,  0.998795,  0.997290,  0.995185,  0.992480,  0.989177,  0.985278,
+	0.980785,  0.975702,  0.970031,  0.963776,  0.956940,  0.949528,  0.941544,  0.932993,
+	0.923880,  0.914210,  0.903989,  0.893224,  0.881921,  0.870087,  0.857729,  0.844854,
+	0.831470,  0.817585,  0.803208,  0.788346,  0.773010,  0.757209,  0.740951,  0.724247,
+	0.707107,  0.689541,  0.671559,  0.653173,  0.634393,  0.615232,  0.595699,  0.575808,
+	0.555570,  0.534998,  0.514103,  0.492898,  0.471397,  0.449611,  0.427555,  0.405241,
+	0.382683,  0.359895,  0.336890,  0.313682,  0.290285,  0.266713,  0.242980,  0.219101,
+	0.195090,  0.170962,  0.146730,  0.122411,  0.098017,  0.073565,  0.049068,  0.024541,
+	0.000000, -0.024541, -0.049068, -0.073565, -0.098017, -0.122411, -0.146730, -0.170962,
+	-0.195090, -0.219101, -0.242980, -0.266713, -0.290285, -0.313682, -0.336890, -0.359895,
+	-0.382683, -0.405241, -0.427555, -0.449611, -0.471397, -0.492898, -0.514103, -0.534998,
+	-0.555570, -0.575808, -0.595699, -0.615232, -0.634393, -0.653173, -0.671559, -0.689541,
+	-0.707107, -0.724247, -0.740951, -0.757209, -0.773010, -0.788346, -0.803208, -0.817585,
+	-0.831470, -0.844854, -0.857729, -0.870087, -0.881921, -0.893224, -0.903989, -0.914210,
+	-0.923880, -0.932993, -0.941544, -0.949528, -0.956940, -0.963776, -0.970031, -0.975702,
+	-0.980785, -0.985278, -0.989177, -0.992480, -0.995185, -0.997290, -0.998795, -0.999699,
+	-1.000000, -0.999699, -0.998795, -0.997290, -0.995185, -0.992480, -0.989177, -0.985278,
+	-0.980785, -0.975702, -0.970031, -0.963776, -0.956940, -0.949528, -0.941544, -0.932993,
+	-0.923880, -0.914210, -0.903989, -0.893224, -0.881921, -0.870087, -0.857729, -0.844854,
+	-0.831470, -0.817585, -0.803208, -0.788346, -0.773010, -0.757209, -0.740951, -0.724247,
+	-0.707107, -0.689541, -0.671559, -0.653173, -0.634393, -0.615232, -0.595699, -0.575808,
+	-0.555570, -0.534998, -0.514103, -0.492898, -0.471397, -0.449611, -0.427555, -0.405241,
+	-0.382683, -0.359895, -0.336890, -0.313682, -0.290285, -0.266713, -0.242980, -0.219101,
+	-0.195090, -0.170962, -0.146730, -0.122411, -0.098017, -0.073565, -0.049068, -0.024541 };
+
+
+static int _fsync_crc(int word1, int word2)
+{
+
+	int paritybit = 0;
+	int crcsr = 0;
+	int bit;
+	int cur;
+	int invert;
+
+	for (bit = 0; bit < 48; bit++)
+	{
+		if (bit < 32)
+		{
+			cur = (word1 >> (31 - bit)) & 0x01;
+		}
+		else
+		{
+			cur = (word2 >> (31 - (bit - 32))) & 0x01;
+		}
+		if (cur)
+			paritybit ^= 1;
+		invert = cur ^ (0x01 & (crcsr >> 15));
+		if (invert)
+		{
+			crcsr ^= 0x6815;
+		}
+		crcsr <<= 1;
+	}
+
+	for (bit = 48; bit < 63; bit++)
+	{
+		cur = (word2 >> (31 - (bit - 32))) & 0x01;
+		if (cur)
+			paritybit ^= 1;
+	}
+
+	crcsr ^= 0x0002;
+	crcsr += paritybit;
+	return crcsr & 0xffff;
+}
+
+static int pcheck[] = { 0x4045, 0x2067, 0x1076, 0x083b, 0x0458, 0x022c, 0x0116, 0x008b };
+static int rpcheck[] = { 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x17, 0x2e, 0x5c, 0xb8, 0x67, 0xce, 0x8b };
+
+static int _fsync2_ecc_repair(int input)
+{
+	int result = 0;
+	int i, j;
+	int s;
+
+	for (i = 0; i < 8; i++)
+	{
+		s = 0;
+		for (j = 0; j < 15; j++)
+		{
+			s += ((pcheck[i] >> j) & 1)* ((input >> j) & 1);
+		}
+		if (s & 1)
+		{
+			result += 1 << i;
+		}
+	}
+
+	if (result == 0)
+		return input;
+
+	for (i = 0; i < 15; i++)
+	{
+		if (result == rpcheck[i])
+		{
+			return input ^ (1 << (14 - i));
+		}
+	}
+	return -1;
+}
+
+fsync_decoder_t * fsync_decoder_new(int sampleRate)
+{
+	fsync_decoder_t *decoder;
+	fsync_int_t i;
+
+	decoder = (fsync_decoder_t *)malloc(sizeof(fsync_decoder_t));
+	if(!decoder)
+		return (fsync_decoder_t *) 0L;
+
+	decoder->hyst = 3.0/256.0;
+	decoder->incr = (1200.0 * TWOPI) / ((fsync_float_t)sampleRate);
+	decoder->actives = 0;
+	decoder->level = 0;
+
+	for(i=0; i<FSYNC_ND; i++)
+	{
+		decoder->th[i] = 0.0 + ( ((fsync_float_t)i) * (TWOPI/(fsync_float_t)FSYNC_ND_12));
+		while(decoder->th[i] >= TWOPI)
+			decoder->th[i] -= TWOPI;
+		decoder->thx[i] = decoder->th[i];
+		decoder->zc[i] = 0;
+		decoder->xorb[i] = 0;
+		decoder->shstate[i] = 0;
+		decoder->shcount[i] = 0;
+		decoder->fs2state[i] = 0;
+	}
+
+	decoder->callback = (fsync_decoder_callback_t)0L;
+	return decoder;
+}
+
+static void _dispatch(fsync_decoder_t *decoder, int x)
+{
+	unsigned char payload[128];
+	int paylen = 0;
+	int aflag;
+	int fleetflag;
+	fsync_u8_t m0, m1;
+	fsync_u8_t *msg = decoder->message[x];
+	fsync_int_t msglen = decoder->msglen[x];
+	fsync_int_t from_fleet, from_unit, to_fleet, to_unit;
+
+	if(msg[0] & 0x01)
+		aflag = 1;
+	else
+		aflag = 0;
+
+	if(msg[1] & 0x01)
+		fleetflag = 1;
+	else
+		fleetflag = 0;
+
+	m0 = msg[0] & 0xfe;
+	m1 = msg[1] & 0xfe;
+
+	from_fleet = msg[2] + 99;
+	from_unit = (msg[3] << 4) + ((msg[4] >> 4) & 0x0f) + 999;
+	to_unit = ((msg[4] << 8) & 0xf00) + msg[5] + 999;
+
+	if(fleetflag)
+	{
+		if(msglen < 7)
+			return;	// cannot dispatch, not enough data
+		to_fleet = msg[6] + 99;
+	}
+	else
+	{
+		to_fleet = from_fleet;
+	}
+
+	if(from_fleet == 99)
+		from_fleet = -1;
+	if(to_fleet == 99)
+		to_fleet = -1;
+	if(to_unit == 999)
+		to_unit = -1;
+	if(from_unit == 999)
+		from_unit = -1;
+
+	if(m1 == 0x42)
+	{
+		int i, offset;
+
+		if(msglen < 11)
+			return;	// truncated before length field, cannot dispatch
+
+		paylen = (msg[9] << 8) + msg[10];
+
+		// XXX unsure if shuffle is appropriate for GPS message (subcmd 0xf4)
+
+		for(i=0; i<paylen; i++)
+		{
+			offset = 11 + (6*((i/6)+1)) - (i%6);
+			if(offset >= msglen)
+				return;	// truncated message (XXX could instead dispatch what we have but with a truncated flag
+			if(i >= sizeof(payload))
+				return; // should never happen unless paylen is corrupted
+
+			payload[i] = msg[offset];
+		}
+	}
+	else
+	{
+		paylen = 0;
+	}
+
+	if(decoder->callback)
+		(decoder->callback)((int)m1, (int)m0, (int)from_fleet, (int)from_unit, (int)to_fleet, (int)to_unit, (int)aflag, payload, paylen, (unsigned char *)msg, (int)msglen, decoder->callback_context, decoder->is_fs2[x], x < FSYNC_ND_12 ? 0 : 1);
+
+}
+	
+
+static void _procbits(fsync_decoder_t *decoder, int x)
+{
+	int crc;
+
+	crc = _fsync_crc(decoder->word1[x], decoder->word2[x]);
+
+	if(crc == (decoder->word2[x] & 0x0000ffff))	// valid fs crc?
+	{
+		decoder->message[x][decoder->msglen[x]++] = (decoder->word1[x] >> 24) & 0xff;
+		decoder->message[x][decoder->msglen[x]++] = (decoder->word1[x] >> 16) & 0xff;
+		decoder->message[x][decoder->msglen[x]++] = (decoder->word1[x] >> 8) & 0xff;
+		decoder->message[x][decoder->msglen[x]++] = (decoder->word1[x] >> 0) & 0xff;
+		decoder->message[x][decoder->msglen[x]++] = (decoder->word2[x] >> 24) & 0xff;
+		decoder->message[x][decoder->msglen[x]++] = (decoder->word2[x] >> 16) & 0xff;
+		// followed by 15 bits of crc and 1 parity bit (already checked)
+		decoder->is_fs2[x] = 0;
+		// go get next word, if there is one
+		decoder->shstate[x] = 1;
+		decoder->shcount[x] = 32;
+
+#if 0
+		// and abort rest
+
+		// we no longer abort the rest, as we give each decoder a shot
+		// at each component of a multi-part message
+
+		for(i=0; i<FSYNC_ND; i++)
+		{
+			if(i != x)
+			{
+				decoder->shstate[i] = 0;
+				decoder->fs2state[i] = 0;
+			}
+		}
+#endif
+	}
+	else
+	{
+		// fs2?
+		// (swap is deliberate)
+		int ec1 = _fsync2_ecc_repair((decoder->word1[x]) & 0x0000ffff);
+		int ec2 = _fsync2_ecc_repair((decoder->word1[x] >> 16) & 0x0000ffff);
+		int ec3 = _fsync2_ecc_repair((decoder->word2[x]) & 0x0000ffff);
+		int ec4 = _fsync2_ecc_repair((decoder->word2[x] >> 16) & 0x0000ffff);
+
+		if(ec1 != -1 && ec2 != -1 && ec3 != -1 && ec4 != -4)
+		{
+			switch(decoder->fs2state[x])
+			{
+			case 0:
+				decoder->fs2w1[x] = (((ec1 >> 8) & 0xf) << 28) + (((ec2 >> 8) & 0xf) << 24) + (((ec3 >> 8) & 0xf) << 20) + (((ec4 >> 8) & 0xf) << 16);
+				decoder->fs2state[x] = 1;
+				decoder->shstate[x] = 1;
+				decoder->shcount[x] = 32;
+				break;
+			case 1:
+				decoder->fs2w1[x] |= (((ec1 >> 8) & 0xf) << 12) + (((ec2 >> 8) & 0xf) << 8) + (((ec3 >> 8) & 0xf) << 4) + (((ec4 >> 8) & 0xf));
+				decoder->fs2state[x] = 2;
+				decoder->shstate[x] = 1;
+				decoder->shcount[x] = 32;
+				break;
+			case 2:
+				decoder->fs2w2[x] = (((ec1 >> 8) & 0xf) << 28) + (((ec2 >> 8) & 0xf) << 24) + (((ec3 >> 8) & 0xf) << 20) + (((ec4 >> 8) & 0xf) << 16);
+				decoder->fs2state[x] = 3;
+				decoder->shstate[x] = 1;
+				decoder->shcount[x] = 32;
+				break;
+			case 3:
+				decoder->fs2w2[x] |= (((ec1 >> 8) & 0xf) << 12) + (((ec2 >> 8) & 0xf) << 8) + (((ec3 >> 8) & 0xf) << 4) + (((ec4 >> 8) & 0xf));
+
+				crc = _fsync_crc(decoder->fs2w1[x], decoder->fs2w2[x]);
+
+				if(crc == (decoder->fs2w2[x] & 0x0000ffff))	// valid fs crc?
+				{
+					decoder->message[x][decoder->msglen[x]++] = (decoder->fs2w1[x] >> 24) & 0xff;
+					decoder->message[x][decoder->msglen[x]++] = (decoder->fs2w1[x] >> 16) & 0xff;
+					decoder->message[x][decoder->msglen[x]++] = (decoder->fs2w1[x] >> 8) & 0xff;
+					decoder->message[x][decoder->msglen[x]++] = (decoder->fs2w1[x] >> 0) & 0xff;
+					decoder->message[x][decoder->msglen[x]++] = (decoder->fs2w2[x] >> 24) & 0xff;
+					decoder->message[x][decoder->msglen[x]++] = (decoder->fs2w2[x] >> 16) & 0xff;
+
+					decoder->is_fs2[x] = 1;
+
+					decoder->fs2state[x] = 0;
+					decoder->shstate[x] = 1;
+					decoder->shcount[x] = 32;
+				}
+				else
+				{
+					// refactor (below)
+					decoder->actives--;
+					if(decoder->msglen[x] > 0)
+					{
+						if(decoder->actives)
+						{
+							// see below
+						}
+						else
+						{
+							_dispatch(decoder, x);
+						}
+					}
+					decoder->shstate[x] = 0;
+					decoder->fs2state[x] = 0;
+				}
+				break;
+			default:
+				decoder->fs2state[x] = 0;
+				break;
+			}
+		}
+		else
+		{
+			decoder->actives--;
+			if(decoder->msglen[x] > 0)
+			{
+				if(decoder->actives)
+				{
+					// others are working, might decode a longer successful run
+					// XXX this approach is a little sensitive to one of them re-syncing on something
+				}
+				else
+				{
+					_dispatch(decoder, x);
+				}
+			}
+			decoder->shstate[x] = 0;
+			decoder->fs2state[x] = 0;
+		}
+	}
+}
+
+static int _onebits(fsync_u32_t n)
+{
+	int i=0;
+	while(n)
+	{
+		++i;
+		n &= (n-1);
+	}
+	return i;
+}
+
+static void _shiftin(fsync_decoder_t *decoder, int x)
+{
+	int bit = decoder->xorb[x];
+
+	decoder->synchigh[x] <<= 1;
+	if(decoder->synclow[x] & 0x80000000)
+		decoder->synchigh[x] |= 1;
+
+	decoder->synclow[x] <<= 1;
+	if(bit)
+		decoder->synclow[x] |= 1;
+
+	switch(decoder->shstate[x])
+	{
+	case 0:
+	 // sync 23eb or can also be 0x052B?
+		if(_onebits(decoder->synchigh[x]^0xaaaa23eb) < FSYNC_GDTHRESH || _onebits(decoder->synchigh[x]^0xaaaa052b) < FSYNC_GDTHRESH)
+		{
+			decoder->actives++;
+			// note, we do sync on the trailing 32 bits and skip state 1 here to ensure we can catch back-to-back messages with the same decoder phase
+			decoder->word1[x] = decoder->synclow[x];
+			decoder->shstate[x] = 2;
+			decoder->shcount[x] = 32;
+			decoder->msglen[x] = 0;
+			decoder->fs2state[x] = 0;
+		}
+		return;
+	case 1:
+		if(--decoder->shcount[x]<= 0)
+		{
+			decoder->word1[x] = decoder->synclow[x];
+			decoder->shcount[x] = 32;
+			decoder->shstate[x] = 2;
+		}
+
+		return;
+	case 2:
+		if(--decoder->shcount[x]<= 0)
+		{
+			decoder->word2[x] = decoder->synclow[x];
+			_procbits(decoder, x);
+		}
+		return;
+
+	default:
+		decoder->shstate[x] = 0; // should never happen
+		decoder->fs2state[x] = 0;
+		return;
+	}
+}
+
+static void _zcproc(fsync_decoder_t *decoder, int x)
+{
+	// XXX optimize the 2400 case
+	if(x >= FSYNC_ND_12)
+	{
+		switch(decoder->zc[x])
+		{
+		case 1:
+			decoder->xorb[x] = 1;
+			break;
+		case 2:
+			decoder->xorb[x] = 0;
+			break;
+		default:
+			return;
+		}
+	}
+	else
+	{
+		switch(decoder->zc[x])
+		{
+		case 2:
+		case 4:
+			decoder->xorb[x] = 1;
+			break;
+		case 3:
+			decoder->xorb[x] = 0;
+			break;
+		default:
+			return;
+		}
+	}
+	_shiftin(decoder, x);
+}
+
+
+int fsync_decoder_process_samples(fsync_decoder_t *decoder,
+                                fsync_sample_t *samples,
+                                int numSamples)
+{
+	fsync_int_t i, j, k;
+	fsync_sample_t sample;
+	fsync_float_t value;
+	fsync_float_t delta;
+
+	if(!decoder)
+		return -1;
+
+	for(i = 0; i<numSamples; i++)
+	{
+		sample = samples[i];
+
+#if defined(FSYNC_SAMPLE_FORMAT_U8)
+		value = (((fsync_float_t)sample) - 128.0)/256;
+#elif defined(FSYNC_SAMPLE_FORMAT_U16)
+		value = (((fsync_float_t)sample) - 32768.0)/65536.0;
+#elif defined(FSYNC_SAMPLE_FORMAT_S16)
+		value = ((fsync_float_t)sample) / 65536.0;
+#elif defined(FSYNC_SAMPLE_FORMAT_FLOAT)
+		value = sample;
+#else
+#error "no known sample format set"
+#endif
+
+#ifdef ZEROCROSSING
+
+#ifdef DIFFERENTIATOR
+		delta = value - decoder->lastvalue;
+		decoder->lastvalue = value;
+
+		if(decoder->level == 0)
+		{
+			if(delta > decoder->hyst)
+			{
+				for(k=0; k<FSYNC_ND; k++)
+					decoder->zc[k]++;
+				decoder->level = 1;
+			}
+		}
+		else
+		{
+			if(delta < (-1 * decoder->hyst))
+			{
+				for(k=0; k<FSYNC_ND; k++)
+					decoder->zc[k]++;
+				decoder->level = 0;
+			}
+		}
+#else	/* DIFFERENTIATOR */
+		if(decoder->level == 0)
+		{
+			if(s > decoder->hyst)
+			{
+				for(k=0; k<FSYNC_ND; k++)
+					decoder->zc[k]++;
+				decoder->level = 1;
+			}
+		}
+		else
+		{
+			if(s < (-1.0 * decoder->hyst))
+			{
+				for(k=0; k<FSYNC_ND; k++)
+					decoder->zc[k]++;
+				decoder->level = 0;
+			}
+		}
+#endif	/* DIFFERENTIATOR */
+		
+
+		for(j=0; j<FSYNC_ND; j++)
+		{
+			if(j < FSYNC_ND_12)
+				decoder->th[j] += decoder->incr;
+			else
+				decoder->th[j] += 2*(decoder->incr);	// 2400
+
+			if(decoder->th[j] >= TWOPI)
+			{
+				_zcproc(decoder, j);
+				decoder->th[j] -= TWOPI;
+				decoder->zc[j] = 0;
+			}
+		}
+#else	/* ZEROCROSSING */
+
+		for(j=0; j<FSYNC_ND; j++)
+		{
+			int th_zero, th_one;
+			if(j < FSYNC_ND_12)
+			{
+				th_zero = (int)((256.0/TWOPI) * decoder->thx[j]);
+				th_one =  (int)((256.0/TWOPI) * decoder->th[j]);
+			}
+			else
+			{
+				th_zero = (int)((256.0/TWOPI) * decoder->th[j]);
+				th_one =  (int)((256.0/TWOPI) * decoder->thx[j]);
+			}
+
+			decoder->accum0[j] += _sintable[th_zero] * value;
+			decoder->accum1[j] += _sintable[th_one] * value;
+
+			decoder->accum0i[j] += _sintable[(th_zero + 64) % 256] * value;
+			decoder->accum1i[j] += _sintable[(th_one + 64) % 256] * value;
+			//
+
+			if(j < FSYNC_ND_12)
+			{
+				decoder->th[j] += decoder->incr;
+				decoder->thx[j] += 1.5 * decoder->incr;
+			}
+			else
+			{
+				decoder->th[j] += 2*(decoder->incr);
+				decoder->thx[j] += decoder->incr;
+			}
+
+			while(decoder->thx[j] >= TWOPI)
+				decoder->thx[j] -= TWOPI;
+
+			if(decoder->th[j] >= TWOPI)
+			{
+				if  (
+					(decoder->accum0[j] * decoder->accum0[j]) + (decoder->accum0i[j] * decoder->accum0i[j]) > (decoder->accum1[j] * decoder->accum1[j]) + (decoder->accum1i[j] * decoder->accum1i[j])
+					)
+					decoder->xorb[j] = 0;
+				else
+					decoder->xorb[j] = 1;
+
+				decoder->accum0[j] = decoder->accum1[j] = 0.0;
+				decoder->accum0i[j] = decoder->accum1i[j] = 0.0;
+
+				_shiftin(decoder, j);
+
+				decoder->th[j] -= TWOPI;
+			}
+
+		}
+
+#endif
+	}
+
+	// XXX callback only -- no longer return 1 if good and have a way to get message. ok?
+
+	return 0;
+}
+
+int fsync_decoder_end_samples(fsync_decoder_t *decoder)
+{
+	int i, j;
+
+	if(!decoder)
+		return -1;
+
+	for(i = 0; i < 70; i++)
+	{
+		for(j = 0; j < FSYNC_ND; j++)
+		{
+			_shiftin(decoder, j);
+		}
+	}
+
+	return 0;
+}
+
+int fsync_decoder_set_callback(fsync_decoder_t *decoder, fsync_decoder_callback_t callback_function, void *context)
+{
+	if(!decoder)
+		return -1;
+
+	decoder->callback = callback_function;
+	decoder->callback_context = context;
+
+	return 0;
+}
+

--- a/lib/gr_blocks/fsync_decode.h
+++ b/lib/gr_blocks/fsync_decode.h
@@ -1,0 +1,141 @@
+/*-
+ * fsync_decode.h
+ *  header for fsync_decode.c
+ *
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2012, 2013, 2014  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's fsync Encoder/Decoder Library
+ *
+ *  The fsync Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The fsync Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#ifndef _FSYNC_DECODE_H_
+#define _FSYNC_DECODE_H_
+
+#include "fsync_types.h"
+
+#ifndef TWOPI
+#define TWOPI (2.0 * 3.1415926535)
+#endif
+
+#define FSYNC_ND 10
+#define FSYNC_ND_12 5
+
+#define FSYNC_GDTHRESH 4  // "good bits" threshold
+
+#define DIFFERENTIATOR
+
+// #define ZEROCROSSING /* turn off for better correlator method */
+
+
+typedef void (*fsync_decoder_callback_t)(int cmd, int subcmd, int from_fleet, int from_unit, int to_fleet, int to_unit, int allflag, unsigned char *payload, int payload_len, unsigned char *raw_msg, int raw_msg_len, void *context, int is_fsync2, int is_2400);
+
+
+typedef struct {
+	fsync_float_t hyst;
+	fsync_float_t incr;
+	fsync_float_t th[FSYNC_ND];
+	fsync_float_t thx[FSYNC_ND];
+	fsync_int_t level;
+	fsync_float_t lastvalue;
+	fsync_float_t accum0[FSYNC_ND];
+	fsync_float_t accum1[FSYNC_ND];
+	fsync_float_t accum0i[FSYNC_ND];
+	fsync_float_t accum1i[FSYNC_ND];
+	fsync_int_t zc[FSYNC_ND];
+	fsync_int_t xorb[FSYNC_ND];
+	fsync_u32_t synclow[FSYNC_ND];
+	fsync_u32_t synchigh[FSYNC_ND];
+	fsync_int_t shstate[FSYNC_ND];
+	fsync_int_t shcount[FSYNC_ND];
+	fsync_int_t fs2state[FSYNC_ND];
+	fsync_int_t fs2w1[FSYNC_ND];
+	fsync_int_t fs2w2[FSYNC_ND];
+	fsync_int_t is_fs2[FSYNC_ND];
+	fsync_u32_t word1[FSYNC_ND];
+	fsync_u32_t word2[FSYNC_ND];
+	fsync_u8_t message[FSYNC_ND][1536];
+	fsync_int_t msglen[FSYNC_ND];
+	fsync_int_t actives;
+	fsync_decoder_callback_t callback;
+	void *callback_context;
+} fsync_decoder_t;
+	
+
+
+/*
+ fsync_decoder_new
+ create a new fsync_decoder object
+
+  parameters: int sampleRate - the sampling rate in Hz
+
+  returns: an fsync_decoder object or null if failure
+
+*/
+fsync_decoder_t * fsync_decoder_new(int sampleRate);
+
+/*
+ fsync_decoder_process_samples
+ process incoming samples using an fsync_decoder object
+
+ parameters: fsync_decoder_t *decoder - pointer to the decoder object
+             fsync_sample_t *samples - pointer to samples (in format set in fsync_types.h)
+             int numSamples - count of the number of samples in buffer
+
+ returns: 0 if more samples are needed (usual case)
+         -1 if an error occurs
+*/
+ 
+int fsync_decoder_process_samples(fsync_decoder_t *decoder,
+                                fsync_sample_t *samples,
+                                int numSamples);
+
+
+/*
+ fsync_decoder_end_samples
+ notify decoder that no more samples will be forthcoming for some time
+ (used to flush any pending messages, may invoke callback)
+
+ returns: -1 if error, 0 otherwise
+*/
+
+int fsync_decoder_end_samples(fsync_decoder_t *decoder);
+
+/*
+ fsync_decoder_set_callback
+ set a callback function to be called upon successful decode
+ if this is set, the functions fsync_decoder_get_packet and fsync_decoder_get_double_packet
+ will no longer be functional, instead the callback function is called immediately when
+ a successful decode happens (from within the context of fsync_decoder_process_samples)
+
+ last parameter of callback will be the (void *)context set here
+
+ returns: -1 if error, 0 otherwise
+ */
+
+int fsync_decoder_set_callback(fsync_decoder_t *decoder, fsync_decoder_callback_t callback_function, void *context);
+
+#endif

--- a/lib/gr_blocks/fsync_types.h
+++ b/lib/gr_blocks/fsync_types.h
@@ -1,0 +1,56 @@
+/*-
+ * fsync_types.h
+ *  common typedef header for fsync_decode.h, fsync_encode.h
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2012, 2013, 2014  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's fsync Encoder/Decoder Library
+ *
+ *  The fsync Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The fsync Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#ifndef _FSYNC_TYPES_H_
+#define _FSYNC_TYPES_H_
+
+typedef int fsync_s32;
+typedef unsigned int fsync_u32_t;
+typedef short fsync_s16_t;
+typedef unsigned short fsync_u16_t;
+typedef char fsync_s8_t;
+typedef unsigned char fsync_u8_t;
+typedef double fsync_float_t;
+typedef int fsync_int_t;
+
+/* to change the data type, set this typedef: */
+typedef float fsync_sample_t;
+
+/* AND set this to match: */
+/* #define FSYNC_SAMPLE_FORMAT_U8 */
+/* #define FSYNC_SAMPLE_FORMAT_S16 */
+/* #define FSYNC_SAMPLE_FORMAT_U16 */
+#define FSYNC_SAMPLE_FORMAT_FLOAT
+
+
+#endif

--- a/lib/gr_blocks/mdc_decode.cc
+++ b/lib/gr_blocks/mdc_decode.cc
@@ -1,0 +1,593 @@
+/*-
+ * mdc_decode.c
+ *   Decodes a specific format of 1200 BPS XOR-precoded MSK data burst
+ *   from input audio samples.
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2005, 2010  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's MDC Encoder/Decoder Library
+ *
+ *  The MDC Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The MDC Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#include <stdlib.h>
+#include "mdc_decode.h"
+
+static mdc_u16_t _flip(mdc_u16_t crc, mdc_int_t bitnum)
+{
+	mdc_u16_t crcout, i, j;
+
+	j = 1;
+	crcout = 0;
+
+	for (i = 1 << (bitnum - 1); i; i >>= 1)
+	{
+		if (crc & i)
+			crcout |= j;
+		j <<= 1;
+	}
+	return (crcout);
+}
+
+
+static mdc_u16_t _docrc(mdc_u8_t* p, int len)
+{
+	mdc_int_t i, j;
+	mdc_u16_t c;
+	mdc_int_t bit;
+	mdc_u16_t crc = 0x0000;
+
+	for (i = 0; i < len; i++)
+	{
+		c = (mdc_u16_t)*p++;
+
+		c = _flip(c, 8);
+
+		for (j = 0x80; j; j >>= 1)
+		{
+			bit = crc & 0x8000;
+			crc <<= 1;
+			if (c & j)
+				bit ^= 0x8000;
+			if (bit)
+				crc ^= 0x1021;
+		}
+	}
+
+	crc = _flip(crc, 16);
+	crc ^= 0xffff;
+	crc &= 0xFFFF;
+
+	return(crc);
+}
+
+
+mdc_decoder_t * mdc_decoder_new(int sampleRate)
+{
+	mdc_decoder_t *decoder;
+	mdc_int_t i;
+
+	decoder = (mdc_decoder_t *)malloc(sizeof(mdc_decoder_t));
+	if(!decoder)
+		return (mdc_decoder_t *) 0L;
+
+//	decoder->hyst = 3.0/256.0; - deprecated (zerocrossing)
+//	decoder->incr = (1200.0 * TWOPI) / ((mdc_float_t)sampleRate);
+
+	if(sampleRate == 8000)
+	{
+		decoder->incru = 644245094;
+	} else if(sampleRate == 16000)
+	{
+		decoder->incru = 322122547;
+	} else if(sampleRate == 22050)
+	{
+		decoder->incru = 233739716;
+	} else if(sampleRate == 32000)
+	{
+		decoder->incru = 161061274;
+	} else if(sampleRate == 44100)
+	{
+		decoder->incru = 116869858;
+	} else if(sampleRate == 48000)
+	{
+		decoder->incru = 107374182;
+	} else
+	{
+		// WARNING: lower precision than above
+		decoder->incru = 1200 * 2 * (0x80000000 / sampleRate);
+	}
+
+	decoder->good = 0;
+	decoder->indouble = 0;
+	decoder->level = 0;
+
+
+	for(i=0; i<MDC_ND; i++)
+	{
+		decoder->du[i].thu = i * 2 * (0x80000000 / MDC_ND);
+		decoder->du[i].xorb = 0;
+		decoder->du[i].invert = 0;
+		decoder->du[i].shstate = -1;
+		decoder->du[i].shcount = 0;
+	#ifdef MDC_FOURPOINT
+		decoder->du[i].nlstep = i;
+	#endif
+	}
+
+	decoder->callback = (mdc_decoder_callback_t)0L;
+
+	return decoder;
+}
+
+static void _clearbits(mdc_decoder_t *decoder, mdc_int_t x)
+{
+	mdc_int_t i;
+	for(i=0; i<112; i++)
+		decoder->du[x].bits[i] = 0;
+}
+
+#ifdef MDC_ECC
+static void _gofix(unsigned char *data)
+{
+	int i, j, b, k;
+	int csr[7];
+	int syn;
+	int fixi,fixj;
+	int ec;
+	
+	syn = 0;
+	for(i=0; i<7; i++)
+		csr[i] = 0;
+
+	for(i=0; i<7; i++)
+	{
+		for(j=0; j<=7; j++)
+		{
+			for(k=6; k > 0; k--)
+				csr[k] = csr[k-1];
+
+			csr[0] = (data[i] >> j) & 0x01;
+			b = csr[0] + csr[2] + csr[5] + csr[6];
+			syn <<= 1;
+			if( (b & 0x01) ^ ((data[i+7] >> j) & 0x01) )
+			{
+				syn |= 1;
+			}
+			ec = 0;
+			if(syn & 0x80) ++ec;
+			if(syn & 0x20) ++ec;
+			if(syn & 0x04) ++ec;
+			if(syn & 0x02) ++ec;
+			if(ec >= 3)
+			{
+				syn ^= 0xa6;
+				fixi = i;
+				fixj = j-7;
+				if(fixj < 0)
+				{
+					--fixi;
+					fixj += 8;
+				}
+				if(fixi >= 0)
+					data[fixi] ^= 1<<fixj; // flip
+			}
+		}
+	}
+
+
+}
+#endif
+
+
+static void _procbits(mdc_decoder_t *decoder, int x)
+{
+	mdc_int_t lbits[112];
+	mdc_int_t lbc = 0;
+	mdc_int_t i, j, k;
+	mdc_u8_t data[14];
+	mdc_u16_t ccrc;
+	mdc_u16_t rcrc;
+
+	for(i=0; i<16; i++)
+	{
+		for(j=0; j<7; j++)
+		{
+			k = (j*16) + i;
+			lbits[lbc] = decoder->du[x].bits[k];
+			++lbc;
+		}
+	}
+
+	for(i=0; i<14; i++)
+	{
+		data[i] = 0;
+		for(j=0; j<8; j++)
+		{
+			k = (i*8)+j;
+
+			if(lbits[k])
+				data[i] |= 1<<j;
+		}
+	}
+
+
+#ifdef MDC_ECC
+	_gofix(data);
+#endif
+
+	ccrc = _docrc(data, 4);
+	rcrc = data[5] << 8 | data[4];
+
+	if(ccrc == rcrc)
+	{
+
+		if(decoder->du[x].shstate == 2)
+		{
+			decoder->extra0 = data[0];
+			decoder->extra1 = data[1];
+			decoder->extra2 = data[2];
+			decoder->extra3 = data[3];
+
+			for(k=0; k<MDC_ND; k++)
+				decoder->du[k].shstate = -1;
+
+			decoder->good = 2;
+			decoder->indouble = 0;
+
+		}
+		else
+		{
+			if(!decoder->indouble)
+			{
+				decoder->good = 1;
+				decoder->op = data[0];
+				decoder->arg = data[1];
+				decoder->unitID = (data[2] << 8) | data[3];
+
+				switch(data[0])
+				{
+				/* list of opcode that mean 'double packet' */
+				case 0x35:
+				case 0x55:
+					decoder->good = 0;
+					decoder->indouble = 1;
+					decoder->du[x].shstate = 2;
+					decoder->du[x].shcount = 0;
+					_clearbits(decoder, x);
+					break;
+				default:
+					for(k=0; k<MDC_ND; k++)
+						decoder->du[k].shstate = -1;	// only in the single-packet case, double keeps rest going
+					break;
+				}
+			}
+			else
+			{
+				// any subsequent good decoder allowed to attempt second half
+				decoder->du[x].shstate = 2;
+				decoder->du[x].shcount = 0;
+				_clearbits(decoder, x);
+			}
+		}
+
+	}
+	else
+	{
+
+		decoder->du[x].shstate = -1;
+	}
+
+	if(decoder->good)
+	{
+		if(decoder->callback)
+		{
+			(decoder->callback)( (int)decoder->good,
+								(unsigned char)decoder->op,
+								(unsigned char)decoder->arg,
+								(unsigned short)decoder->unitID,
+								(unsigned char)decoder->extra0,
+								(unsigned char)decoder->extra1,
+								(unsigned char)decoder->extra2,
+								(unsigned char)decoder->extra3,
+								decoder->callback_context);
+			decoder->good = 0;
+
+		}
+	}
+}
+
+
+static int _onebits(mdc_u32_t n)
+{
+	int i=0;
+	while(n)
+	{
+		++i;
+		n &= (n-1);
+	}
+	return i;
+}
+
+static void _shiftin(mdc_decoder_t *decoder, int x)
+{
+	int bit = decoder->du[x].xorb;
+	int gcount;
+
+	switch(decoder->du[x].shstate)
+	{
+	case -1:
+		decoder->du[x].synchigh = 0;
+		decoder->du[x].synclow = 0;
+		decoder->du[x].shstate = 0;
+		// deliberately fall through
+	case 0:
+		decoder->du[x].synchigh <<= 1;
+		if(decoder->du[x].synclow & 0x80000000)
+			decoder->du[x].synchigh |= 1;
+		decoder->du[x].synclow <<= 1;
+		if(bit)
+			decoder->du[x].synclow |= 1;
+
+		gcount = _onebits(0x000000ff & (0x00000007 ^ decoder->du[x].synchigh));
+		gcount += _onebits(0x092a446f ^ decoder->du[x].synclow);
+
+		if(gcount <= MDC_GDTHRESH)
+		{
+ //printf("sync %d  %x %x \n",gcount,decoder->du[x].synchigh, decoder->du[x].synclow);
+			decoder->du[x].shstate = 1;
+			decoder->du[x].shcount = 0;
+			_clearbits(decoder, x);
+		}
+		else if(gcount >= (40 - MDC_GDTHRESH))
+		{
+ //printf("isync %d\n",gcount);
+			decoder->du[x].shstate = 1;
+			decoder->du[x].shcount = 0;
+			decoder->du[x].xorb = !(decoder->du[x].xorb);
+			decoder->du[x].invert = !(decoder->du[x].invert);
+			_clearbits(decoder, x);
+		}
+		return;
+	case 1:
+	case 2:
+		decoder->du[x].bits[decoder->du[x].shcount] = bit;
+		decoder->du[x].shcount++;
+		if(decoder->du[x].shcount > 111)
+		{
+			_procbits(decoder, x);
+		}
+		return;
+
+	default:
+		return;
+	}
+}
+
+#ifdef MDC_FOURPOINT
+
+static void _nlproc(mdc_decoder_t *decoder, int x)
+{
+	mdc_float_t vnow;
+	mdc_float_t vpast;
+
+	switch(decoder->du[x].nlstep)
+	{
+	case 3:
+		vnow = ((-0.60 * decoder->du[x].nlevel[3]) + (.97 * decoder->du[x].nlevel[1]));
+		vpast = ((-0.60 * decoder->du[x].nlevel[7]) + (.97 * decoder->du[x].nlevel[9]));
+		break;
+	case 8:
+		vnow = ((-0.60 * decoder->du[x].nlevel[8]) + (.97 * decoder->du[x].nlevel[6]));
+		vpast = ((-0.60 * decoder->du[x].nlevel[2]) + (.97 * decoder->du[x].nlevel[4]));
+		break;
+	default:
+		return;
+	}
+
+	decoder->du[x].xorb = (vnow > vpast) ? 1 : 0;
+	if(decoder->du[x].invert)
+		decoder->du[x].xorb = !(decoder->du[x].xorb);
+	_shiftin(decoder, x);
+}
+#endif
+
+int mdc_decoder_process_samples(mdc_decoder_t *decoder,
+                                mdc_sample_t *samples,
+                                int numSamples)
+{
+	mdc_int_t i, j;
+	mdc_sample_t sample;
+#ifndef MDC_FIXEDMATH
+	mdc_float_t value;
+#else
+	mdc_int_t value;
+#endif
+
+	if(!decoder)
+		return -1;
+
+	for(i = 0; i<numSamples; i++)
+	{
+		sample = samples[i];
+
+#ifdef MDC_FIXEDMATH
+#if defined(MDC_SAMPLE_FORMAT_U8)
+		value = ((mdc_int_t)sample) - 127;
+#elif defined(MDC_SAMPLE_FORMAT_U16)
+		value = ((mdc_int_t)sample) - 32767;
+#elif defined(MDC_SAMPLE_FORMAT_S16)
+		value = (mdc_int_t) sample;
+#elif defined(MDC_SAMPLE_FORMAT_FLOAT)
+#error "fixed-point math not allowed with float sample format"
+#else
+#error "no known sample format set"
+#endif // sample format
+
+#endif // is MDC_FIXEDMATH
+
+#ifndef MDC_FIXEDMATH
+#if defined(MDC_SAMPLE_FORMAT_U8)
+		value = (((mdc_float_t)sample) - 128.0)/256;
+#elif defined(MDC_SAMPLE_FORMAT_U16)
+		value = (((mdc_float_t)sample) - 32768.0)/65536.0;
+#elif defined(MDC_SAMPLE_FORMAT_S16)
+		value = ((mdc_float_t)sample) / 65536.0;
+#elif defined(MDC_SAMPLE_FORMAT_FLOAT)
+		value = sample;
+#else
+#error "no known sample format set"
+#endif // sample format
+#endif // not MDC_FIXEDMATH
+
+#if defined(MDC_ONEPOINT)
+
+		for(j=0; j<MDC_ND; j++)
+		{
+			mdc_u32_t lthu = decoder->du[j].thu;
+			decoder->du[j].thu += decoder->incru;
+			if(decoder->du[j].thu < lthu) // wrapped
+			{
+				if(value > 0)
+					decoder->du[j].xorb = 1;
+				else
+					decoder->du[j].xorb = 0;
+				if(decoder->du[j].invert)
+					decoder->du[j].xorb = !(decoder->du[j].xorb);
+				_shiftin(decoder, j);
+			}
+		}
+
+#elif defined(MDC_FOURPOINT)
+
+#ifdef MDC_FIXEDMATH
+#error "fixed-point math not allowed for fourpoint strategy"
+#endif
+
+		for(j=0; j<MDC_ND; j++)
+		{
+			//decoder->du[j].th += (5.0 * decoder->incr);
+			mdc_u32_t lthu = decoder->du[j].thu;
+			decoder->du[j].thu += 5 * decoder->incru;
+		//	if(decoder->du[j].th >= TWOPI)
+			if(decoder->du[j].thu < lthu) // wrapped
+			{
+				decoder->du[j].nlstep++;
+				if(decoder->du[j].nlstep > 9)
+					decoder->du[j].nlstep = 0;
+				decoder->du[j].nlevel[decoder->du[j].nlstep] = value;	
+
+				_nlproc(decoder, j);
+
+				//decoder->du[j].th -= TWOPI;
+			}
+		}
+
+#else
+#error "no decode strategy chosen"
+#endif
+	}
+
+	
+
+	if(decoder->good)
+		return decoder->good;
+
+	return 0;
+}
+
+int mdc_decoder_get_packet(mdc_decoder_t *decoder, 
+                           unsigned char *op,
+			   unsigned char *arg,
+			   unsigned short *unitID)
+{
+	if(!decoder)
+		return -1;
+
+	if(decoder->good != 1)
+		return -1;
+
+	if(op)
+		*op = decoder->op;
+
+	if(arg)
+		*arg = decoder->arg;
+
+	if(unitID)
+		*unitID = decoder->unitID;
+
+	decoder->good = 0;
+
+	return 0;
+}
+
+int mdc_decoder_get_double_packet(mdc_decoder_t *decoder, 
+                           unsigned char *op,
+			   unsigned char *arg,
+			   unsigned short *unitID,
+                           unsigned char *extra0,
+                           unsigned char *extra1,
+                           unsigned char *extra2,
+                           unsigned char *extra3)
+{
+	if(!decoder)
+		return -1;
+
+	if(decoder->good != 2)
+		return -1;
+
+	if(op)
+		*op = decoder->op;
+
+	if(arg)
+		*arg = decoder->arg;
+
+	if(unitID)
+		*unitID = decoder->unitID;
+
+	if(extra0)
+		*extra0 = decoder->extra0;
+	if(extra1)
+		*extra1 = decoder->extra1;
+	if(extra2)
+		*extra2 = decoder->extra2;
+	if(extra3)
+		*extra3 = decoder->extra3;
+
+	decoder->good = 0;
+
+	return 0;
+}
+
+int mdc_decoder_set_callback(mdc_decoder_t *decoder, mdc_decoder_callback_t callbackFunction, void *context)
+{
+	if(!decoder)
+		return -1;
+
+	decoder->callback = callbackFunction;
+	decoder->callback_context = context;
+
+	return 0;
+}

--- a/lib/gr_blocks/mdc_decode.h
+++ b/lib/gr_blocks/mdc_decode.h
@@ -1,0 +1,203 @@
+/*-
+ * mdc_decode.h
+ *  header for mdc_decode.c
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2005, 2010  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's MDC Encoder/Decoder Library
+ *
+ *  The MDC Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The MDC Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#ifndef _MDC_DECODE_H_
+#define _MDC_DECODE_H_
+
+// #define MDC_FIXEDMATH // if you want this, define before mdc_types.h
+
+#include "mdc_types.h"
+
+#define MDC_GDTHRESH 5  // "good bits" threshold
+
+#define MDC_ECC
+
+#define MDC_FOURPOINT	// recommended 4-point method, requires high sample rates (16000 or higher)
+#undef  MDC_ONEPOINT    // alternative 1-point method
+
+#ifdef MDC_FOURPOINT
+ #define MDC_ND 5  // recommended for four-point method
+#endif
+
+#ifdef MDC_ONEPOINT
+ #define MDC_ND 4  // recommended for one-point method
+#endif
+
+typedef void (*mdc_decoder_callback_t)(	int frameCount, // 1 or 2 - if 2 then extra0-3 are valid
+										unsigned char op,
+										unsigned char arg,
+										unsigned short unitID,
+										unsigned char extra0,
+										unsigned char extra1,
+										unsigned char extra2,
+										unsigned char extra3,
+										void *context);
+
+typedef struct
+{
+//	mdc_float_t th;
+	mdc_u32_t thu;
+//	mdc_int_t zc; - deprecated
+	mdc_int_t xorb;
+	mdc_int_t invert;
+#ifdef MDC_FOURPOINT
+#ifdef MDC_FIXEDMATH
+#error "fixed-point math not allowed for fourpoint strategy"
+#endif // MDC_FIXEDMATH
+	mdc_int_t nlstep;
+	mdc_float_t nlevel[10];
+#endif  // MDC_FOURPOINT
+#ifdef PLL
+	mdc_u32_t plt;
+#endif
+	mdc_u32_t synclow;
+	mdc_u32_t synchigh;
+	mdc_int_t shstate;
+	mdc_int_t shcount;
+	mdc_int_t bits[112];
+} mdc_decode_unit_t;
+
+typedef struct {
+	mdc_decode_unit_t du[MDC_ND];
+//	mdc_float_t hyst;
+//	mdc_float_t incr;
+	mdc_u32_t incru;
+#ifdef PLL
+	mdc_u32_t zthu;
+	mdc_int_t zprev;
+	mdc_float_t vprev;
+#endif
+	mdc_int_t level;
+	mdc_int_t good;
+	mdc_int_t indouble;
+	mdc_u8_t op;
+	mdc_u8_t arg;
+	mdc_u16_t unitID;
+	mdc_u8_t extra0;
+	mdc_u8_t extra1;
+	mdc_u8_t extra2;
+	mdc_u8_t extra3;
+	mdc_decoder_callback_t callback;
+	void *callback_context;
+} mdc_decoder_t;
+	
+
+
+/*
+ mdc_decoder_new
+ create a new mdc_decoder object
+
+  parameters: int sampleRate - the sampling rate in Hz
+
+  returns: an mdc_decoder object or null if failure
+
+*/
+mdc_decoder_t * mdc_decoder_new(int sampleRate);
+
+/*
+ mdc_decoder_process_samples
+ process incoming samples using an mdc_decoder object
+
+ parameters: mdc_decoder_t *decoder - pointer to the decoder object
+             mdc_sample_t *samples - pointer to samples (in format set in mdc_types.h)
+             int numSamples - count of the number of samples in buffer
+
+ returns: 0 if more samples are needed
+         -1 if an error occurs
+          1 if a decoded single packet is available to read (if no callback set)
+          2 if a decoded double packet is available to read (if no callback set)
+*/
+ 
+int mdc_decoder_process_samples(mdc_decoder_t *decoder,
+                                mdc_sample_t *samples,
+                                int numSamples);
+
+
+/*
+ mdc_decoder_get_packet
+ retrieve last successfully decoded data packet from decoder object
+
+ parameters: mdc_decoder_t *decoder - pointer to the decoder object
+             unsigned char *op      - pointer to where to store "opcode"
+             unsigned char *arg     - pointer to where to store "argument"
+             unsigned short *unitID - pointer to where to store "unit ID"
+
+ returns: -1 if error, 0 otherwise
+*/
+
+int mdc_decoder_get_packet(mdc_decoder_t *decoder, 
+                           unsigned char *op,
+			   unsigned char *arg,
+			   unsigned short *unitID);
+
+/*
+ mdc_decoder_get_double_packet
+ retrieve last successfully decoded double-length packet from decoder object
+
+ parameters: mdc_decoder_t *decoder - pointer to the decoder object
+             unsigned char *op      - pointer to where to store "opcode"
+             unsigned char *arg     - pointer to where to store "argument"
+             unsigned short *unitID - pointer to where to store "unit ID"
+             unsigned char *extra0  - pointer to where to store 1st extra byte
+             unsigned char *extra1  - pointer to where to store 2nd extra byte
+             unsigned char *extra2  - pointer to where to store 3rd extra byte
+             unsigned char *extra3  - pointer to where to store 4th extra byte
+
+ returns: -1 if error, 0 otherwise
+*/
+
+int mdc_decoder_get_double_packet(mdc_decoder_t *decoder, 
+                           unsigned char *op,
+			   unsigned char *arg,
+			   unsigned short *unitID,
+                           unsigned char *extra0,
+                           unsigned char *extra1,
+                           unsigned char *extra2,
+                           unsigned char *extra3);
+
+
+/*
+ mdc_decoder_set_callback
+ set a callback function to be called upon successful decode
+ if this is set, the functions mdc_decoder_get_packet and mdc_decoder_get_double_packet
+ will no longer be functional, instead the callback function is called immediately when
+ a successful decode happens (from within the context of mdc_decoder_process_samples)
+
+ the callback function will be passed the (void *)context that is set here
+
+ returns: -1 if error, 0 otherwise
+ */
+
+int mdc_decoder_set_callback(mdc_decoder_t *decoder, mdc_decoder_callback_t callbackFunction, void *context);
+
+#endif

--- a/lib/gr_blocks/mdc_types.h
+++ b/lib/gr_blocks/mdc_types.h
@@ -1,0 +1,59 @@
+/*-
+ * mdc_types.h
+ *  common typedef header for mdc_decode.h, mdc_encode.h
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2010  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's MDC Encoder/Decoder Library
+ *
+ *  The MDC Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The MDC Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#ifndef _MDC_TYPES_H_
+#define _MDC_TYPES_H_
+
+typedef int mdc_s32;
+typedef unsigned int mdc_u32_t;
+typedef short mdc_s16_t;
+typedef unsigned short mdc_u16_t;
+typedef char mdc_s8_t;
+typedef unsigned char mdc_u8_t;
+typedef int mdc_int_t;
+
+#ifndef MDC_FIXEDMATH
+typedef double mdc_float_t;
+#endif // MDC_FIXEDMATH
+
+/* to change the data type, set this typedef: */
+typedef float mdc_sample_t;
+
+/* AND set this to match: */
+/* #define MDC_SAMPLE_FORMAT_U8 */
+/* #define MDC_SAMPLE_FORMAT_S16 */
+/* #define MDC_SAMPLE_FORMAT_U16 */
+#define MDC_SAMPLE_FORMAT_FLOAT
+
+
+#endif

--- a/lib/gr_blocks/signal_decoder_sink.h
+++ b/lib/gr_blocks/signal_decoder_sink.h
@@ -1,0 +1,64 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GR_SIGNAL_DECODER_SINK_H
+#define INCLUDED_GR_SIGNAL_DECODER_SINK_H
+
+#include "../trunk-recorder/call.h"
+#include "../trunk-recorder/call_conventional.h"
+#include <boost/log/trivial.hpp>
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+    namespace blocks {
+
+        /*!
+         * \brief Write stream to a Microsoft PCM (.wav) file.
+         * \ingroup audio_blk
+         *
+         * \details
+         * Values must be floats within [-1;1].
+         * Check gr_make_wavfile_sink() for extra info.
+         */
+        class BLOCKS_API signal_decoder_sink : virtual public sync_block
+        {
+        public:
+            // gr::blocks::wavfile_sink::sptr
+            typedef boost::shared_ptr<signal_decoder_sink> sptr;
+
+            virtual void set_mdc_enabled(bool b) {};
+            virtual void set_fsync_enabled(bool b) {};
+            virtual void set_star_enabled(bool b) {};
+
+            virtual bool get_mdc_enabled() { return false; };
+            virtual bool get_fsync_enabled() { return false; };
+            virtual bool get_star_enabled() { return false; };
+
+            virtual void set_call(Call* call) {};
+            virtual void end_call() {};
+        };
+
+    } /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_SIGNAL_DECODER_SINK_H */

--- a/lib/gr_blocks/signal_decoder_sink_impl.cc
+++ b/lib/gr_blocks/signal_decoder_sink_impl.cc
@@ -168,9 +168,15 @@ namespace gr {
 
         void signal_decoder_sink_impl::log_decoder_msg(long unitId, const char* system_type, bool emergency)
         {
-            if (d_current_call == NULL) return;
-
-            d_current_call->add_signal_source(unitId, system_type, emergency);
+            if (d_current_call == NULL)
+            {
+                BOOST_LOG_TRIVIAL(error) << "Unable to log: " << system_type << " : " << unitId << ", no current call.";
+            }
+            else
+            {
+                BOOST_LOG_TRIVIAL(error) << "Logging " << system_type << " : " << unitId << " to current call.";
+                d_current_call->add_signal_source(unitId, system_type, emergency);
+            }
         }
 
         void signal_decoder_sink_impl::set_call(Call* call) {

--- a/lib/gr_blocks/signal_decoder_sink_impl.cc
+++ b/lib/gr_blocks/signal_decoder_sink_impl.cc
@@ -1,0 +1,194 @@
+/* -*- c++ -*- */
+
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif // ifdef HAVE_CONFIG_H
+
+#include "signal_decoder_sink.h"
+#include "signal_decoder_sink_impl.h"
+#include <gnuradio/io_signature.h>
+#include <stdexcept>
+#include <climits>
+#include <cstring>
+#include <cmath>
+#include <fcntl.h>
+#include <gnuradio/thread/thread.h>
+#include <boost/math/special_functions/round.hpp>
+#include <stdio.h>
+
+#include "mdc_decode.h"
+#include "fsync_decode.h"
+#include "star_decode.h"
+
+namespace gr {
+    namespace blocks {
+
+        void mdc_callback(int frameCount, // 1 or 2 - if 2 then extra0-3 are valid
+            unsigned char op,
+            unsigned char arg,
+            unsigned short unitID,
+            unsigned char extra0,
+            unsigned char extra1,
+            unsigned char extra2,
+            unsigned char extra3,
+            void* context) {
+            char json_buffer[2048];
+            snprintf(json_buffer, sizeof(json_buffer), "{\"type\":\"MDC1200\","\
+                "\"timestamp\":\"%d\","\
+                "\"op\":\"%02x\","\
+                "\"arg\":\"%02x\","\
+                "\"unitID\":\"%04x\","\
+                "\"ex0\":\"%02x\","\
+                "\"ex1\":\"%02x\","\
+                "\"ex2\":\"%02x\","\
+                "\"ex3\":\"%02x\"}\n", (int)time(NULL), op, arg, unitID, extra0, extra1, extra2, extra3);
+
+            fprintf(stdout, "%s\n", json_buffer);
+
+            signal_decoder_sink_impl* decoder = (signal_decoder_sink_impl*)context;
+            decoder->log_decoder_msg(unitID, "MDC1200", op == 0x00);
+        }
+
+        void fsync_callback(int cmd, int subcmd, int from_fleet, int from_unit, int to_fleet, int to_unit, int allflag, unsigned char* payload, int payload_len, unsigned char* raw_msg, int raw_msg_len, void* context, int is_fsync2, int is_2400) {
+            char json_buffer[2048];
+            snprintf(json_buffer, sizeof(json_buffer), "{\"type\":\"FLEETSYNC\","\
+                "\"timestamp\":\"%d\","\
+                "\"cmd\":\"%d\","\
+                "\"subcmd\":\"%d\","\
+                "\"from_fleet\":\"%d\","\
+                "\"from_unit\":\"%d\","\
+                "\"to_fleet\":\"%d\","\
+                "\"to_unit\":\"%d\","\
+                "\"all_flag\":\"%d\","\
+                "\"payload\":\"%.*s\","\
+                "\"fsync2\":\"%d\","\
+                "\"2400\":\"%d\"}\n", (int)time(NULL), cmd, subcmd, from_fleet, from_unit, \
+                to_fleet, to_unit, allflag, \
+                payload_len, payload, \
+                is_fsync2, is_2400);
+            fprintf(stdout, "%s\n", json_buffer);
+
+            signal_decoder_sink_impl* decoder = (signal_decoder_sink_impl*)context;
+            decoder->log_decoder_msg(from_unit, "FLEETSYNC", false);
+        }
+
+        void star_callback(int unitID, int tag, int status, int message, void* context) {
+            char json_buffer[2048];
+            snprintf(json_buffer, sizeof(json_buffer), "{\"type\":\"STAR\","\
+                "\"timestamp\":\"%d\","\
+                "\"unitID\":\"%d\","\
+                "\"tag\":\"%d\","\
+                "\"status\":\"%d\","\
+                "\"message\":\"%d\"}\n", (int)time(NULL), unitID, tag, status, message);
+            fprintf(stdout, "%s\n", json_buffer);
+
+            signal_decoder_sink_impl* decoder = (signal_decoder_sink_impl*)context;
+            decoder->log_decoder_msg(unitID, "STAR", false);
+        }
+
+        signal_decoder_sink_impl::sptr
+            signal_decoder_sink_impl::make(unsigned int sample_rate)
+        {
+            return gnuradio::get_initial_sptr
+            (new signal_decoder_sink_impl(sample_rate));
+        }
+
+        signal_decoder_sink_impl::signal_decoder_sink_impl(unsigned int sample_rate)
+            : sync_block("signal_decoder_sink_impl",
+                io_signature::make(1, 1, sizeof(float)),
+                io_signature::make(0, 0, 0)),
+            d_mdc_enabled(false),
+            d_fsync_enabled(false),
+            d_star_enabled(false)
+        {
+            d_mdc_decoder = mdc_decoder_new(sample_rate);
+            d_fsync_decoder = fsync_decoder_new(sample_rate);
+            d_star_decoder = star_decoder_new(sample_rate);
+
+            mdc_decoder_set_callback(d_mdc_decoder, mdc_callback, this);
+            fsync_decoder_set_callback(d_fsync_decoder, fsync_callback, this);
+            star_decoder_set_callback(d_star_decoder, star_format_1_16383, star_callback, this);
+        }
+
+        void signal_decoder_sink_impl::set_mdc_enabled(bool b) { d_mdc_enabled = b; };
+        void signal_decoder_sink_impl::set_fsync_enabled(bool b) { d_fsync_enabled = b; };
+        void signal_decoder_sink_impl::set_star_enabled(bool b) { d_star_enabled = b; };
+
+        bool signal_decoder_sink_impl::get_mdc_enabled() { return d_mdc_enabled; };
+        bool signal_decoder_sink_impl::get_fsync_enabled() { return d_fsync_enabled; };
+        bool signal_decoder_sink_impl::get_star_enabled() { return d_star_enabled; };
+
+        int signal_decoder_sink_impl::work(int noutput_items, gr_vector_const_void_star& input_items, gr_vector_void_star& output_items) {
+
+            gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this
+
+            return dowork(noutput_items, input_items, output_items);
+        }
+
+        int signal_decoder_sink_impl::dowork(int noutput_items, gr_vector_const_void_star& input_items, gr_vector_void_star& output_items) {
+
+            if (d_mdc_enabled)
+            {
+                mdc_decoder_process_samples(d_mdc_decoder, (float *)input_items[0], noutput_items);
+            }
+
+            if (d_fsync_enabled)
+            {
+                fsync_decoder_process_samples(d_fsync_decoder, (float *)input_items[0], noutput_items);
+            }
+
+            if (d_star_enabled)
+            {
+                star_decoder_process_samples(d_star_decoder, (float *)input_items[0], noutput_items);
+            }
+
+            return noutput_items;
+        }
+
+        void signal_decoder_sink_impl::log_decoder_msg(long unitId, const char* system_type, bool emergency)
+        {
+            if (d_current_call == NULL) return;
+
+            d_current_call->add_signal_source(unitId, system_type, emergency);
+        }
+
+        void signal_decoder_sink_impl::set_call(Call* call) {
+            d_current_call = call;
+
+            if (d_current_call == NULL) {
+                d_mdc_enabled = false;
+                d_fsync_enabled = false;
+                d_star_enabled = false;
+            }
+            else {
+                d_mdc_enabled = d_current_call->get_system()->get_mdc_enabled();
+                d_fsync_enabled = d_current_call->get_system()->get_fsync_enabled();
+                d_star_enabled = d_current_call->get_system()->get_star_enabled();
+            }
+        }
+        void signal_decoder_sink_impl::end_call() {
+            set_call(NULL);
+        }
+    } /* namespace blocks */
+} /* namespace gr */

--- a/lib/gr_blocks/signal_decoder_sink_impl.h
+++ b/lib/gr_blocks/signal_decoder_sink_impl.h
@@ -1,0 +1,88 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GR_SIGNAL_DECODER_SINK_IMPL_H
+#define INCLUDED_GR_SIGNAL_DECODER_SINK_IMPL_H
+
+#include "signal_decoder_sink.h"
+#include <boost/log/trivial.hpp>
+
+#include "mdc_decode.h"
+#include "fsync_decode.h"
+#include "star_decode.h"
+
+namespace gr {
+	namespace blocks {
+
+		class signal_decoder_sink_impl : public signal_decoder_sink
+		{
+		private:
+			mdc_decoder_t * d_mdc_decoder;
+			fsync_decoder_t * d_fsync_decoder;
+			star_decoder_t * d_star_decoder;
+			Call * d_current_call;
+
+			bool d_mdc_enabled;
+			bool d_fsync_enabled;
+			bool d_star_enabled;
+
+		protected:
+
+			boost::mutex d_mutex;
+			virtual int dowork(int noutput_items, gr_vector_const_void_star& input_items, gr_vector_void_star& output_items);
+
+		public:
+
+			typedef boost::shared_ptr <signal_decoder_sink_impl> sptr;
+
+			/*
+			 * \param filename The .wav file to be opened
+			 * \param n_channels Number of channels (2 = stereo or I/Q output)
+			 * \param sample_rate Sample rate [S/s]
+			 * \param bits_per_sample 16 or 8 bit, default is 16
+			 */
+			static sptr make(unsigned int sample_rate);
+
+			signal_decoder_sink_impl(unsigned int sample_rate);
+
+			virtual int work(int noutput_items,
+				gr_vector_const_void_star& input_items,
+				gr_vector_void_star& output_items);
+
+			void set_mdc_enabled(bool b);
+			void set_fsync_enabled(bool b);
+			void set_star_enabled(bool b);
+
+			bool get_mdc_enabled();
+			bool get_fsync_enabled();
+			bool get_star_enabled();
+
+			void set_call(Call* call);
+			void end_call();
+
+			void log_decoder_msg(long unitId, const char* system_type, bool emergency);
+		};
+
+	} /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_SIGNAL_DECODER_SINK_IMPL_H */

--- a/lib/gr_blocks/star_common.h
+++ b/lib/gr_blocks/star_common.h
@@ -1,0 +1,52 @@
+/*-
+ * star_common.h
+ *  common header for star_encode.h, star_decode.h
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2012  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's STAR Encoder/Decoder Library
+ *
+ *  The STAR Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The STAR Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#ifndef __STAR_COMMON_H__
+#define __STAR_COMMON_H__
+
+#ifndef TWOPI
+ #define TWOPI (2.0 * 3.1415926535)
+#endif
+
+
+typedef enum _star_format {
+	star_format_1,			// t1, t2, and s1 do not contribute to unit ID - original format, IDs to 2047
+	star_format_1_4095,		// t1 = 2048, t2 used for mobile/portable, s1 ignored
+	star_format_1_16383,	// t1 = 8192, t2 = 4096, s1 = 2048 used to allow unit IDs to 16383 -- most typical
+	star_format_sys,		// t1,t2 used for system ID, s1 = 2048
+	star_format_2,			// t1 = 4096, t2 = mobile/portable, s1 = 2048
+	star_format_3,			// t1 = 4096, t2 = 8192, s1 = 2048
+	star_format_4			// t1 = 4096, t2 = 2048, s1 = 8192
+} star_format;
+
+#endif

--- a/lib/gr_blocks/star_decode.cc
+++ b/lib/gr_blocks/star_decode.cc
@@ -1,0 +1,417 @@
+
+/*-
+ * star_decode.c
+ *  implementation of a 1600 Hz carrier, 400 bps PSK decoder
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2012  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's STAR Encoder/Decoder Library
+ *
+ *  The STAR Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The STAR Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#include <stdlib.h> // for malloc
+
+#include "star_types.h"
+#include "star_decode.h"
+
+static star_float_t _sintable[] = {
+	 0.000000,  0.024541,  0.049068,  0.073565,  0.098017,  0.122411,  0.146730,  0.170962,
+	 0.195090,  0.219101,  0.242980,  0.266713,  0.290285,  0.313682,  0.336890,  0.359895,
+	 0.382683,  0.405241,  0.427555,  0.449611,  0.471397,  0.492898,  0.514103,  0.534998,
+	 0.555570,  0.575808,  0.595699,  0.615232,  0.634393,  0.653173,  0.671559,  0.689541,
+	 0.707107,  0.724247,  0.740951,  0.757209,  0.773010,  0.788346,  0.803208,  0.817585,
+	 0.831470,  0.844854,  0.857729,  0.870087,  0.881921,  0.893224,  0.903989,  0.914210,
+	 0.923880,  0.932993,  0.941544,  0.949528,  0.956940,  0.963776,  0.970031,  0.975702,
+	 0.980785,  0.985278,  0.989177,  0.992480,  0.995185,  0.997290,  0.998795,  0.999699,
+	 1.000000,  0.999699,  0.998795,  0.997290,  0.995185,  0.992480,  0.989177,  0.985278,
+	 0.980785,  0.975702,  0.970031,  0.963776,  0.956940,  0.949528,  0.941544,  0.932993,
+	 0.923880,  0.914210,  0.903989,  0.893224,  0.881921,  0.870087,  0.857729,  0.844854,
+	 0.831470,  0.817585,  0.803208,  0.788346,  0.773010,  0.757209,  0.740951,  0.724247,
+	 0.707107,  0.689541,  0.671559,  0.653173,  0.634393,  0.615232,  0.595699,  0.575808,
+	 0.555570,  0.534998,  0.514103,  0.492898,  0.471397,  0.449611,  0.427555,  0.405241,
+	 0.382683,  0.359895,  0.336890,  0.313682,  0.290285,  0.266713,  0.242980,  0.219101,
+	 0.195090,  0.170962,  0.146730,  0.122411,  0.098017,  0.073565,  0.049068,  0.024541,
+	 0.000000, -0.024541, -0.049068, -0.073565, -0.098017, -0.122411, -0.146730, -0.170962,
+	-0.195090, -0.219101, -0.242980, -0.266713, -0.290285, -0.313682, -0.336890, -0.359895,
+	-0.382683, -0.405241, -0.427555, -0.449611, -0.471397, -0.492898, -0.514103, -0.534998,
+	-0.555570, -0.575808, -0.595699, -0.615232, -0.634393, -0.653173, -0.671559, -0.689541,
+	-0.707107, -0.724247, -0.740951, -0.757209, -0.773010, -0.788346, -0.803208, -0.817585,
+	-0.831470, -0.844854, -0.857729, -0.870087, -0.881921, -0.893224, -0.903989, -0.914210,
+	-0.923880, -0.932993, -0.941544, -0.949528, -0.956940, -0.963776, -0.970031, -0.975702,
+	-0.980785, -0.985278, -0.989177, -0.992480, -0.995185, -0.997290, -0.998795, -0.999699,
+	-1.000000, -0.999699, -0.998795, -0.997290, -0.995185, -0.992480, -0.989177, -0.985278,
+	-0.980785, -0.975702, -0.970031, -0.963776, -0.956940, -0.949528, -0.941544, -0.932993,
+	-0.923880, -0.914210, -0.903989, -0.893224, -0.881921, -0.870087, -0.857729, -0.844854,
+	-0.831470, -0.817585, -0.803208, -0.788346, -0.773010, -0.757209, -0.740951, -0.724247,
+	-0.707107, -0.689541, -0.671559, -0.653173, -0.634393, -0.615232, -0.595699, -0.575808,
+	-0.555570, -0.534998, -0.514103, -0.492898, -0.471397, -0.449611, -0.427555, -0.405241,
+	-0.382683, -0.359895, -0.336890, -0.313682, -0.290285, -0.266713, -0.242980, -0.219101,
+	-0.195090, -0.170962, -0.146730, -0.122411, -0.098017, -0.073565, -0.049068, -0.024541 };
+
+static star_u32_t _star_crc(star_u32_t input)
+{
+	star_u32_t crcsr;
+	star_int_t bit;
+	star_u32_t cur;
+	star_int_t inv;
+
+	crcsr = 0x2a;
+	for (bit = 6; bit < (21 + 6); bit++)
+	{
+		cur = (input >> (32 - bit)) & 0x01;
+		inv = cur ^ (0x01 & (crcsr >> 5));
+		crcsr <<= 1;
+		if (inv)
+			crcsr ^= 0x2f;
+	}
+
+	return crcsr & 0x3f;
+}
+
+static void _reset_decoder(star_decoder_t *dec, star_int_t num)
+{
+
+	dec->phsr[num] = 0;
+	dec->phstate[num] = 0;
+	dec->lastbit[num] = 0;
+	dec->rbit[num] = 0;
+	dec->accum[num] = 0.0;
+	dec->bitsr[num] = 0;
+	dec->bitstate[num] = 0;
+}
+
+static void _bitshift(star_decoder_t *dec, star_int_t num, star_int_t b)
+{
+	star_int_t i;
+
+	dec->bitsr[num] <<= 1;
+	dec->bitsr[num] |= b;
+
+	switch(dec->bitstate[num])
+	{
+	case 0:
+		if((dec->bitsr[num] & 0x001f) == 0x0e)
+		{
+			dec->bitstate[num] = 1;
+			dec->bitcount[num] = 32-5;
+		}
+		else if((dec->bitsr[num] & 0x001f) == 0x11)
+		{
+			dec->bitsr[num] ^= 0x1f;
+			dec->bitstate[num] = 1;
+			dec->bitcount[num] = 32-5;
+			dec->rbit[num] ^= 1;
+		}
+		break;
+	case 1:
+		if(--dec->bitcount[num] == 0)
+		{
+			dec->bits0[num] = dec->bitsr[num];
+			dec->bitstate[num] = 2;
+			dec->bitcount[num] = 32;
+		}
+		break;
+	case 2:
+		if(--dec->bitcount[num] == 0)
+		{
+			dec->bits1[num] = dec->bitsr[num];
+			dec->bitstate[num] = 3;
+			dec->bitcount[num] = 16;
+		}
+		break;
+	case 3:
+		if(--dec->bitcount[num] == 0)
+		{
+			dec->bits2[num] = dec->bitsr[num];
+			dec->bits2[num] <<= 16;
+			dec->bitstate[num] = 4; // unless we all get reset after success of this one
+
+			// XXX TODO: smarter logic in here about making the best of the bits we get in error cases
+			if((dec->bits0[num] & 0x07ff0000) == ((~(dec->bits1[num])) & 0x07ff0000)) // 1fff0000 mod rbit
+			{
+
+				if(_star_crc(dec->bits0[num]) == (dec->bits0[num] & 0x3f) && ((dec->bits0[num] & 0x3f) == (dec->bits1[num] & 0x3f)))
+				{
+					// printf("decoder %d got %08x %08x %04x\n",num,dec->bits0[num],dec->bits1[num],dec->bits2[num] >> 16);
+					// printf("unit id %d\n",(dec->bits0[num] >> 16) & 0x07ff);
+
+					dec->valid = 1;
+					dec->lastBits0 = dec->bits0[num];
+
+					for(i=0; i<NDEC; i++)
+						_reset_decoder(dec, i);
+				} 
+			} 
+
+		}
+		break;
+	case 4:
+		// we get here if this decoder processed all the bits it could and it wasn't a success
+		_reset_decoder(dec, num);
+		break;
+	}
+}
+
+static void _ph_shift(star_decoder_t *dec, star_int_t num, star_int_t ph)
+{
+	star_int_t x;
+	dec->phsr[num] <<= 1;
+	dec->phsr[num] |= ph;
+
+	switch(dec->phstate[num])
+	{
+	case 0:
+		if((dec->phsr[num] & 0xffffffff) == 0xf0f0f0f0)   // relax to allow even shorter preamble?
+		{
+			dec->phstate[num] = 1;
+			dec->bitstate[num] = 0;
+		}
+		break;
+	case 1:
+		dec->phstate[num] = 2;
+		break;
+	case 2:
+		dec->phstate[num] = 3;
+		break;
+	case 3:
+		dec->phstate[num] = 4;
+		break;
+	case 4:
+		x = dec->phsr[num] & 0x01;
+		x+= (dec->phsr[num] >> 1) & 0x01;
+		x+= (dec->phsr[num] >> 2) & 0x01;
+		x+= (dec->phsr[num] >> 3) & 0x01;
+		
+		if(x > 2)
+			dec->thisbit[num] = 0x01;
+		else
+			dec->thisbit[num] = 0x00;
+
+		if(dec->thisbit[num] ^ dec->lastbit[num])
+			dec->rbit[num] ^= 0x01;
+		_bitshift(dec, num, dec->rbit[num]);
+		dec->lastbit[num] = dec->thisbit[num];
+		dec->phstate[num] = 1;
+		break;
+	}
+}
+
+
+static void _process_sample_per(star_decoder_t *dec, star_int_t num, star_float_t s)
+{
+	star_int_t ofs;
+
+	dec->theta[num] += (TWOPI * 1600.0) / dec->sampleRate;
+
+	ofs = (star_int_t) (dec->theta[num] * (256.0 / TWOPI));
+	dec->accum[num] += (_sintable[ofs] * s);
+
+	if(dec->theta[num] >= TWOPI)
+	{
+		if(dec->accum[num] < 0.0)
+			_ph_shift(dec,num,0);
+		else
+			_ph_shift(dec,num,1);
+
+		dec->theta[num] -= TWOPI;
+		dec->accum[num] = 0.0;
+	}
+}
+
+static void _process_sample(star_decoder_t *dec, star_float_t s)
+{
+	star_int_t i;
+	for(i=0; i<NDEC; i++)
+	{
+		_process_sample_per(dec, i, s);
+	}
+}
+
+
+// public API
+
+star_decoder_t * star_decoder_new(int sampleRate)
+{
+	star_decoder_t *dec;
+	star_int_t i;
+
+	dec = (star_decoder_t *)malloc(sizeof(star_decoder_t));
+
+	if(dec)
+	{
+
+		dec->sampleRate = (star_float_t)sampleRate;
+		dec->valid = 0;
+		for(i=0; i<NDEC; i++)
+		{
+			dec->theta[i] = THINCR * ((star_float_t)i);
+			_reset_decoder(dec, i);
+		}
+
+		dec->callback = (star_decoder_callback_t)0;
+	}
+	return dec;
+}
+
+int star_decoder_process_samples(star_decoder_t *decoder, star_sample_t *samples, int sampleCount)
+{
+	star_int_t i;
+	star_float_t value;
+	star_sample_t sample;
+
+	if(!decoder)
+		return -1;
+
+	for(i=0; i<sampleCount; i++)
+	{
+		sample = samples[i];
+
+#if defined(STAR_SAMPLE_FORMAT_U8)
+        value = (((star_float_t)sample) - 128.0)/256;
+#elif defined(STAR_SAMPLE_FORMAT_U16)
+        value = (((star_float_t)sample) - 32768.0)/65536.0;
+#elif defined(STAR_SAMPLE_FORMAT_S16)
+        value = ((star_float_t)sample) / 65536.0;
+#elif defined(STAR_SAMPLE_FORMAT_FLOAT)
+        value = sample;
+#else
+#error "no known sample format set"
+#endif
+
+		_process_sample(decoder, value);
+
+		if(decoder->valid && decoder->callback)
+		{
+			int unitID, tag, status, message;
+
+			if(-1 != star_decoder_get(decoder, decoder->callback_format, &unitID, &tag, &status, &message))
+			{
+				decoder->callback(unitID, tag, status, message, decoder->callback_context);
+			}
+		}
+	}
+	return decoder->valid;
+}
+
+int star_decoder_get(star_decoder_t *decoder, star_format format, int *_unitID, int *_tag, int *_status, int *_message)
+{
+	if(!decoder)
+		return -1;
+
+	if(decoder->valid)
+	{
+		int unitID = (decoder->lastBits0 >> 16) & 0x07ff;
+		int tag = (decoder->lastBits0  >> 14) & 0x03;
+		int status = (decoder->lastBits0  >> 10) & 0x0f;
+		int message = (decoder->lastBits0  >> 6) & 0x0f;
+
+		switch(format)
+		{
+		case star_format_1:	// t1, t2, and s1 do not contribute to unit ID - original format, IDs to 2047
+			break;
+
+		case star_format_1_4095: // t1 = 2048, t2 used for mobile/portable, s1 ignored
+			if(tag & 0x02)
+				unitID += 2048;
+			status &= 0x07;
+			break;
+		case star_format_1_16383:  // t1 = 8192, t2 = 4096, s1 = 2048 used to allow unit IDs to 16383 -- most typical
+			if(tag & 0x02)
+				unitID += 8192;
+			if(tag & 0x01)
+				unitID += 4096;
+			if(status & 0x08)
+				unitID += 2048;
+			status &= 0x07;
+			tag = 0;
+			break;
+		case star_format_sys:	// t1,t2 used for system ID, s1 = 2048
+			if(status & 0x08)
+				unitID += 2048;
+			status &= 0x07;
+			break;
+		case star_format_2:  // t1 = 4096, t2 = mobile/portable, s1 = 2048
+			if(tag & 0x02)
+				unitID += 4096;
+			tag &= 0x01;
+			if(status & 0x08)
+				unitID += 2048;
+			status &= 0x07;
+			break;
+		case star_format_3:  // t1 = 4096, t2 = 8192, s1 = 2048
+			if(tag & 0x02)
+				unitID += 4096;
+			if(tag & 0x01)
+				unitID += 8192;
+			tag = 0;
+			if(status & 0x08)
+				unitID += 2048;
+			status &= 0x07;
+			break;
+		case star_format_4:  // t1 = 4096, t2 = 2048, s1 = 8192
+			if(tag & 0x02)
+				unitID += 4096;
+			if(tag & 0x01)
+				unitID += 2048;
+			tag = 0;
+			if(status & 0x08)
+				unitID += 8192;
+			status &= 0x07;
+			break;
+		default:
+			return -1;
+		}
+
+		if(_unitID)
+			*_unitID = unitID;
+		if(_tag)
+			*_tag = tag;
+		if(_status)
+			*_status = status;
+		if(_message)
+			*_message = message;
+
+		decoder->valid = 0;
+	}
+	else
+	{
+		return -1;
+	}
+
+	return 0;
+}
+
+ int star_decoder_set_callback(star_decoder_t *decoder, star_format callback_format, star_decoder_callback_t callbackFunction, void *context)
+ {
+ 	if(!decoder)
+ 		return -1;
+
+ 	decoder->callback = callbackFunction;
+ 	decoder->callback_format = callback_format;
+	decoder->callback_context = context;
+
+ 	return 0;
+ }

--- a/lib/gr_blocks/star_decode.h
+++ b/lib/gr_blocks/star_decode.h
@@ -1,0 +1,132 @@
+
+/*-
+ * star_decode.h
+ *  header for star_decode.c
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2012  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's STAR Encoder/Decoder Library
+ *
+ *  The STAR Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The STAR Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#ifndef __STAR_DECODE_H__
+#define __STAR_DECODE_H__
+
+#include "star_types.h"
+#include "star_common.h"
+
+#define NDEC 4
+#define THINCR (TWOPI / 8)
+
+/*
+ callback function is called based on format set when callback installed
+*/
+
+typedef void (*star_decoder_callback_t)(int unitID, int tag, int status, int message, void *context);
+
+
+typedef struct {
+	star_float_t sampleRate;
+	star_u32_t phsr[NDEC];
+	star_int_t phstate[NDEC];
+	star_int_t lastbit[NDEC];
+	star_int_t thisbit[NDEC];
+	star_int_t rbit[NDEC];
+	star_float_t theta[NDEC];
+	star_float_t accum[NDEC];
+	star_u32_t bitsr[NDEC];
+	star_int_t bitstate[NDEC];
+	star_u32_t bits0[NDEC];
+	star_u32_t bits1[NDEC];
+	star_u32_t bits2[NDEC];
+	star_int_t bitcount[NDEC];
+	star_u32_t lastBits0;
+	star_int_t valid;
+	star_decoder_callback_t callback;
+	star_format callback_format;
+	void * callback_context;
+} star_decoder_t;
+
+
+/*
+ star_decoder_new
+  create a new star_decoder_t object
+
+  parameters: int sampleRate - the sampling rate in Hz
+
+  returns: a star_decoder_t object or null if failure
+ */
+
+star_decoder_t * star_decoder_new(int sampleRate);
+
+/*
+ star_decoder_process_samples
+  process incoming samples using a star_decoder_t object
+
+  parameters: star_deocder_t *decoder - pointer to the decoder object
+              star_sample_t *samples  - pointer to samples (in format set in star_types.h)
+              int sampleCount         - count of number of samples in the buffer
+
+  returns: 0 if more samples are needed
+          -1 if an error occurs
+           1 if a decoded packet is available to read (assuming no callback set)
+*/
+
+int star_decoder_process_samples(star_decoder_t *decoder, star_sample_t *samples, int sampleCount);  // 8 bit version
+
+
+/*
+ star_decoder_get
+  retrieve last successfully decoded packet from decoder object
+
+  parameters: star_decoder_t *decoder - pointer to the decoder object
+              star_format format      - format to apply to interpret bits
+              int *unitID             - pointer to where to store "unid ID"
+              int *tag                - pointer to where to store "tag"
+              int *status             - pointer to where to store "status"
+              int *message            - pointer to where to store "message"
+
+  returns -1 if failure, 0 otherwise
+*/
+
+int star_decoder_get(star_decoder_t *decoder, star_format format, int *unitID, int *tag, int *status, int *message);
+
+/*
+ star_decoder_set_callback
+  set a callback function to be called upon successful decode
+  if this is set, the function star_decoder_get will no longer be functional,
+  instead the callback function is called immediately when a successful decode happens
+  from within the calling context of star_decoder_process_samples()
+  the callback function will use the format set with callback_format
+
+  the callback function will be called with (void *)context as its last parameter
+
+  returns -1 if failure, 0 otherwise
+*/
+
+ int star_decoder_set_callback(star_decoder_t *decoder, star_format callback_format, star_decoder_callback_t callbackFunction, void *context);
+
+#endif

--- a/lib/gr_blocks/star_types.h
+++ b/lib/gr_blocks/star_types.h
@@ -1,0 +1,58 @@
+/*-
+ * star_types.h
+ *  common typedef header for star_encode.h, star_decode.h
+ *
+ * Author: Matthew Kaufman (matthew@eeph.com)
+ *
+ * Copyright (c) 2012  Matthew Kaufman  All rights reserved.
+ * 
+ *  This file is part of Matthew Kaufman's STAR Encoder/Decoder Library
+ *
+ *  The STAR Encoder/Decoder Library is free software; you can
+ *  redistribute it and/or modify it under the terms of version 2 of
+ *  the GNU General Public License as published by the Free Software
+ *  Foundation.
+ *
+ *  If you cannot comply with the terms of this license, contact
+ *  the author for alternative license arrangements or do not use
+ *  or redistribute this software.
+ *
+ *  The STAR Encoder/Decoder Library is distributed in the hope
+ *  that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ *  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this software; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  USA.
+ *
+ *  or see http://www.gnu.org/copyleft/gpl.html
+ *
+-*/
+
+#ifndef _STAR_TYPES_H_
+#define _STAR_TYPES_H_
+
+typedef int star_s32_t;
+typedef unsigned int star_u32_t;
+typedef short star_s16_t;
+typedef unsigned short star_u16_t;
+typedef char star_s8_t;
+typedef unsigned char star_u8_t;
+typedef double star_float_t;
+typedef int star_int_t;
+
+/* to change the data type, set this typedef: */
+typedef float star_sample_t;
+
+/* AND uncomment this to match: */
+/* #define STAR_SAMPLE_FORMAT_U8 */
+/* #define STAR_SAMPLE_FORMAT_S16 */
+/* #define STAR_SAMPLE_FORMAT_U16 */
+#define STAR_SAMPLE_FORMAT_FLOAT
+
+
+#endif
+
+

--- a/trunk-recorder/call.cc
+++ b/trunk-recorder/call.cc
@@ -400,6 +400,8 @@ bool Call::add_signal_source(long src, const char* system_type, bool signal_emer
 
     if (signal_emergency) {
         set_emergency(true);
+
+        BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tEmergency flag set by " << src;
     }
 
     std::string system((system_type == NULL) ? "" : strdup(system_type));
@@ -410,7 +412,7 @@ bool Call::add_signal_source(long src, const char* system_type, bool signal_emer
 
     src_list.push_back(call_source);
 
-    BOOST_LOG_TRIVIAL(info) << "Added " << src << " to source list.";
+    BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tAdded " << src << " to source list\tCalls: " << src_list.size() << "\tTag: " << tag;
 
     return true;
 }

--- a/trunk-recorder/call.h
+++ b/trunk-recorder/call.h
@@ -69,7 +69,7 @@ public:
 								void set_freq(double f);
 								long get_talkgroup();
 								long get_source_count();
-								Call_Source *get_source_list();
+								std::vector<Call_Source> get_source_list();
 								Call_Freq *get_freq_list();
 								Call_Error *get_error_list();
 								long get_error_list_count();
@@ -118,10 +118,9 @@ protected:
 								double curr_freq;
 								System *sys;
 								std::string short_name;
-								int src_count;
 								long curr_src_id;
 								Call_Error error_list[50];
-								Call_Source src_list[50];
+								std::vector<Call_Source> src_list;
 								Call_Freq freq_list[50];
 								long error_list_count;
 								long freq_count;

--- a/trunk-recorder/call.h
+++ b/trunk-recorder/call.h
@@ -2,12 +2,16 @@
 #define CALL_H
 #include <sys/time.h>
 #include <boost/log/trivial.hpp>
+#include <string>
+#include <vector>
 
 struct Call_Source {
-								long source;
-								long time;
-								double position;
-
+	long source;
+	long time;
+	double position;
+	bool emergency;
+	std::string signal_system;
+	std::string tag;
 };
 
 struct Call_Freq {
@@ -33,8 +37,6 @@ class Recorder;
 #include "state.h"
 #include "systems/system.h"
 #include "systems/parser.h"
-#include <string>
-
 
 class System;
 //enum  CallState { monitoring=0, recording=1, stopping=2};
@@ -103,9 +105,13 @@ public:
 								void set_talkgroup_display_format(std::string format);
 								void set_talkgroup_tag(std::string tag);
 								boost::property_tree::ptree get_stats();
+
+								bool add_signal_source(long src, const char* system_type, bool signal_emergency);
 								
 								std::string get_talkgroup_tag();
 								double get_final_length();
+
+								System* get_system();
 protected:
 								State state;
 								long talkgroup;
@@ -144,7 +150,6 @@ protected:
 								std::string talkgroup_display;
 								std::string talkgroup_tag;
 								void update_talkgroup_display();
-
 };
 
 #endif

--- a/trunk-recorder/call_conventional.cc
+++ b/trunk-recorder/call_conventional.cc
@@ -14,7 +14,6 @@ Call_conventional::~Call_conventional() {
 void Call_conventional::restart_call() {
     idle_count       = 0;
     freq_count       = 0;
-    src_count        = 0;
     error_list_count = 0;
     curr_src_id      = 0;
     start_time       = time(NULL);

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -75,8 +75,16 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       BOOST_LOG_TRIVIAL(info) << "Audio Archive: " << system->get_audio_archive();
       system->set_talkgroups_file(node.second.get<std::string>("talkgroupsFile", ""));
       BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << system->get_talkgroups_file();
+      system->set_unit_tags_file(node.second.get<std::string>("unitTagsFile", ""));
+      BOOST_LOG_TRIVIAL(info) << "Unit Tags File: " << system->get_unit_tags_file();
       system->set_record_unknown(node.second.get<bool>("recordUnknown", true));
       BOOST_LOG_TRIVIAL(info) << "Record Unknown Talkgroups: " << system->get_record_unknown();
+      system->set_mdc_enabled(node.second.get<bool>("decodeMDC", false));
+      BOOST_LOG_TRIVIAL(info) << "Decode MDC: " << system->get_mdc_enabled();
+      system->set_fsync_enabled(node.second.get<bool>("decodeFSync", false));
+      BOOST_LOG_TRIVIAL(info) << "Decode FSync: " << system->get_fsync_enabled();
+      system->set_star_enabled(node.second.get<bool>("decodeStar", false));
+      BOOST_LOG_TRIVIAL(info) << "Decode Star: " << system->get_star_enabled();
       system->set_min_duration(node.second.get<double>("minDuration", 0));
       BOOST_LOG_TRIVIAL(info) << "Minimum Call Duration (in seconds): " << system->get_min_duration();
       systems.push_back(system);

--- a/trunk-recorder/csv_helper.cc
+++ b/trunk-recorder/csv_helper.cc
@@ -1,0 +1,41 @@
+#include "csv_helper.h"
+
+// Retrieved from
+// https://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
+std::istream& safeGetline(std::istream& is, std::string& t) {
+    t.clear();
+
+    // The characters in the stream are read one-by-one using a std::streambuf.
+    // That is faster than reading them one-by-one using the std::istream.
+    // Code that uses streambuf this way must be guarded by a sentry object.
+    // The sentry object performs various tasks,
+    // such as thread synchronization and updating the stream state.
+
+    std::istream::sentry se(is, true);
+    std::streambuf* sb = is.rdbuf();
+
+    for (;;) {
+        int c = sb->sbumpc();
+
+        switch (c) {
+        case '\n':
+            return is;
+
+        case '\r':
+
+            if (sb->sgetc() == '\n')
+                sb->sbumpc();
+            return is;
+
+        case EOF:
+
+            // Also handle the case when the last line has no line ending
+            if (t.empty())
+                is.setstate(std::ios::eofbit);
+            return is;
+
+        default:
+            t += (char)c;
+        }
+    }
+}

--- a/trunk-recorder/csv_helper.h
+++ b/trunk-recorder/csv_helper.h
@@ -1,0 +1,18 @@
+#ifndef _CSV_HELPER_H_
+#define _CSV_HELPER_H_
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/tokenizer.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+std::istream& safeGetline(std::istream& is, std::string& t);
+
+#endif // _CSV_HELPER_H_

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -243,8 +243,16 @@ void load_config(string config_file)
       BOOST_LOG_TRIVIAL(info) << "Audio Archive: " << system->get_audio_archive();
       system->set_talkgroups_file(node.second.get<std::string>("talkgroupsFile", ""));
       BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << system->get_talkgroups_file();
+      system->set_unit_tags_file(node.second.get<std::string>("unitTagsFile", ""));
+      BOOST_LOG_TRIVIAL(info) << "Unit Tags File: " << system->get_unit_tags_file();
       system->set_record_unknown(node.second.get<bool>("recordUnknown", true));
       BOOST_LOG_TRIVIAL(info) << "Record Unknown Talkgroups: " << system->get_record_unknown();
+      system->set_mdc_enabled(node.second.get<bool>("decodeMDC", false));
+      BOOST_LOG_TRIVIAL(info) << "Decode MDC: " << system->get_mdc_enabled();
+      system->set_fsync_enabled(node.second.get<bool>("decodeFSync", false));
+      BOOST_LOG_TRIVIAL(info) << "Decode FSync: " << system->get_fsync_enabled();
+      system->set_star_enabled(node.second.get<bool>("decodeStar", false));
+      BOOST_LOG_TRIVIAL(info) << "Decode Star: " << system->get_star_enabled();
       std::string talkgroup_display_format_string = node.second.get<std::string>("talkgroupDisplayFormat", "Id");
       if (boost::iequals(talkgroup_display_format_string, "id_tag")){
         system->set_talkgroup_display_format(System::talkGroupDisplayFormat_id_tag);

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -2,6 +2,8 @@
 #include "analog_recorder.h"
 #include "../formatter.h"
 #include "../../lib/gr_blocks/nonstop_wavfile_sink_impl.h"
+#include "../../lib/gr_blocks/signal_decoder_sink_impl.h"
+
 using namespace std;
 
 bool analog_recorder::logging = false;
@@ -165,6 +167,8 @@ analog_recorder::analog_recorder(Source *src)
 
   wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, 8000, 16, true);
 
+  decoder_sink = gr::blocks::signal_decoder_sink_impl::make(8000);
+
   // Try and get rid of the FSK wobble
   high_f_taps =  gr::filter::firdes::high_pass(1, 8000, 300, 50, gr::filter::firdes::WIN_HANN);
   high_f      = gr::filter::fir_filter_fff::make(1, high_f_taps);
@@ -181,6 +185,7 @@ analog_recorder::analog_recorder(Source *src)
     connect(demod,         0, deemph,        0);
     connect(deemph,        0, decim_audio,   0);
     connect(decim_audio,   0, high_f,        0);
+    connect(decim_audio,   0, decoder_sink,  0);
     connect(high_f,        0, squelch_two,   0);
     connect(squelch_two,   0, levels,        0);
     connect(levels,        0, wav_sink,      0);
@@ -194,6 +199,7 @@ analog_recorder::analog_recorder(Source *src)
     connect(demod,         0, deemph,        0);
     connect(deemph,        0, decim_audio,   0);
     connect(decim_audio,   0, levels,        0);
+    connect(decim_audio,   0, decoder_sink,  0);
     connect(levels,        0, wav_sink,      0);
   }
 }
@@ -217,6 +223,10 @@ void analog_recorder::stop() {
 
     BOOST_LOG_TRIVIAL(error) << "analog_recorder.cc: Stopping an inactive Logger \t[ " << rec_num << " ] - freq[ " << FormatFreq(chan_freq) << "] \t talkgroup[ " << talkgroup << " ]";
   }
+
+  decoder_sink->set_mdc_enabled(false);
+  decoder_sink->set_fsync_enabled(false);
+  decoder_sink->set_star_enabled(false);
 }
 
 bool analog_recorder::is_analog() {
@@ -278,6 +288,10 @@ void analog_recorder::tune_offset(double f) {
 
 void analog_recorder::start(Call *call) {
   starttime = time(NULL);
+
+  decoder_sink->set_mdc_enabled(call->get_system()->get_mdc_enabled());
+  decoder_sink->set_fsync_enabled(call->get_system()->get_fsync_enabled());
+  decoder_sink->set_star_enabled(call->get_system()->get_star_enabled());
 
   talkgroup = call->get_talkgroup();
   chan_freq = call->get_freq();

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -43,7 +43,7 @@ class analog_recorder;
 #include "../config.h"
 #include <gr_blocks/nonstop_wavfile_sink.h>
 #include <gr_blocks/freq_xlating_fft_filter.h>
-
+#include <gr_blocks/signal_decoder_sink.h>
 
 typedef boost::shared_ptr<analog_recorder>analog_recorder_sptr;
 
@@ -129,6 +129,8 @@ void calculate_iir_taps(double tau);
 
   gr::blocks::nonstop_wavfile_sink::sptr wav_sink;
   gr::blocks::copy::sptr valve;
+
+  gr::blocks::signal_decoder_sink::sptr decoder_sink;
 };
 
 #endif // ifndef ANALOG_RECORDER_H

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -44,9 +44,14 @@ System::System(int sys_num) {
   xor_mask = NULL;
   // Setup the talkgroups from the CSV file
   talkgroups = new Talkgroups();
+  // Setup the unit tags from the CSV file
+  unit_tags = new UnitTags();
   d_delaycreateoutput = false;
   d_hideEncrypted = false;
   d_hideUnknown = false;
+  d_mdc_enabled = false;
+  d_fsync_enabled = false;
+  d_star_enabled = false;
   retune_attempts = 0;
   message_count = 0;
 }
@@ -120,6 +125,14 @@ void System::set_call_log(bool call_log) {
   this->call_log = call_log;
 }
 
+void System::set_mdc_enabled(bool b) { d_mdc_enabled = b; };
+void System::set_fsync_enabled(bool b) { d_fsync_enabled = b; };
+void System::set_star_enabled(bool b) { d_star_enabled = b; };
+
+bool System::get_mdc_enabled() { return d_mdc_enabled; };
+bool System::get_fsync_enabled() { return d_fsync_enabled; };
+bool System::get_star_enabled() { return d_star_enabled; };
+
 bool System::get_audio_archive() {
   return this->audio_archive;
 }
@@ -149,10 +162,20 @@ std::string System::get_talkgroups_file() {
   return this->talkgroups_file;
 }
 
+std::string System::get_unit_tags_file() {
+    return this->unit_tags_file;
+}
+
 void System::set_talkgroups_file(std::string talkgroups_file) {
   BOOST_LOG_TRIVIAL(info) << "Loading Talkgroups...";
   this->talkgroups_file = talkgroups_file;
   this->talkgroups->load_talkgroups(talkgroups_file);
+}
+
+void System::set_unit_tags_file(std::string unit_tags_file) {
+    BOOST_LOG_TRIVIAL(info) << "Loading Unit Tags...";
+    this->unit_tags_file = unit_tags_file;
+    this->unit_tags->load_unit_tags(unit_tags_file);
 }
 
 Source *System::get_source(){
@@ -165,6 +188,10 @@ void System::set_source(Source *s) {
 
 Talkgroup * System::find_talkgroup(long tg_number) {
   return talkgroups->find_talkgroup(tg_number);
+}
+
+UnitTag * System::find_unit_tag(long unitID) {
+    return unit_tags->find_unit_tag(unitID);
 }
 
 std::vector<double> System::get_channels(){

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <boost/log/trivial.hpp>
 #include "../talkgroups.h"
+#include "../unit_tags.h"
 //#include "../source.h"
 #include "smartnet_trunking.h"
 #include "p25_trunking.h"
@@ -42,9 +43,11 @@ public:
         enum TalkgroupDisplayFormat { talkGroupDisplayFormat_id=0, talkGroupDisplayFormat_id_tag=1, talkGroupDisplayFormat_tag_id=2};
 
         Talkgroups *talkgroups;
+        UnitTags *unit_tags;
         p25p2_lfsr *lfsr;
         Source *source;
         std::string talkgroups_file;
+        std::string unit_tags_file;
         std::string short_name;
         std::string api_key;
         std::string default_mode;
@@ -73,6 +76,7 @@ public:
         bool audio_archive;
         bool record_unknown;
         bool call_log;
+
         smartnet_trunking_sptr smartnet_trunking;
         p25_trunking_sptr p25_trunking;
 
@@ -90,6 +94,15 @@ public:
         void set_record_unknown(bool);
         bool get_call_log();
         void set_call_log(bool);
+
+        void set_mdc_enabled(bool b);
+        void set_fsync_enabled(bool b);
+        void set_star_enabled(bool b);
+
+        bool get_mdc_enabled();
+        bool get_fsync_enabled();
+        bool get_star_enabled();
+
         std::string get_system_type();
         unsigned long get_sys_id();
         unsigned long get_wacn();
@@ -100,10 +113,13 @@ public:
         int get_sys_num();
         void set_system_type(std::string);
         std::string get_talkgroups_file();
+        std::string get_unit_tags_file();
         Source *get_source();
         void set_source(Source *);
         Talkgroup *find_talkgroup(long tg);
+        UnitTag* find_unit_tag(long unitID);
         void set_talkgroups_file(std::string);
+        void set_unit_tags_file(std::string);
         int control_channel_count();
         void add_control_channel(double channel);
         double get_next_control_channel();
@@ -149,5 +165,9 @@ private:
         bool d_delaycreateoutput;
         bool d_hideEncrypted;
         bool d_hideUnknown;
+
+        bool d_mdc_enabled;
+        bool d_fsync_enabled;
+        bool d_star_enabled;
 };
 #endif

--- a/trunk-recorder/talkgroups.cc
+++ b/trunk-recorder/talkgroups.cc
@@ -10,46 +10,7 @@
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
-
-// Retrieved from
-// https://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
-std::istream &safeGetline(std::istream &is, std::string &t) {
-  t.clear();
-
-  // The characters in the stream are read one-by-one using a std::streambuf.
-  // That is faster than reading them one-by-one using the std::istream.
-  // Code that uses streambuf this way must be guarded by a sentry object.
-  // The sentry object performs various tasks,
-  // such as thread synchronization and updating the stream state.
-
-  std::istream::sentry se(is, true);
-  std::streambuf *sb = is.rdbuf();
-
-  for (;;) {
-    int c = sb->sbumpc();
-
-    switch (c) {
-    case '\n':
-      return is;
-
-    case '\r':
-
-      if (sb->sgetc() == '\n')
-        sb->sbumpc();
-      return is;
-
-    case EOF:
-
-      // Also handle the case when the last line has no line ending
-      if (t.empty())
-        is.setstate(std::ios::eofbit);
-      return is;
-
-    default:
-      t += (char)c;
-    }
-  }
-}
+#include "csv_helper.h"
 
 Talkgroups::Talkgroups() {}
 

--- a/trunk-recorder/unit_tag.cc
+++ b/trunk-recorder/unit_tag.cc
@@ -1,0 +1,8 @@
+#include "unit_tag.h"
+
+
+UnitTag::UnitTag(long num, std::string t, std::string d) {
+    number = num;
+    tag = t;
+    description = d;
+}

--- a/trunk-recorder/unit_tag.cc
+++ b/trunk-recorder/unit_tag.cc
@@ -1,8 +1,7 @@
 #include "unit_tag.h"
 
 
-UnitTag::UnitTag(long num, std::string t, std::string d) {
+UnitTag::UnitTag(long num, std::string t) {
     number = num;
     tag = t;
-    description = d;
 }

--- a/trunk-recorder/unit_tag.h
+++ b/trunk-recorder/unit_tag.h
@@ -10,9 +10,8 @@ class UnitTag {
 public:
 	long number;
 	std::string tag;
-	std::string description;
 	
-	UnitTag(long num, std::string t, std::string d);
+	UnitTag(long num, std::string t);
 
 };
 

--- a/trunk-recorder/unit_tag.h
+++ b/trunk-recorder/unit_tag.h
@@ -1,0 +1,19 @@
+#ifndef UNIT_TAG_H
+#define UNIT_TAG_H
+
+#include <iostream>
+#include <string>
+#include <stdio.h>
+//#include <sstream>
+
+class UnitTag {
+public:
+	long number;
+	std::string tag;
+	std::string description;
+	
+	UnitTag(long num, std::string t, std::string d);
+
+};
+
+#endif // UNIT_TAG_H

--- a/trunk-recorder/unit_tags.cc
+++ b/trunk-recorder/unit_tags.cc
@@ -1,0 +1,102 @@
+#include "unit_tags.h"
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/tokenizer.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+#include "csv_helper.h"
+
+UnitTags::UnitTags() {}
+
+void UnitTags::load_unit_tags(std::string filename) {
+    std::ifstream in(filename.c_str());
+
+    if (!in.is_open()) {
+        BOOST_LOG_TRIVIAL(error) << "Error Opening Unit Tag File: " << filename
+            << std::endl;
+        return;
+    }
+
+    boost::char_separator<char> sep(",\t");
+    typedef boost::tokenizer< boost::char_separator<char> > t_tokenizer;
+
+    std::vector<std::string> vec;
+    std::string line;
+
+    int lines_read = 0;
+    int lines_pushed = 0;
+
+    while (!safeGetline(in, line).eof()) // this works with \r, \n, or \r\n
+    {
+        if (line.size() && (line[line.size() - 1] == '\r')) {
+            line = line.substr(0, line.size() - 1);
+        }
+
+        lines_read++;
+
+        if (line == "")
+            continue;
+
+        t_tokenizer tok(line, sep);
+
+        // Unit Tag configuration columns:
+        //
+        // [0] - talkgroup number
+        // [1] - tag
+        // [2] - description
+
+        vec.assign(tok.begin(), tok.end());
+
+        if (vec.size() != 3) {
+            BOOST_LOG_TRIVIAL(error) << "Malformed talkgroup entry at line " << lines_read << ".";
+            continue;
+        }
+        
+        UnitTag* tg =
+            new UnitTag(atoi(vec[0].c_str()), vec[1].c_str(), vec[2].c_str());
+
+        unit_tags.push_back(tg);
+        lines_pushed++;
+    }
+
+    if (lines_pushed != lines_read) {
+        // The parser above is pretty brittle. This will help with debugging it, for
+        // now.
+        BOOST_LOG_TRIVIAL(error) << "Warning: skipped " << lines_read - lines_pushed
+            << " of " << lines_read
+            << " unit tag entries! Invalid format?";
+        BOOST_LOG_TRIVIAL(error) << "The format is very particular. See "
+            "https://github.com/robotastic/trunk-recorder "
+            "for example input.";
+    }
+    else {
+        BOOST_LOG_TRIVIAL(info) << "Read " << lines_pushed << " unit tags.";
+    }
+}
+
+UnitTag* UnitTags::find_unit_tag(long tg_number) {
+    UnitTag* tg_match = NULL;
+
+    for (std::vector<UnitTag*>::iterator it = unit_tags.begin();
+        it != unit_tags.end(); ++it) {
+        UnitTag* tg = (UnitTag*)*it;
+
+        if (tg->number == tg_number) {
+            tg_match = tg;
+            break;
+        }
+    }
+    return tg_match;
+}
+
+void UnitTags::add(long num, std::string tag)
+{
+    UnitTag* unit_tag = new UnitTag(num, tag, "");
+    unit_tags.push_back(unit_tag);
+}

--- a/trunk-recorder/unit_tags.cc
+++ b/trunk-recorder/unit_tags.cc
@@ -49,19 +49,16 @@ void UnitTags::load_unit_tags(std::string filename) {
         //
         // [0] - talkgroup number
         // [1] - tag
-        // [2] - description
 
         vec.assign(tok.begin(), tok.end());
 
-        if (vec.size() != 3) {
+        if (vec.size() < 2) {
             BOOST_LOG_TRIVIAL(error) << "Malformed talkgroup entry at line " << lines_read << ".";
             continue;
         }
         
-        UnitTag* tg =
-            new UnitTag(atoi(vec[0].c_str()), vec[1].c_str(), vec[2].c_str());
+        add(atoi(vec[0].c_str()), vec[1].c_str());
 
-        unit_tags.push_back(tg);
         lines_pushed++;
     }
 
@@ -97,6 +94,6 @@ UnitTag* UnitTags::find_unit_tag(long tg_number) {
 
 void UnitTags::add(long num, std::string tag)
 {
-    UnitTag* unit_tag = new UnitTag(num, tag, "");
+    UnitTag* unit_tag = new UnitTag(num, tag);
     unit_tags.push_back(unit_tag);
 }

--- a/trunk-recorder/unit_tags.h
+++ b/trunk-recorder/unit_tags.h
@@ -1,0 +1,18 @@
+#ifndef UNIT_TAGS_H
+#define UNIT_TAGS_H
+
+#include "unit_tag.h"
+
+#include <string>
+#include <vector>
+
+class UnitTags {
+    std::vector<UnitTag*> unit_tags;
+
+public:
+    UnitTags();
+    void load_unit_tags(std::string filename);
+    UnitTag* find_unit_tag(long unitID);
+    void add(long num, std::string tag);
+};
+#endif // UNIT_TAGS_H

--- a/trunk-recorder/uploaders/call_uploader.cc
+++ b/trunk-recorder/uploaders/call_uploader.cc
@@ -1,3 +1,4 @@
+#include <vector>
 #include "call_uploader.h"
 #include "../formatter.h"
 
@@ -223,7 +224,7 @@ void send_call(Call *call, System *sys, Config config) {
   }
 
   // std::cout << "Setting up thread\n";
-  Call_Source *source_list = call->get_source_list();
+  std::vector<Call_Source> source_list = call->get_source_list();
   Call_Freq   *freq_list   = call->get_freq_list();
   //Call_Error  *error_list  = call->get_error_list();
   call_info->talkgroup        = call->get_talkgroup();
@@ -250,7 +251,7 @@ void send_call(Call *call, System *sys, Config config) {
   // call_info->path << "\n";
 
   for (int i = 0; i < call_info->source_count; i++) {
-    call_info->source_list[i] = source_list[i];
+    call_info->source_list.push_back(source_list[i]);
   }
 
   for (int i = 0; i < call_info->freq_count; i++) {

--- a/trunk-recorder/uploaders/call_uploader.h
+++ b/trunk-recorder/uploaders/call_uploader.h
@@ -2,6 +2,7 @@
 #define CALL_UPLOADER_H
 
 #include "uploader.h"
+#include <vector>
 
 class Call;
 
@@ -32,7 +33,7 @@ struct call_data_t {
         int length;
         bool phase2_tdma;
         long source_count;
-        Call_Source source_list[50];
+        std::vector<Call_Source> source_list;
         long freq_count;
         Call_Freq freq_list[50];
         long error_list_count;


### PR DESCRIPTION
- Adds MDC, FleetSync & Star signal decoding.
- Adds any decoded Unit ID's to the current call source list.
- Adds emergency and tag to the specific call source.
- Adds support for Unit ID tags, similar to Talkgroup ID tags. (Issue #237)
- Updates the gitignore to support Visual Studio 2019 (easier WSL support than VS Code)