### PR TITLE
Adding support for GNURadio 3.8, introducing install and rebuild scripts for easier installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,13 @@ find_package(CppUnit)
 #    find_package(Gnuradio)
 #endif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 
-set(GR_REQUIRED_COMPONENTS ANALOG DIGITAL RUNTIME BLOCKS FILTER PMT)
-find_package(Gnuradio)
+set(GR_REQUIRED_COMPONENTS ANALOG DIGITAL RUNTIME BLOCKS FILTER PMT FFT)
+find_package(Gnuradio REQUIRED COMPONENTS analog blocks digital filter fft)
 find_package(GnuradioRuntime)
 find_package(CppUnit)
+
+math(EXPR GNURADIO_VERSION "(${Gnuradio_VERSION_MAJOR} / 10) << 20 | (${Gnuradio_VERSION_MAJOR} % 10) << 16 | (${Gnuradio_VERSION_MINOR} / 10) << 12 | (${Gnuradio_VERSION_MINOR} % 10) <<  8 | (${Gnuradio_VERSION_PATCH} / 10) <<  4 | (${Gnuradio_VERSION_PATCH} % 10) <<  0   ")
+message(STATUS "GnuRadio Version: " ${GNURADIO_VERSION})
 
 if(NOT GNURADIO_RUNTIME_FOUND)
     message(FATAL_ERROR "GnuRadio Runtime required to compile Trunk Recorder")
@@ -105,9 +108,7 @@ find_package(UHD)
 find_package(OpenSSL REQUIRED)
 find_package(CURL REQUIRED)
 
-if(NOT GNURADIO_RUNTIME_FOUND)
-    message(FATAL_ERROR "GnuRadio Runtime required to build " ${CMAKE_PROJECT_NAME})
-endif()
+
 
 ########################################################################
 # Setup boost
@@ -141,14 +142,14 @@ set(Boost_ADDITIONAL_VERSIONS
     "1.70.0" "1.70" "1.71.0" "1.71" "1.72.0" "1.72" "1.73.0" "1.73" "1.74.0" "1.74"
 )
 
