### PR TITLE
Fixing call data length datatype to not round to 0

### DIFF
--- a/trunk-recorder/uploaders/uploader.h
+++ b/trunk-recorder/uploaders/uploader.h
@@ -32,7 +32,7 @@ struct call_data_t {
     std::string short_name;
     int bcfy_system_id;
     int tdma_slot;
-    int length;
+    double length;
     bool phase2_tdma;
     long source_count;
     std::vector<Call_Source> source_list;


### PR DESCRIPTION
I noticed a small bug with my recent call uploading refactor only affecting Brodcastify - since the call length is converted to an int, there are some cases where a call length of under 0.5s (but greater than 0) will attempt to be uploaded but fail with error "Call Duration Must be Specified for Conventional P25 Trunked Recorder Calls". There's probably something on Broadcastify's backend that's doing `if (!callDuration) throw error`.

To fix this and provide Broadcastify (and other future uploaders) with more detailed call data, the length is going from an int to a double. OpenMHz is not affected since there's already logic setting the precision to 0 for the length, so it effectively remains an int there.