### PR TITLE
Making callLog optional for Broadcastify Calls to work, better error handling for missing call upload deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Here are the different arguments:
    - **broadcastifyApiKey** - *(Optional)* System-specific API key for Broadcastify Calls
    - **broadcastifySystemId** - *(Optional)* System ID for Broadcastify Calls (this is an integer, and different from the RadioReference system ID)
    - **audioArchive** - should the recorded audio files be kept after successfully uploading them. The options are *true* and *false* (without quotes). The default is *true*.
-   - **callLog** - should a json file with the call details be generated. The options are *true* and *false* (without quotes). The default is *true*. This is required if uploading to Broadcastify Calls or trunk-player.
+   - **callLog** - should a json file with the call details be kept after successful uploads. The options are *true* and *false* (without quotes). The default is *true*.
    - **minDuration** - the minimum call (transmission) duration in seconds (decimals allowed), calls below this number will have recordings deleted and will not be uploaded. The default is *0* (no minimum duration).
    - **bandplan** - [SmartNet only] this is the SmartNet bandplan that will be used. The options are *800_standard*, *800_reband*, *800_splinter*, and *400_custom*. *800_standard* is the default.
    - **bandplanBase** - [SmartNet, 400_custom only] this is for the *400_custom* bandplan only. This is the base frequency, specified in Hz.

--- a/trunk-recorder/call.cc
+++ b/trunk-recorder/call.cc
@@ -131,40 +131,37 @@ void Call::end_call() {
       freq_list[freq_count - 1].error_count = rx_status.error_count;
     }
 
