### PR TITLE
Improving frequency format Mhz precision, applying to earlier startup messages

### DIFF
--- a/trunk-recorder/formatter.cc
+++ b/trunk-recorder/formatter.cc
@@ -4,12 +4,12 @@
 int frequencyFormat = 0;
 bool statusAsString = true;
 
-boost::format FormatFreq(float f)
+boost::format FormatFreq(double f)
 {
 	if (frequencyFormat == 1)
-		return boost::format("%10.6f")	% (f / 1000000);
+		return boost::format("%10.6f MHz")	% (f / 1000000.0);
 	else if (frequencyFormat == 2)
-		return boost::format("%.0f")	% f;
+		return boost::format("%.0f Hz")	% f;
 	else
 		return boost::format("%e")		% f;
 }

--- a/trunk-recorder/formatter.h
+++ b/trunk-recorder/formatter.h
@@ -5,7 +5,7 @@
 #include <string>
 #include "state.h"
 
-extern boost::format FormatFreq(float f);
+extern boost::format FormatFreq(double f);
 extern boost::format FormatSamplingRate(float f);
 extern std::string FormatState(State state);
 extern int frequencyFormat;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -176,8 +176,18 @@ void load_config(string config_file)
 
     boost::property_tree::ptree pt;
     boost::property_tree::read_json(config_file, pt);
-    BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\n     Trunk Recorder\n-------------------------------------\n" << sys_count;
-    BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\nSYSTEMS\n-------------------------------------\n" << sys_count;
+    BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\n     Trunk Recorder\n-------------------------------------\n";
+    BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\nSYSTEMS\n-------------------------------------\n";
+
+    std::string frequencyFormatString = pt.get<std::string>("frequencyFormat", "exp");
+
+    if (boost::iequals(frequencyFormatString, "mhz")){
+      frequencyFormat = 1;
+    } else if (boost::iequals(frequencyFormatString, "hz")){
+      frequencyFormat = 2;
+    } else {
+      frequencyFormat = 0;
+    }
     
     config.debug_recorder   = pt.get<bool>("debugRecorder", 0);
     config.debug_recorder_address = pt.get<std::string>("debugRecorderAddress", "127.0.0.1");
@@ -195,7 +205,7 @@ void load_config(string config_file)
       unsigned long     nac;
       default_script << "sys_" << sys_count;
 
-      BOOST_LOG_TRIVIAL(info) << "\n\nSystem Number: " << sys_count << "\n-------------------------------------\n" << sys_count;
+      BOOST_LOG_TRIVIAL(info) << "\n\nSystem Number: " << sys_count << "\n-------------------------------------\n";
       system->set_short_name(node.second.get<std::string>("shortName", default_script.str()));
       BOOST_LOG_TRIVIAL(info) << "Short Name: " << system->get_short_name();
 
@@ -208,7 +218,7 @@ void load_config(string config_file)
         {
           double channel = sub_node.second.get<double>("", 0);
 
-          BOOST_LOG_TRIVIAL(info) << sub_node.second.get<double>("", 0) << " ";
+          BOOST_LOG_TRIVIAL(info) << "  " << FormatFreq(channel);
           system->add_channel(channel);
         }
 
@@ -219,7 +229,7 @@ void load_config(string config_file)
           BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("alphatags"))
           {
             std::string alphaTag = sub_node.second.get<std::string>("", "");
-            BOOST_LOG_TRIVIAL(info) << alphaTag << " ";
+            BOOST_LOG_TRIVIAL(info) << "  " << alphaTag;
             system->talkgroups->add(alphaIndex, alphaTag);
             alphaIndex++;
           }
@@ -231,7 +241,7 @@ void load_config(string config_file)
         {
           double channel = sub_node.second.get<double>("", 0);
 
-          BOOST_LOG_TRIVIAL(info) << sub_node.second.get<double>("", 0) << " ";
+          BOOST_LOG_TRIVIAL(info) << "  " << FormatFreq(channel);
           system->add_channel(channel);
         }
 
@@ -242,7 +252,7 @@ void load_config(string config_file)
           BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("alphatags"))
           {
             std::string alphaTag = sub_node.second.get<std::string>("", "");
-            BOOST_LOG_TRIVIAL(info) << alphaTag << " ";
+            BOOST_LOG_TRIVIAL(info) << "  " << alphaTag;
             system->talkgroups->add(alphaIndex, alphaTag);
             alphaIndex++;
           }
