### PR TITLE
Silence fdkaac output to avoid unnecessary log messages when uploading calls to OpenMHz

### DIFF
--- a/trunk-recorder/uploaders/call_uploader.cc
+++ b/trunk-recorder/uploaders/call_uploader.cc
@@ -126,7 +126,7 @@ void convert_upload_call(call_data_t *call_info, server_data_t *server_info) {
   //int nchars = snprintf(shell_command, 400, "ffmpeg -y -i %s  -c:a libfdk_aac -b:a 32k -filter:a \"volume=15db\" -filter:a loudnorm  -hide_banner -loglevel panic %s ", call_info->filename, call_info->converted);
   //int nchars = snprintf(shell_command, 400, "cd %s && fdkaac -S -b16 --raw-channels 1 --raw-rate 8000 %s", call_info->file_path, call_info->filename);
   //hints from here https://github.com/nu774/fdkaac/issues/5 on how to pipe between the 2
-  int nchars = snprintf(shell_command, 400, "sox %s -t wav - --norm=-3 | fdkaac --ignorelength -b 8000 -o %s -", call_info->filename, call_info->converted);
+  int nchars = snprintf(shell_command, 400, "sox %s -t wav - --norm=-3 | fdkaac --silent --ignorelength -b 8000 -o %s -", call_info->filename, call_info->converted);
 
   if (nchars >= 400) {
     BOOST_LOG_TRIVIAL(error) << "Call Uploader: Path longer than 400 charecters";


### PR DESCRIPTION
When a call is uploaded to OpenMHz after the switch was made to fdkaac, the following log messages occur amongst other logs:

```
[100%] 00:14.290/00:14.290 (246x), ETA 00:00.000   
114322/114322 samples processed in 00:00.058
```

To clean up the output, I'm adding the `--silent` argument, after which these messages aren't shown.