-    if (sys->get_call_log()) {
-      std::ofstream myfile(status_filename);
+    std::ofstream myfile(status_filename);
 
 
-      if (myfile.is_open())
-      {
-        myfile << "{\n";
-        myfile << "\"freq\": " << this->curr_freq << ",\n";
-        myfile << "\"start_time\": " << this->start_time << ",\n";
-        myfile << "\"stop_time\": " << this->stop_time << ",\n";
-        myfile << "\"emergency\": " << this->emergency << ",\n";
-        //myfile << "\"source\": \"" << this->get_recorder()->get_source()->get_device() << "\",\n";
-        myfile << "\"talkgroup\": " << this->talkgroup << ",\n";
-        myfile << "\"srcList\": [ ";
+    if (myfile.is_open()) {
+      myfile << "{\n";
+      myfile << "\"freq\": " << this->curr_freq << ",\n";
+      myfile << "\"start_time\": " << this->start_time << ",\n";
+      myfile << "\"stop_time\": " << this->stop_time << ",\n";
+      myfile << "\"emergency\": " << this->emergency << ",\n";
+      //myfile << "\"source\": \"" << this->get_recorder()->get_source()->get_device() << "\",\n";
+      myfile << "\"talkgroup\": " << this->talkgroup << ",\n";
+      myfile << "\"srcList\": [ ";
 
-        for (std::size_t i = 0; i < src_list.size(); i++) {
-          if (i != 0) {
-            myfile << ", ";
-          }
-          myfile << "{\"src\": " << std::fixed << src_list[i].source << ", \"time\": " << src_list[i].time << ", \"pos\": " << src_list[i].position << ", \"emergency\": " << src_list[i].emergency << ", \"signal_system\": \"" << src_list[i].signal_system << "\", \"tag\": \"" << src_list[i].tag << "\"}";
+      for (std::size_t i = 0; i < src_list.size(); i++) {
+        if (i != 0) {
+          myfile << ", ";
         }
-        myfile << " ],\n";
-        myfile << "\"freqList\": [ ";
-
-        for (int i = 0; i < freq_count; i++) {
-          if (i != 0) {
-            myfile << ", ";
-          }
-          myfile << "{ \"freq\": " << std::fixed <<  freq_list[i].freq << ", \"time\": " << freq_list[i].time << ", \"pos\": " << freq_list[i].position << ", \"len\": " << freq_list[i].total_len << ", \"error_count\": " << freq_list[i].error_count << ", \"spike_count\": " << freq_list[i].spike_count << "}";
-        }
-        myfile << "]\n";
-        myfile << "}\n";
-        myfile.close();
+        myfile << "{\"src\": " << std::fixed << src_list[i].source << ", \"time\": " << src_list[i].time << ", \"pos\": " << src_list[i].position << ", \"emergency\": " << src_list[i].emergency << ", \"signal_system\": \"" << src_list[i].signal_system << "\", \"tag\": \"" << src_list[i].tag << "\"}";
       }
+      myfile << " ],\n";
+      myfile << "\"freqList\": [ ";
+
+      for (int i = 0; i < freq_count; i++) {
+        if (i != 0) {
+          myfile << ", ";
+        }
+        myfile << "{ \"freq\": " << std::fixed <<  freq_list[i].freq << ", \"time\": " << freq_list[i].time << ", \"pos\": " << freq_list[i].position << ", \"len\": " << freq_list[i].total_len << ", \"error_count\": " << freq_list[i].error_count << ", \"spike_count\": " << freq_list[i].spike_count << "}";
+      }
+      myfile << "]\n";
+      myfile << "}\n";
+      myfile.close();
     }
 
     if (sys->get_upload_script().length() != 0) {
@@ -175,13 +172,23 @@ void Call::end_call() {
     if (this->get_recorder()->get_current_length() > sys->get_min_duration()) {
       if (this->config.upload_server != "" || this->config.bcfy_calls_server != "") {
         send_call(this, sys, config);
-      } else {}
+      }
 
       if (sys->get_upload_script().length() != 0) {
         BOOST_LOG_TRIVIAL(info) << "Running upload script: " << shell_command.str();
         signal(SIGCHLD, SIG_IGN);
         //int rc = system(shell_command.str().c_str());
         system(shell_command.str().c_str());
+      }
+
+      // These files may have already been deleted by upload_call_thread() so only do deletion here if that wasn't called
+      if (this->config.upload_server == "" && this->config.bcfy_calls_server == "") {
+        if (!sys->get_audio_archive() && remove(filename) != 0) {
+          BOOST_LOG_TRIVIAL(error) << "Could not delete file " << filename;
+        }
+        if (!sys->get_call_log() && remove(status_filename) != 0) {
+          BOOST_LOG_TRIVIAL(error) << "Could not delete file " << status_filename;
+        }
       }
     } else {
       // Call too short, delete it (we are deleting it after since we can't easily prevent the file from saving)

--- a/trunk-recorder/uploaders/call_uploader.cc
+++ b/trunk-recorder/uploaders/call_uploader.cc
@@ -52,8 +52,11 @@ void* upload_call_thread(void *thread_arg) {
 
   if (!error) {
     if (!call_info->audio_archive) {
-      unlink(call_info->filename);
-      unlink(call_info->converted);
+      remove(call_info->filename);
+      remove(call_info->converted);
+    }
+    if (!call_info->call_log) {
+      remove(call_info->status_filename);
     }
   }
 
@@ -113,6 +116,7 @@ void send_call(Call *call, System *sys, Config config) {
   call_info->bcfy_system_id   = sys->get_bcfy_system_id();
   call_info->short_name       = sys->get_short_name();
   call_info->audio_archive    = sys->get_audio_archive();
+  call_info->call_log         = sys->get_call_log();
 
   for (int i = 0; i < call_info->source_count; i++) {
     call_info->source_list.push_back(source_list[i]);

--- a/trunk-recorder/uploaders/call_uploader.cc
+++ b/trunk-recorder/uploaders/call_uploader.cc
@@ -20,15 +20,23 @@ void* upload_call_thread(void *thread_arg) {
   int nchars = snprintf(shell_command, 400, "sox %s -t wav - --norm=-3 | fdkaac --silent --ignorelength -b 8000 -o %s -", call_info->filename, call_info->converted);
 
   if (nchars >= 400) {
-    BOOST_LOG_TRIVIAL(error) << "Call uploader: Path longer than 400 characters";
+    BOOST_LOG_TRIVIAL(error) << "Call uploader: Command longer than 400 characters";
+    delete(call_info);
+    return NULL;
   }
 
-  // BOOST_LOG_TRIVIAL(info) << "Converting: " << call_info->converted << "\n";
-  // BOOST_LOG_TRIVIAL(info) <<"Command: " << shell_command << "\n";
-  system(shell_command);
-  //int rc = system(shell_command);
+  BOOST_LOG_TRIVIAL(trace) << "Converting: " << call_info->converted;
+  BOOST_LOG_TRIVIAL(trace) << "Command: " << shell_command;
 
-  // BOOST_LOG_TRIVIAL(info) << "Finished converting\n";
+  int rc = system(shell_command);
+
+  if (rc > 0) {
+    BOOST_LOG_TRIVIAL(error) << "Failed to convert call recording, see above error. Make sure you have sox and fdkaac installed.";
+    delete(call_info);
+    return NULL;
+  } else {
+    BOOST_LOG_TRIVIAL(trace) << "Finished converting call";
+  }
 
   int error = 0;
 

--- a/trunk-recorder/uploaders/uploader.h
+++ b/trunk-recorder/uploaders/uploader.h
@@ -21,6 +21,7 @@ struct call_data_t {
     bool encrypted;
     bool emergency;
     bool audio_archive;
+    bool call_log;
     char filename[255];
     char status_filename[255];
     char converted[255];


### PR DESCRIPTION
This PR adds two enhancements to provide a smoother experience when using trunk-recorder only for Broadcastify Calls.

First, if a user forgets to install sox or fdkaac, and so the wav conversion fails, the upload thread will alert the user and not continue on to try and upload the call. Here's what this looks like:

```
[2020-05-03 18:17:31.857895] (info)   	- Starting P25 Recorder Num [0]	TG:       9008	Freq: 770.943750 MHz 	TDMA: false	Slot: 0
[2020-05-03 18:17:31.858128] (info)   [sc21102]	TG:       9008	Freq: 770.943750 MHz	Starting Recorder on Src: rtl=1,buflen=65536
[2020-05-03 18:17:32.750410] (info)   [sc21102]	TG:       9008	Freq: 772.643750 MHz	Update Retuning - New Freq: 772.643750 MHz	Elapsed: 1s 	Since update: 0s
[2020-05-03 18:17:33.003577] (info)   [sc21102]	TG:       3981	Freq: 773.531250 MHz	Ending Recorded Call - Last Update: 4s	Call Elapsed: A
[2020-05-03 18:17:33.003776] (info)   	- Stopping P25 Recorder Num [1]	TG:       3981	Freq: 773.531250 MHz 	TDMA: false	Slot: 0
sh: 1: sox: not found
ERROR: unsupported input file
[2020-05-03 18:17:33.012433] (error)   Failed to convert call recording, see above error. Make sure you have sox and fdkaac installed.
[2020-05-03 18:17:37.004152] (info)   [sc21102]	TG:       9008	Freq: 772.643750 MHz	Ending Recorded Call - Last Update: 4s	Call Elapsed: 6
[2020-05-03 18:17:37.004470] (info)   	- Stopping P25 Recorder Num [0]	TG:       9008	Freq: 772.643750 MHz 	TDMA: false	Slot: 0
sh: 1: sox: not found
ERROR: unsupported input file
[2020-05-03 18:17:37.012710] (error)   Failed to convert call recording, see above error. Make sure you have sox and fdkaac installed.
[2020-05-03 18:17:57.601939] (info)   [sc21102]	TG:       2753	Freq: 773.293750 MHz	TG not in Talkgroup File 
[2020-05-03 18:17:57.602028] (info)   	- Starting P25 Recorder Num [0]	TG:       2753	Freq: 773.293750 MHz 	TDMA: false	Slot: 0
[2020-05-03 18:17:57.602252] (info)   [sc21102]	TG:       2753	Freq: 773.293750 MHz	Starting Recorder on Src: rtl=1,buflen=65536
```

Second, it changes the behavior of the `callLog` config option slightly, so that a JSON file is always generated, but like `audioArchive`, when `callLog` is false the JSON will get deleted after the builtin call upload as well as any other upload scripts run. This means that both audioArchive and callLog can be false, and uploads will still work.

I tested this by turning both off and doing `watch ls -lt` within the appropriate media directory, seeing that the only new files created were temporary ones for the current call being recorded/uploaded.

The diff looks a bit bigger than it actually is because there's whitespace changes from unindenting a block.