### PR TITLE
Adding ability to retune control channel across sources

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -847,6 +847,7 @@ bool retune_recorder(TrunkMessage message, Call *call) {
       }
       return true;
     } else {
+      // TODO: Find the source that has the frequency on it, update our recorder to use that source for the rest of the call
       //Couldn't find a source that covers it
       return false;
     }
@@ -1047,30 +1048,65 @@ System* find_system(int sys_num) {
 }
 
 void retune_system(System *system) {
-  //bool source_found            = false;
-  Source *source               = system->get_source();
+  bool source_found            = false;
+  Source *current_source       = system->get_source();
   double  control_channel_freq = system->get_next_control_channel();
 
-    BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "] Retuning to Control Channel: " << FormatFreq(control_channel_freq);
-    BOOST_LOG_TRIVIAL(info) << "\t - System Source " << source->get_num() << " - Min Freq: " << FormatFreq(source->get_min_hz()) << " Max Freq: " << FormatFreq(source->get_max_hz());
+  BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "] Retuning to Control Channel: " << FormatFreq(control_channel_freq);
 
-  if ((source->get_min_hz() <= control_channel_freq) &&
-      (source->get_max_hz() >= control_channel_freq)) {
+  if ((current_source->get_min_hz() <= control_channel_freq) &&
+      (current_source->get_max_hz() >= control_channel_freq)) {
+    source_found = true;
+    BOOST_LOG_TRIVIAL(info) << "\t - System Source " << current_source->get_num() << " - Min Freq: " << FormatFreq(current_source->get_min_hz()) << " Max Freq: " << FormatFreq(current_source->get_max_hz());
     // The source can cover the System's control channel, break out of the
     // For Loop
     if (system->get_system_type() == "smartnet") {
-      // what you really need to do is go through all of the sources to find
-      // the one with the right frequencies
       system->smartnet_trunking->tune_freq(control_channel_freq);
     } else if (system->get_system_type() == "p25") {
-      // what you really need to do is go through all of the sources to find
-      // the one with the right frequencies
       system->p25_trunking->tune_freq(control_channel_freq);
     } else {
-      BOOST_LOG_TRIVIAL(error) << "\t - Unkown system type for Retune";
+      BOOST_LOG_TRIVIAL(error) << "\t - Unknown system type for Retune";
     }
   } else {
-    BOOST_LOG_TRIVIAL(error) << "\t - Unable to retune System control channel, freq not covered by the Source used for the inital control channel freq.";
+    for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
+      Source *source = *src_it;
+
+      if ((source->get_min_hz() <= control_channel_freq) &&
+          (source->get_max_hz() >= control_channel_freq)) {
+        source_found = true;
+        BOOST_LOG_TRIVIAL(info) << "\t - System Source " << source->get_num() << " - Min Freq: " << FormatFreq(source->get_min_hz()) << " Max Freq: " << FormatFreq(source->get_max_hz());
+
+        if (system->get_system_type() == "smartnet") {
+          system->set_source(source);
+          // We must lock the flow graph in order to disconnect and reconnect blocks
+          tb->lock();
+          tb->disconnect(current_source->get_src_block(), 0, system->smartnet_trunking, 0);
+          tb->connect(source->get_src_block(), 0, system->smartnet_trunking, 0);
+          tb->unlock();
+          system->smartnet_trunking->set_center(source->get_center());
+          system->smartnet_trunking->set_rate(source->get_rate());
+          system->smartnet_trunking->tune_freq(control_channel_freq);
+        } else if (system->get_system_type() == "p25") {
+          system->set_source(source);
+          // We must lock the flow graph in order to disconnect and reconnect blocks
+          tb->lock();
+          tb->disconnect(current_source->get_src_block(), 0, system->p25_trunking, 0);
+          tb->connect(source->get_src_block(), 0, system->p25_trunking, 0);
+          tb->unlock();
+          system->p25_trunking->set_center(source->get_center());
+          system->p25_trunking->set_rate(source->get_rate());
+          system->p25_trunking->tune_freq(control_channel_freq);
+        } else {
+          BOOST_LOG_TRIVIAL(error) << "\t - Unkown system type for Retune";
+        }
+
+        // break out of the For Loop
+        break;
+      }
+    }
+  }
+  if (!source_found) {
+    BOOST_LOG_TRIVIAL(error) << "\t - Unable to retune System control channel, freq not covered by any source.";
   }
 }
 

--- a/trunk-recorder/systems/p25_trunking.cc
+++ b/trunk-recorder/systems/p25_trunking.cc
@@ -282,6 +282,15 @@ p25_trunking::p25_trunking(double f, double c, long s, gr::msg_queue::sptr queue
 
 p25_trunking::~p25_trunking() {}
 
+void p25_trunking::set_center(double c) {
+  center_freq = c;
+}
+
+void p25_trunking::set_rate(long s) {
+  input_rate = s;
+  // TODO: Update/remake blocks that depend on input_rate
+}
+
 double p25_trunking::get_freq() {
   return chan_freq;
 }

--- a/trunk-recorder/systems/p25_trunking.h
+++ b/trunk-recorder/systems/p25_trunking.h
@@ -96,8 +96,10 @@ public:
 
   ~p25_trunking();
 
+  void   set_center(double c);
+  void   set_rate(long s);
   void   tune_offset(double f);
-  void    tune_freq(double f);
+  void   tune_freq(double f);
   double get_freq();
   void   enable();
 

--- a/trunk-recorder/systems/smartnet_trunking.cc
+++ b/trunk-recorder/systems/smartnet_trunking.cc
@@ -225,6 +225,15 @@ void smartnet_trunking::reset() {
 
 }
 
+void smartnet_trunking::set_center(double c) {
+  center_freq = c;
+}
+
+void smartnet_trunking::set_rate(long s) {
+  input_rate = s;
+  // TODO: Update/remake blocks that depend on input_rate
+}
+
 void smartnet_trunking::tune_freq(double f) {
   chan_freq = f;
   int offset_amount = (center_freq - f);

--- a/trunk-recorder/systems/smartnet_trunking.h
+++ b/trunk-recorder/systems/smartnet_trunking.h
@@ -58,6 +58,8 @@ public:
 		long decim;
 		long decim2;
 	};
+  void set_center(double c);
+  void set_rate(long s);
   void tune_offset(double f);
   void    tune_freq(double f);
   void reset();


### PR DESCRIPTION
This is an initial attempt at fixing #328 and #120, allowing a retune of the control channel frequency across multiple sources.

This works by iterating thru the list of sources and checking if the frequency we want falls within its bounds, just like when we are first creating the P25 or Smartnet trunking block. If we do find a source that matches, it will disconnect the old source from the trunking block and connect the new source, then updating the various parameters and retuning to the new frequency using the updated source.

At some point this same process may be able to be applied to keep a single recording during a retune across sources, however that's a bit more tricky since a recorder is tied to a given source.

This is only a draft because it appears there are some potential flaws if the sample rate is different between sources, as some blocks that used the sample rate in calculations are not reloaded with the new sample rate. Interestingly, I tested it with two RTL-SDRs that were configured to use different sample rates, and it still seemed to work, which I don't yet understand why. Opening this to get some feedback and have others try this out.

Despite all this, assuming someone has the same sample rate for every source (e.g. three different RTL-SDRs all at 2.4Msps) then things should work out. I was able to successfully start on one source and pick up a control channel on a different source.

Fixes #328
Fixes #120