@@ -257,7 +267,7 @@ void load_config(string config_file)
         {
           double control_channel = sub_node.second.get<double>("", 0);
 
-          BOOST_LOG_TRIVIAL(info) << sub_node.second.get<double>("", 0) << " ";
+          BOOST_LOG_TRIVIAL(info) << "  " << FormatFreq(control_channel);
           system->add_control_channel(control_channel);
         }
       } else {
@@ -530,16 +540,6 @@ void load_config(string config_file)
     BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
     config.control_retune_limit = pt.get<int>("controlRetuneLimit", 0);
     BOOST_LOG_TRIVIAL(info) << "Control channel retune limit: " << config.control_retune_limit;
-
-    std::string frequencyFormatString = pt.get<std::string>("frequencyFormat", "exp");
-
-    if (boost::iequals(frequencyFormatString, "mhz")){
-      frequencyFormat = 1;
-    } else if (boost::iequals(frequencyFormatString, "hz")){
-      frequencyFormat = 2;
-    } else {
-      frequencyFormat = 0;
-    }
 
     BOOST_LOG_TRIVIAL(info) << "Frequency format: " << frequencyFormat;
 

--- a/trunk-recorder/talkgroups.cc
+++ b/trunk-recorder/talkgroups.cc
@@ -15,6 +15,10 @@
 Talkgroups::Talkgroups() {}
 
 void Talkgroups::load_talkgroups(std::string filename) {
+  if (filename == "") {
+    return;
+  }
+
   std::ifstream in(filename.c_str());
 
   if (!in.is_open()) {

--- a/trunk-recorder/unit_tags.cc
+++ b/trunk-recorder/unit_tags.cc
@@ -15,6 +15,10 @@
 UnitTags::UnitTags() {}
 
 void UnitTags::load_unit_tags(std::string filename) {
+    if (filename == "") {
+      return;
+    }
+
     std::ifstream in(filename.c_str());
 
     if (!in.is_open()) {


### PR DESCRIPTION
I've noticed that the `FormatFreq` function was not actually printing the correct frequencies when using the mhz option, due to floating point issues. This might confuse some people if they see frequencies different from what they've input.

To fix this, I've changed it to a `double` and made sure the divisor was a double/floating point as well. "MHz" and "Hz" were added as suffixes to the format strings to indicate what unit was being used. The setting of the `frequencyFormat` value was moved to the top of the startup process so that any subsequent frequency mention can be formatted properly.

In addition to these changes, I've cleaned up some other bits of the startup log messages to provide an overall cleaner output.

It's a bit easier to explain when looking at the before and after of a startup process:

### Before

```
linux; GNU C++ version 7.3.0; Boost_106501; UHD_003.010.003.000-0-unknown

[2020-04-29 04:00:24.561374] (info)   Using Config file: /app/config/cpd-rtl.json

[2020-04-29 04:00:24.564838] (info)   
-------------------------------------
     Trunk Recorder
-------------------------------------
0
[2020-04-29 04:00:24.564897] (info)   
-------------------------------------
SYSTEMS
-------------------------------------
0
[2020-04-29 04:00:24.564933] (info)   

System Number: 1
-------------------------------------
1
[2020-04-29 04:00:24.564945] (info)   Short Name: chi_cpd_test
[2020-04-29 04:00:24.564956] (info)   System Type: conventional
[2020-04-29 04:00:24.564968] (info)   Conventional Channels: 
[2020-04-29 04:00:24.565011] (info)   4.601e+08 
[2020-04-29 04:00:24.565079] (info)   4.60225e+08 
[2020-04-29 04:00:24.565121] (info)   Alpha Tags: 
[2020-04-29 04:00:24.565144] (info)   API Key: test
[2020-04-29 04:00:24.565213] (info)   Broadcastify API Key: 
[2020-04-29 04:00:24.565272] (info)   Broadcastify Calls System ID: 0
[2020-04-29 04:00:24.565296] (info)   Upload Script: 
[2020-04-29 04:00:24.565317] (info)   Call Log: true
[2020-04-29 04:00:24.565346] (info)   Audio Archive: true
[2020-04-29 04:00:24.565374] (info)   Loading Talkgroups...
[2020-04-29 04:00:24.565433] (info)   Read 2 talkgroups.
[2020-04-29 04:00:24.565455] (info)   Talkgroups File: config/cpd.csv
[2020-04-29 04:00:24.565466] (info)   Loading Unit Tags...
[2020-04-29 04:00:24.565479] (error)   Error Opening Unit Tag File: 

[2020-04-29 04:00:24.565489] (info)   Unit Tags File: 
[2020-04-29 04:00:24.565505] (info)   Record Unknown Talkgroups: true
[2020-04-29 04:00:24.565519] (info)   Decode MDC: false
[2020-04-29 04:00:24.565529] (info)   Decode FSync: false
[2020-04-29 04:00:24.565540] (info)   Decode Star: false
[2020-04-29 04:00:24.565553] (info)   Decode TPS: false
[2020-04-29 04:00:24.565565] (info)   Talkgroup Display Format: Id
[2020-04-29 04:00:24.565578] (info)   Hide Encrypted Talkgroups: false
[2020-04-29 04:00:24.565591] (info)   Hide Unknown Talkgroups: false
[2020-04-29 04:00:24.565601] (info)   Minimum Call Duration (in seconds): 0
[2020-04-29 04:00:24.565615] (info)   
[2020-04-29 04:00:24.565624] (info)   

-------------------------------------
SOURCES
-------------------------------------

[2020-04-29 04:00:24.565657] (info)   Driver: osmosdr
[2020-04-29 04:00:24.565691] (info)   Center: 4.603150e+08
[2020-04-29 04:00:24.565729] (info)   Rate: 1800000
[2020-04-29 04:00:24.565753] (info)   Error: 0
[2020-04-29 04:00:24.565766] (info)   PPM Error: -3
[2020-04-29 04:00:24.565783] (info)   Gain: 20
[2020-04-29 04:00:24.565798] (info)   IF Gain: 0
[2020-04-29 04:00:24.565809] (info)   BB Gain: 0
[2020-04-29 04:00:24.565823] (info)   LNA Gain: 0
[2020-04-29 04:00:24.565835] (info)   PGA Gain: 0
[2020-04-29 04:00:24.565845] (info)   TIA Gain: 0
[2020-04-29 04:00:24.565856] (info)   MIX Gain: 0
[2020-04-29 04:00:24.565867] (info)   VGA1 Gain: 0
[2020-04-29 04:00:24.565880] (info)   VGA2 Gain: 0
[2020-04-29 04:00:24.565892] (info)   Squelch: -60
[2020-04-29 04:00:24.565908] (info)   Idle Silence: false
[2020-04-29 04:00:24.565921] (info)   Digital Recorders: 0
[2020-04-29 04:00:24.565932] (info)   Debug Recorder: false
[2020-04-29 04:00:24.565942] (info)   SigMF Recorders: 0
[2020-04-29 04:00:24.565951] (info)   Analog Recorders: 1
[2020-04-29 04:00:24.565968] (info)   Modulation: qpsk
[2020-04-29 04:00:24.565980] (info)   Source Device: rtl=0000000A,buflen=65536
gr-osmosdr v0.1.x-xxx-xunknown (0.1.5git) gnuradio 3.7.10
built-in source types: file osmosdr fcd rtl rtl_tcp uhd plutosdr miri hackrf bladerf rfspace airspy airspyhf soapy redpitaya 
Using device #1 RTL-SDRblog RTL2838UHIDIR SN: 0000000A
Using 15 buffers of size 65536.
Found Rafael Micro R820T tuner
[R82XX] PLL not locked!
[2020-04-29 04:00:24.635221] (info)   SOURCE TYPE OSMOSDR (osmosdr)
[2020-04-29 04:00:24.635253] (info)   Setting sample rate to: 1800000
[2020-04-29 04:00:24.635330] (info)   Actual sample rate: 0
[2020-04-29 04:00:24.635350] (info)   Tuning to 4.603150e+08
[2020-04-29 04:00:24.635367] (info)   Max Frequency: 4.611650e+08
[2020-04-29 04:00:24.635386] (info)   Min Frequency: 4.594650e+08
[2020-04-29 04:00:24.635403] (info)   Gain set to: 0
[2020-04-29 04:00:24.635432] (info)   Setting antenna to []
[2020-04-29 04:00:25.046252] (info)   Analog Recorder Taps - initial: 145 channel: 1309 ARB: 545 Total: 1999
[2020-04-29 04:00:25.046952] (info)   Creating decoder sink...

Project 25 IMBE Encoder/Decoder Fixed-Point implementation
Developed by Pavel Yazev E-mail: pyazev@gmail.com
Version 1.0 (c) Copyright 2009
This program comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it
under certain conditions; see the file ``LICENSE'' for details.
[2020-04-29 04:00:25.047457] (info)   Decoder sink created!

[2020-04-29 04:00:25.047750] (info)   
-------------------------------------


[2020-04-29 04:00:25.047793] (info)   

-------------------------------------
INSTANCE
-------------------------------------

[2020-04-29 04:00:25.047822] (info)   Capture Directory: media
[2020-04-29 04:00:25.047833] (info)   Upload Server: 
[2020-04-29 04:00:25.047843] (info)   Broadcastify Calls Server: 
[2020-04-29 04:00:25.047852] (info)   Status Server: 
[2020-04-29 04:00:25.047861] (info)   Instance Key: 
[2020-04-29 04:00:25.047872] (info)   Instance Id: 
[2020-04-29 04:00:25.047881] (info)   Broadcast Signals: false
[2020-04-29 04:00:25.047895] (info)   Default Mode: digital
[2020-04-29 04:00:25.047905] (info)   Call Timeout (seconds): 3
[2020-04-29 04:00:25.047915] (info)   Log to File: false
[2020-04-29 04:00:25.047924] (info)   Control channel warning rate: 10
[2020-04-29 04:00:25.047935] (info)   Control channel retune limit: 0
[2020-04-29 04:00:25.047949] (info)   Maximum Call Duration (seconds): 60
[2020-04-29 04:00:25.047963] (info)   Frequency format: 1
[2020-04-29 04:00:25.047973] (info)   Status as String: true
[2020-04-29 04:00:25.047982] (info)   Log Level: info
[2020-04-29 04:00:25.048001] (info)   [chi_cpd_test]	Monitoring Conventional Channel: 460.100006 Talkgroup: 1
[2020-04-29 04:00:25.057399] (info)   Analog Recorder Taps - initial: 145 channel: 1309 ARB: 545 Total: 1999
[2020-04-29 04:00:25.057968] (info)   Creating decoder sink...

[2020-04-29 04:00:25.058295] (info)   Decoder sink created!

[2020-04-29 04:00:25.058605] (info)   [chi_cpd_test]	TG:          1	Freq: 460.100006
[2020-04-29 04:00:25.058674] (info)   [chi_cpd_test]	Monitoring Conventional Channel: 460.225006 Talkgroup: 2
[2020-04-29 04:00:25.064032] (info)   Analog Recorder Taps - initial: 145 channel: 1309 ARB: 545 Total: 1999
[2020-04-29 04:00:25.064611] (info)   Creating decoder sink...

[2020-04-29 04:00:25.064967] (info)   Decoder sink created!

[2020-04-29 04:00:25.065261] (info)   [chi_cpd_test]	TG:          2	Freq: 460.225006
```

### After

```
linux; GNU C++ version 5.4.0 20160609; Boost_105800; UHD_003.010.003.000-0-unknown

[2020-04-28 22:55:52.901988] (info)   Using Config file: config/cpd-rtl.json

[2020-04-28 22:55:52.903057] (info)   
-------------------------------------
     Trunk Recorder
-------------------------------------

[2020-04-28 22:55:52.903106] (info)   
-------------------------------------
SYSTEMS
-------------------------------------

[2020-04-28 22:55:52.903284] (info)   

System Number: 1
-------------------------------------

[2020-04-28 22:55:52.903347] (info)   Short Name: chi_cpd_test
[2020-04-28 22:55:52.903400] (info)   System Type: conventional
[2020-04-28 22:55:52.903425] (info)   Conventional Channels: 
[2020-04-28 22:55:52.903611] (info)     460.100000 MHz
[2020-04-28 22:55:52.903701] (info)     460.225000 MHz
[2020-04-28 22:55:52.903748] (info)   Alpha Tags: 
[2020-04-28 22:55:52.903900] (info)   API Key: test
[2020-04-28 22:55:52.903941] (info)   Broadcastify API Key: 
[2020-04-28 22:55:52.903959] (info)   Broadcastify Calls System ID: 0
[2020-04-28 22:55:52.904007] (info)   Upload Script: 
[2020-04-28 22:55:52.904026] (info)   Call Log: true
[2020-04-28 22:55:52.904048] (info)   Audio Archive: true
[2020-04-28 22:55:52.904178] (info)   Loading Talkgroups...
[2020-04-28 22:55:52.904284] (info)   Read 2 talkgroups.
[2020-04-28 22:55:52.904349] (info)   Talkgroups File: config/cpd.csv
[2020-04-28 22:55:52.904522] (info)   Loading Unit Tags...
[2020-04-28 22:55:52.904563] (info)   Unit Tags File: 
[2020-04-28 22:55:52.904579] (info)   Record Unknown Talkgroups: true
[2020-04-28 22:55:52.904606] (info)   Decode MDC: false
[2020-04-28 22:55:52.904640] (info)   Decode FSync: false
[2020-04-28 22:55:52.904658] (info)   Decode Star: false
[2020-04-28 22:55:52.904671] (info)   Decode TPS: false
[2020-04-28 22:55:52.904688] (info)   Talkgroup Display Format: Id
[2020-04-28 22:55:52.904845] (info)   Hide Encrypted Talkgroups: false
[2020-04-28 22:55:52.904918] (info)   Hide Unknown Talkgroups: false
[2020-04-28 22:55:52.904976] (info)   Minimum Call Duration (in seconds): 0
[2020-04-28 22:55:52.905001] (info)   
[2020-04-28 22:55:52.905045] (info)   

-------------------------------------
SOURCES
-------------------------------------

[2020-04-28 22:55:52.905424] (info)   Driver: osmosdr
[2020-04-28 22:55:52.905829] (info)   Center: 460.315000 MHz
[2020-04-28 22:55:52.907047] (info)   Rate: 1800000
[2020-04-28 22:55:52.907200] (info)   Error: 0
[2020-04-28 22:55:52.907284] (info)   PPM Error: -3
[2020-04-28 22:55:52.907383] (info)   Gain: 20
[2020-04-28 22:55:52.907517] (info)   IF Gain: 0
[2020-04-28 22:55:52.907602] (info)   BB Gain: 0
[2020-04-28 22:55:52.907684] (info)   LNA Gain: 0
[2020-04-28 22:55:52.907765] (info)   PGA Gain: 0
[2020-04-28 22:55:52.907843] (info)   TIA Gain: 0
[2020-04-28 22:55:52.907925] (info)   MIX Gain: 0
[2020-04-28 22:55:52.907982] (info)   VGA1 Gain: 0
[2020-04-28 22:55:52.908086] (info)   VGA2 Gain: 0
[2020-04-28 22:55:52.908173] (info)   Squelch: -60
[2020-04-28 22:55:52.908265] (info)   Idle Silence: false
[2020-04-28 22:55:52.908369] (info)   Digital Recorders: 0
[2020-04-28 22:55:52.908446] (info)   Debug Recorder: false
[2020-04-28 22:55:52.908536] (info)   SigMF Recorders: 0
[2020-04-28 22:55:52.908611] (info)   Analog Recorders: 1
[2020-04-28 22:55:52.908741] (info)   Modulation: qpsk
[2020-04-28 22:55:52.908858] (info)   Source Device: rtl=0000000A,buflen=65536
gr-osmosdr v0.1.x-xxx-xunknown (0.1.5git) gnuradio 3.7.10
built-in source types: file osmosdr fcd rtl rtl_tcp uhd plutosdr miri hackrf bladerf rfspace airspy airspyhf soapy redpitaya 
Using device #1 RTL-SDRblog RTL2838UHIDIR SN: 0000000A
Using 15 buffers of size 65536.
Found Rafael Micro R820T tuner
[R82XX] PLL not locked!
[2020-04-28 22:55:53.707104] (info)   SOURCE TYPE OSMOSDR (osmosdr)
[2020-04-28 22:55:53.707170] (info)   Setting sample rate to: 1800000
[R82XX] PLL not locked!
[2020-04-28 22:55:53.858939] (info)   Actual sample rate: 1800000
[2020-04-28 22:55:53.859049] (info)   Tuning to 460.315000 MHz
[2020-04-28 22:55:53.928525] (info)   Gain Stage: LNA supported values: 0 0.9 1.4 2.7 3.7 7.7 8.7 12.5 14.4 15.7 16.6 19.7 20.7 22.9 25.4 28 29.7 32.8 33.8 36.4 37.2 38.6 40.2 42.1 43.4 43.9 44.5 48 49.6 
[2020-04-28 22:55:53.928635] (info)   Max Frequency: 461.165000 MHz
[2020-04-28 22:55:53.928686] (info)   Min Frequency: 459.465000 MHz
[2020-04-28 22:55:53.962175] (info)   Gain set to: 19.7
[2020-04-28 22:55:53.962277] (info)   Setting antenna to [RX]
[2020-04-28 22:55:54.055269] (info)   Analog Recorder Taps - initial: 145 channel: 1309 ARB: 545 Total: 1999
[2020-04-28 22:55:54.056604] (info)   Creating decoder sink...

Project 25 IMBE Encoder/Decoder Fixed-Point implementation
Developed by Pavel Yazev E-mail: pyazev@gmail.com
Version 1.0 (c) Copyright 2009
This program comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it
under certain conditions; see the file ``LICENSE'' for details.
[2020-04-28 22:55:54.057395] (info)   Decoder sink created!

[2020-04-28 22:55:54.057701] (info)   
-------------------------------------


[2020-04-28 22:55:54.057753] (info)   

-------------------------------------
INSTANCE
-------------------------------------

[2020-04-28 22:55:54.057859] (info)   Capture Directory: media
[2020-04-28 22:55:54.057890] (info)   Upload Server: 
[2020-04-28 22:55:54.057907] (info)   Broadcastify Calls Server: 
[2020-04-28 22:55:54.057922] (info)   Status Server: 
[2020-04-28 22:55:54.057936] (info)   Instance Key: 
[2020-04-28 22:55:54.057952] (info)   Instance Id: 
[2020-04-28 22:55:54.057968] (info)   Broadcast Signals: false
[2020-04-28 22:55:54.057983] (info)   Default Mode: digital
[2020-04-28 22:55:54.057997] (info)   Call Timeout (seconds): 3
[2020-04-28 22:55:54.058044] (info)   Log to File: false
[2020-04-28 22:55:54.058069] (info)   Control channel warning rate: 10
[2020-04-28 22:55:54.058093] (info)   Control channel retune limit: 0
[2020-04-28 22:55:54.058138] (info)   Maximum Call Duration (seconds): 60
[2020-04-28 22:55:54.058180] (info)   Frequency format: 1
[2020-04-28 22:55:54.058206] (info)   Status as String: true
[2020-04-28 22:55:54.058227] (info)   Log Level: info
[2020-04-28 22:55:54.058280] (info)   [chi_cpd_test]	Monitoring Conventional Channel: 460.100000 MHz Talkgroup: 1
[2020-04-28 22:55:54.066717] (info)   Analog Recorder Taps - initial: 145 channel: 1309 ARB: 545 Total: 1999
[2020-04-28 22:55:54.067993] (info)   Creating decoder sink...

[2020-04-28 22:55:54.068566] (info)   Decoder sink created!

[2020-04-28 22:55:54.069173] (info)   [chi_cpd_test]	TG:          1	Freq: 460.100000 MHz
[2020-04-28 22:55:54.069242] (info)   [chi_cpd_test]	Monitoring Conventional Channel: 460.225000 MHz Talkgroup: 2
[2020-04-28 22:55:54.079519] (info)   Analog Recorder Taps - initial: 145 channel: 1309 ARB: 545 Total: 1999
[2020-04-28 22:55:54.081681] (info)   Creating decoder sink...

[2020-04-28 22:55:54.082105] (info)   Decoder sink created!

[2020-04-28 22:55:54.082512] (info)   [chi_cpd_test]	TG:          2	Freq: 460.225000 MHz
```