-find_package(Boost COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+find_package(Boost COMPONENTS ${BOOST_REQUIRED_COMPONENTS} REQUIRED)
 
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost required to build " ${CMAKE_PROJECT_NAME})
 endif()
 
 ADD_DEFINITIONS(-DBOOST_ALL_DYN_LINK)
-
+add_definitions(-DGNURADIO_VERSION=${GNURADIO_VERSION})
 
 ########################################################################
 # Setup the include and linker paths
@@ -175,16 +176,13 @@ link_directories(
     ${OPENSSL_ROOT_DIR}/lib
 )
 
-
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wno-unused-local-typedef -Wno-deprecated-declarations -Wno-error=deprecated-declarations -g")
 
 SET(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wno-narrowing")
 
-
 add_subdirectory(lib/op25_repeater)
-
 
 list(APPEND trunk_recorder_sources
   trunk-recorder/main.cc
@@ -240,4 +238,13 @@ target_compile_options(
 
 add_executable(recorder ${trunk_recorder_sources})
 
-target_link_libraries(recorder ssl crypto ${CURL_LIBRARIES} ${GNURADIO_PMT_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_FILTER_LIBRARIES} ${GNURADIO_DIGITAL_LIBRARIES} ${GNURADIO_ANALOG_LIBRARIES} ${GNURADIO_AUDIO_LIBRARIES} ${GNURADIO_UHD_LIBRARIES} ${UHD_LIBRARIES} ${GNURADIO_BLOCKS_LIBRARIES} ${GROSMOSDR_LIBRARIES} ${Boost_LIBRARIES} ${LIBOP25_REPEATER_LIBRARIES}  gnuradio-op25_repeater imbe_vocoder)
+target_link_libraries(recorder ssl crypto ${CURL_LIBRARIES} ${Boost_LIBRARIES} ${GNURADIO_PMT_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_FILTER_LIBRARIES} ${GNURADIO_DIGITAL_LIBRARIES} ${GNURADIO_ANALOG_LIBRARIES} ${GNURADIO_AUDIO_LIBRARIES} ${GNURADIO_UHD_LIBRARIES} ${UHD_LIBRARIES} ${GNURADIO_BLOCKS_LIBRARIES} ${GROSMOSDR_LIBRARIES}  ${LIBOP25_REPEATER_LIBRARIES} gnuradio-op25_repeater imbe_vocoder)
+message(STATUS "All libraries:" ${GNURADIO_ALL_LIBRARIES})
+if(NOT Gnuradio_VERSION VERSION_LESS "3.8")
+    target_link_libraries(recorder
+        gnuradio::gnuradio-analog
+        gnuradio::gnuradio-blocks
+        gnuradio::gnuradio-digital
+        gnuradio::gnuradio-filter
+    )
+endif()

--- a/blacklist-rtl.conf
+++ b/blacklist-rtl.conf
@@ -1,0 +1,4 @@
+blacklist dvb_usb_rtl28xxu
+blacklist rtl2832
+blacklist rtl2830
+blacklist rtl2838

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+set -e
+
+# trunk-recorder install script for debian based systems
+# including ubuntu 18.04/20.04 and raspbian
+
+if [ ! -d trunk-recorder/recorders ]; then
+	echo ====== ERROR: trunk-recorder top level directories not found.
+	echo ====== You must change to the trunk-recorder top level directory
+	echo ====== before running this script.
+	exit
+fi
+
+sudo apt-get update
+sudo apt-get install gnuradio gnuradio-dev gr-osmosdr libhackrf-dev libuhd-dev libgmp-dev
+sudo apt-get install git cmake build-essential libboost-all-dev libusb-1.0-0.dev libssl-dev libcurl4-openssl-dev liborc-0.4-dev
+
+mkdir build
+cd build
+cmake ../
+make
+sudo cp -i recorder /usr/local/bin/trunk-recorder
+
+cd ..
+
+if [ ! -f /etc/modprobe.d/blacklist-rtl.conf ]; then
+	echo ====== Installing blacklist-rtl.conf for selecting the correct RTL-SDR drivers
+	echo ====== Please reboot before running trunk-recorder.
+	sudo install -m 0644 ./blacklist-rtl.conf /etc/modprobe.d/
+fi

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+git pull
+mkdir -p build
+cd build
+rm -rf *
+cmake ../
+make
+sudo cp -i recorder /usr/local/bin/trunk-recorder

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -20,11 +20,16 @@
 
 #include <gnuradio/block.h>
 #include <gnuradio/blocks/copy.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
+#if GNURADIO_VERSION < 0x030800
+#include <gnuradio/filter/fir_filter_fff.h>
 
+#include <gnuradio/blocks/multiply_const_ff.h>
+#else
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/blocks/multiply_const.h>
+#endif
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/filter/iir_filter_ffd.h>
-#include <gnuradio/filter/fir_filter_fff.h>
 #include <gnuradio/filter/fft_filter_ccf.h>
 
 #include <gnuradio/analog/quadrature_demod_cf.h>

--- a/trunk-recorder/recorders/debug_recorder.h
+++ b/trunk-recorder/recorders/debug_recorder.h
@@ -20,24 +20,29 @@
 #include <gnuradio/hier_block2.h>
 
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/fir_filter_ccc.h>
-#include <gnuradio/filter/fir_filter_ccf.h>
-#include <gnuradio/filter/fir_filter_fff.h>
 #include <gnuradio/filter/pfb_arb_resampler_ccf.h>
-#include <gnuradio/filter/fft_filter_fff.h>
-
-#include <gnuradio/analog/sig_source_c.h>
 #include <gnuradio/analog/pwr_squelch_cc.h>
 #include <gnuradio/analog/feedforward_agc_cc.h>
 #include <gnuradio/analog/pll_freqdet_cf.h>
 #include <gnuradio/digital/diff_phasor_cc.h>
 
+#if GNURADIO_VERSION < 0x030800
+#include <gnuradio/analog/sig_source_c.h>
+#include <gnuradio/blocks/multiply_cc.h>
+#include <gnuradio/blocks/multiply_const_ff.h>
+#include <gnuradio/blocks/multiply_const_ss.h>
+#include <gnuradio/filter/fir_filter_ccf.h>
+#include <gnuradio/filter/fir_filter_fff.h>
+#else
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/blocks/multiply_const.h>
+#endif
+
 #include <gnuradio/block.h>
 #include <gnuradio/blocks/copy.h>
 #include <gnuradio/blocks/short_to_float.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
-#include <gnuradio/blocks/multiply_cc.h>
-#include <gnuradio/blocks/multiply_const_ss.h>
 #include <gnuradio/blocks/complex_to_arg.h>
 
 #include <op25_repeater/include/op25_repeater/fsk4_demod_ff.h>

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -17,15 +17,11 @@
 
 #include <gnuradio/io_signature.h>
 #include <gnuradio/hier_block2.h>
-
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/fir_filter_ccc.h>
-#include <gnuradio/filter/fir_filter_ccf.h>
-#include <gnuradio/filter/fir_filter_fff.h>
+
 #include <gnuradio/filter/pfb_arb_resampler_ccf.h>
 #include <gnuradio/filter/fft_filter_fff.h>
 
-#include <gnuradio/analog/sig_source_c.h>
 #include <gnuradio/analog/pwr_squelch_cc.h>
 #include <gnuradio/analog/feedforward_agc_cc.h>
 #include <gnuradio/analog/pll_freqdet_cf.h>
@@ -34,9 +30,22 @@
 #include <gnuradio/block.h>
 #include <gnuradio/blocks/copy.h>
 #include <gnuradio/blocks/short_to_float.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
+
+#if GNURADIO_VERSION < 0x030800
+#include <gnuradio/analog/sig_source_c.h>
 #include <gnuradio/blocks/multiply_cc.h>
+#include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/blocks/multiply_const_ss.h>
+#include <gnuradio/filter/fir_filter_ccc.h>
+#include <gnuradio/filter/fir_filter_ccf.h>
+#include <gnuradio/filter/fir_filter_fff.h>
+#else
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#endif
+
 #include <gnuradio/blocks/complex_to_arg.h>
 
 #include <op25_repeater/include/op25_repeater/fsk4_demod_ff.h>

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -17,21 +17,32 @@
 
 #include <gnuradio/io_signature.h>
 #include <gnuradio/hier_block2.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/fir_filter_ccf.h>
-#include <gnuradio/filter/fir_filter_fff.h>
-#include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
-#include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/rational_resampler_base_ccc.h>
-#include <gnuradio/analog/quadrature_demod_cf.h>
-#include <gnuradio/analog/quadrature_demod_cf.h>
+
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/analog/sig_source_f.h>
 #include <gnuradio/analog/sig_source_c.h>
+#include <gnuradio/filter/fir_filter_ccf.h>
+#include <gnuradio/filter/fir_filter_fff.h>
+#include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/blocks/multiply_cc.h>
-#include <gnuradio/blocks/file_sink.h>
+#include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
+#include <gnuradio/filter/rational_resampler_base_ccc.h>
 #include <gnuradio/filter/rational_resampler_base_ccf.h>
 #include <gnuradio/filter/rational_resampler_base_fff.h>
+#else
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
+#include <gnuradio/filter/rational_resampler_base.h>
+#endif
+
+#include <gnuradio/analog/quadrature_demod_cf.h>
+
+#include <gnuradio/blocks/file_sink.h>
+
 #include <gnuradio/block.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/blocks/copy.h>

--- a/trunk-recorder/recorders/sigmf_recorder.h
+++ b/trunk-recorder/recorders/sigmf_recorder.h
@@ -17,17 +17,13 @@
 
 #include <gnuradio/io_signature.h>
 #include <gnuradio/hier_block2.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/fir_filter_ccf.h>
-#include <gnuradio/filter/fir_filter_fff.h>
-#include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/rational_resampler_base_ccc.h>
+
 
 #include <gnuradio/analog/quadrature_demod_cf.h>
 
-#include <gnuradio/analog/sig_source_c.h>
+
 #include <gnuradio/analog/feedforward_agc_cc.h>
 #include <gnuradio/analog/agc2_ff.h>
 #include <gnuradio/analog/agc2_cc.h>
@@ -36,14 +32,30 @@
 #include <gnuradio/blocks/complex_to_arg.h>
 
 
+#if GNURADIO_VERSION < 0x030800
+#include <gnuradio/analog/sig_source_c.h>
 #include <gnuradio/blocks/multiply_cc.h>
 #include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/blocks/multiply_const_cc.h>
+#include <gnuradio/filter/fir_filter_ccf.h>
+#include <gnuradio/filter/fir_filter_fff.h>
+#include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
+#include <gnuradio/filter/rational_resampler_base_ccf.h>
+#include <gnuradio/filter/rational_resampler_base_fff.h>
+#include <gnuradio/filter/rational_resampler_base_ccc.h>
+#else
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
+#include <gnuradio/filter/rational_resampler_base.h>
+#endif
+
 
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/filter/pfb_arb_resampler_ccf.h>
-#include <gnuradio/filter/rational_resampler_base_ccf.h>
-#include <gnuradio/filter/rational_resampler_base_fff.h>
+
 
 #include <gnuradio/block.h>
 #include <gnuradio/blocks/null_sink.h>

--- a/trunk-recorder/systems/p25_trunking.h
+++ b/trunk-recorder/systems/p25_trunking.h
@@ -20,19 +20,28 @@
 #include <gnuradio/hier_block2.h>
 
 #include <gnuradio/block.h>
+
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/blocks/multiply_cc.h>
+#include <gnuradio/filter/fir_filter_ccf.h>
+#include <gnuradio/filter/fir_filter_fff.h>
+#include <gnuradio/analog/sig_source_c.h>
+#else
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/analog/sig_source.h>
+#endif
+
 #include <gnuradio/blocks/complex_to_arg.h>
 #include <gnuradio/blocks/short_to_float.h>
 
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/fir_filter_ccf.h>
 #include <gnuradio/filter/fft_filter_ccf.h>
-#include <gnuradio/filter/fir_filter_fff.h>
 #include <gnuradio/filter/pfb_arb_resampler_ccf.h>
 #include <gnuradio/filter/fft_filter_fff.h>
 
-#include <gnuradio/analog/sig_source_c.h>
 #include <gnuradio/analog/quadrature_demod_cf.h>
 #include <gnuradio/analog/feedforward_agc_cc.h>
 #include <gnuradio/analog/pll_freqdet_cf.h>

--- a/trunk-recorder/systems/smartnet_trunking.h
+++ b/trunk-recorder/systems/smartnet_trunking.h
@@ -11,19 +11,26 @@
 
 #include <gnuradio/filter/firdes.h>
 
+#if GNURADIO_VERSION < 0x030800
+#include <gnuradio/filter/fir_filter_fff.h>
+#include <gnuradio/analog/sig_source_c.h>
+#include <gnuradio/blocks/multiply_cc.h>
+#else
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/blocks/multiply.h>
+#endif
+
 #include <gnuradio/filter/fft_filter_ccc.h>
 #include <gnuradio/filter/fft_filter_ccf.h>
-#include <gnuradio/filter/fir_filter_fff.h>
 #include <gnuradio/filter/pfb_arb_resampler_ccf.h>
 #include <gnuradio/digital/fll_band_edge_cc.h>
 #include <gnuradio/digital/clock_recovery_mm_ff.h>
 #include <gnuradio/digital/binary_slicer_fb.h>
 #include <gnuradio/digital/correlate_access_code_tag_bb.h>
 
-#include <gnuradio/analog/sig_source_c.h>
-#include <gnuradio/analog/pll_freqdet_cf.h>
 
-#include <gnuradio/blocks/multiply_cc.h>
+#include <gnuradio/analog/pll_freqdet_cf.h>
 
 
 #include "smartnet_decode.h"


### PR DESCRIPTION
With Ubuntu 20.04 being released for a few weeks now, there will be more people trying to compile this on that version, however it won't work because the GNURadio dependency is on 3.8.

I rebased https://github.com/robotastic/trunk-recorder/tree/gr3.8 on top of the latest master branch, resolving merge conflicts in the process to account for newly introduced code.

I tested this by running the `install.sh` script on fresh Ubuntu 18.04.4 and 20.04 VMs (standard live CD install), verifying that the project could successfully compile on both. Then I did a quick test run on a P25 trunked system. I don't have an easy way to test on a Raspberry Pi, so wasn't able to do it there.

The install and rebuild scripts are something I took from the OP25 project, adjusting the actual dependencies needed to match what is needed for this project (based on the Dockerfile and my own testing). If accepted, this could be added to the wiki or README as an easy way to get the project running on a Debian-based system.