### PR TITLE
Set final length in call status JSON too

### DIFF
--- a/trunk-recorder/call.cc
+++ b/trunk-recorder/call.cc
@@ -137,6 +137,7 @@ void Call::end_call() {
         myfile << "\"freq\": " << this->curr_freq << ",\n";
         myfile << "\"start_time\": " << this->start_time << ",\n";
         myfile << "\"stop_time\": " << this->stop_time << ",\n";
+        myfile << "\"call_length\": " << final_length << ",\n";
         myfile << "\"emergency\": " << this->emergency << ",\n";
         //myfile << "\"source\": \"" << this->get_recorder()->get_source()->get_device() << "\",\n";
         myfile << "\"talkgroup\": " << this->talkgroup << ",\n";


### PR DESCRIPTION
Busy time around here with pull requests! Thought I'd throw this one in too to set the final call length in the status json file as well, for those of us not using openmhz