### PR TITLE
Adding auto gain control option to source if it supports it

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Here are the different arguments:
    - **center** - the center frequency in Hz to tune the SDR to
    - **rate** - the sampling rate to set the SDR to, in samples / second
    - **squelch** - Analog Squelch, my rtl-sdr's are around -60. [0 = Disabled] _Squelch needs to be set if the System using the source is conventional._
-   - **error** - the tuning error for the SDR in Hz. This is the difference between the target value and the actual value. So if you wanted to recv 856MHz but you had to tune your SDR to 855MHz to actually receive it, you would set this to -1000000. You should also probably get a new SDR if it is off by this much.
+   - **error** - the tuning error for the SDR in Hz. This is the difference between the target value and the actual value. So if you wanted to recv 856MHz but you had to tune your SDR to 855MHz (when set to 0ppm)  to actually receive it, you would set this to -1000000. You should also probably get a new SDR if it is off by this much.
+   - **ppm** - the tuning error for the SDR in ppm (parts per million), as an alternative to `error` above. Use a program like GQRX to find an accurate value.
+   - **agc** - whether or not to enable the SDR's automatic gain control (if supported). This is false by default. It is not recommended to set this as it often yields worse performance compared to a manual gain setting.
    - **gain** - the RF gain to set the SDR to. Use a program like GQRX to find a good value.
    - **ifGain** - [hackrf only] sets the if gain.
    - **bbGain** - [hackrf only] sets the bb gain.

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -151,6 +151,7 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       double rate           = node.second.get<double>("rate", 0);
       double error          = node.second.get<double>("error", 0);
       double ppm            = node.second.get<double>("ppm", 0);
+      bool   agc            = node.second.get<bool>("agc", false);
       int    gain           = node.second.get<double>("gain", 0);
       int    if_gain        = node.second.get<double>("ifGain", 0);
       int    bb_gain        = node.second.get<double>("bbGain", 0);
@@ -181,6 +182,7 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
       BOOST_LOG_TRIVIAL(info) << "Rate: " << node.second.get<double>("rate", 0);
       BOOST_LOG_TRIVIAL(info) << "Error: " << node.second.get<double>("error", 0);
       BOOST_LOG_TRIVIAL(info) << "PPM Error: " <<  node.second.get<double>("ppm", 0);
+      BOOST_LOG_TRIVIAL(info) << "Auto gain control: " << node.second.get<bool>("agc", false);
       BOOST_LOG_TRIVIAL(info) << "Gain: " << node.second.get<double>("gain", 0);
       BOOST_LOG_TRIVIAL(info) << "IF Gain: " << node.second.get<double>("ifGain", 0);
       BOOST_LOG_TRIVIAL(info) << "BB Gain: " << node.second.get<double>("bbGain", 0);
@@ -259,6 +261,7 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
         source->set_vga2_gain(vga2_gain);
       }
 
+      source->set_gain_mode(agc);
       source->set_gain(gain);
       source->set_antenna(antenna);
       source->set_squelch_db(squelch_db);

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -363,6 +363,7 @@ void load_config(string config_file)
       double rate           = node.second.get<double>("rate", 0);
       double error          = node.second.get<double>("error", 0);
       double ppm            = node.second.get<double>("ppm", 0);
+      bool   agc            = node.second.get<bool>("agc", false);
       int    gain           = node.second.get<double>("gain", 0);
       int    if_gain        = node.second.get<double>("ifGain", 0);
       int    bb_gain        = node.second.get<double>("bbGain", 0);
@@ -393,6 +394,7 @@ void load_config(string config_file)
       BOOST_LOG_TRIVIAL(info) << "Rate: " << FormatSamplingRate(node.second.get<double>("rate", 0));
       BOOST_LOG_TRIVIAL(info) << "Error: " << node.second.get<double>("error", 0);
       BOOST_LOG_TRIVIAL(info) << "PPM Error: " <<  node.second.get<double>("ppm", 0);
+      BOOST_LOG_TRIVIAL(info) << "Auto gain control: " << node.second.get<bool>("agc", false);
       BOOST_LOG_TRIVIAL(info) << "Gain: " << node.second.get<double>("gain", 0);
       BOOST_LOG_TRIVIAL(info) << "IF Gain: " << node.second.get<double>("ifGain", 0);
       BOOST_LOG_TRIVIAL(info) << "BB Gain: " << node.second.get<double>("bbGain", 0);
@@ -487,6 +489,7 @@ void load_config(string config_file)
         BOOST_LOG_TRIVIAL(error) << "! No Gain was specified! Things will probably not work";
       }
 
+      source->set_gain_mode(agc);
       source->set_antenna(antenna);
       source->set_squelch_db(squelch_db);
       source->set_analog_levels(analog_levels);

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -240,6 +240,22 @@ int Source::get_gain() {
   return gain;
 }
 
+void Source::set_gain_mode(bool m) {
+  if (driver == "osmosdr") {
+    gain_mode = m;
+    cast_to_osmo_sptr(source_block)->set_gain_mode(gain_mode);
+    if (cast_to_osmo_sptr(source_block)->get_gain_mode()) {
+      BOOST_LOG_TRIVIAL(info) << "Auto gain control is ON";
+    } else {
+      BOOST_LOG_TRIVIAL(info) << "Auto gain control is OFF";
+    }
+  }
+}
+
+bool Source::get_gain_mode() {
+  return gain_mode;
+}
+
 void Source::set_if_gain(int i)
 {
   if (driver == "osmosdr") {
@@ -255,6 +271,7 @@ void Source::set_freq_corr(double p)
 
   if (driver == "osmosdr") {
     cast_to_osmo_sptr(source_block)->set_freq_corr(ppm);
+    BOOST_LOG_TRIVIAL(info) << "PPM set to: " << cast_to_osmo_sptr(source_block)->get_freq_corr();
   }
 }
 

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -26,6 +26,7 @@ class Source
 								double squelch_db;
 								double analog_levels;
 								double digital_levels;
+								bool gain_mode;
 								int gain;
 								int bb_gain;
 								int if_gain;
@@ -73,6 +74,8 @@ public:
 								int get_if_gain();
 								void set_squelch_db(double s);
 								double get_squelch_db();
+								void set_gain_mode(bool m);
+								bool get_gain_mode();
 								void set_gain(int r);
 								int get_gain();
 								void set_qpsk_mod(bool m);


### PR DESCRIPTION
Since some SDRs (like the RTL-SDR) support the ability for AGC to be turned on/off, I figured that setting should be available in the config. Added it to the relevant spots, as well as updated the README. Tested it on my own RTL-SDR.

I included a warning on it since I've read that most SDR AGC's don't work that well for the kind of narrowband monitoring done here.

I also added a line for ppm in the README since people have already been using it but it wasn't officially documented.