### PR TITLE
Removing usages of basename for MacOS compatibility

### DIFF
--- a/trunk-recorder/uploaders/broadcastify_uploader.cc
+++ b/trunk-recorder/uploaders/broadcastify_uploader.cc
@@ -87,7 +87,7 @@ int BroadcastifyUploader::upload(struct call_data_t *call) {
   curl_formadd(&formpost,
                &lastptr,
                CURLFORM_COPYNAME, "filename",
-               CURLFORM_COPYCONTENTS, basename(call->converted),
+               CURLFORM_COPYCONTENTS, call->converted,
                CURLFORM_END);
 
   curl_formadd(&formpost,

--- a/trunk-recorder/uploaders/openmhz_uploader.cc
+++ b/trunk-recorder/uploaders/openmhz_uploader.cc
@@ -67,7 +67,6 @@ int OpenmhzUploader::upload(struct call_data_t *call) {
                CURLFORM_COPYNAME, "call",
                CURLFORM_FILE, call->converted,
                CURLFORM_CONTENTTYPE, "application/octet-stream",
-               CURLFORM_FILENAME, basename(call->converted),
                CURLFORM_END);
 
   curl_formadd(&formpost,


### PR DESCRIPTION
Turns out that `basename()` as used is coming from the Linux standard library, which obviously isn't available in MacOS. It wasn't necessary (just a potentially helpful way to obfuscate the true path of the file), so I'm removing it here. 