### PR TITLE
Adding maximum call duration to split long calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Here are the different arguments:
  - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile** the options are *digital* or *analog*.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
+ - **maxDuration** - If a call is being recorded and the duration exceeds this value in seconds, the call will stop recording and a new call will pick up where the previous on left off. The default is *0* or "no timeout".
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.
  - **frequencyFormat** - the display format for frequencies to display in the console and log file. The options are *exp*, *mhz* & *hz*. The default is *exp*.
  - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -140,6 +140,8 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
     BOOST_LOG_TRIVIAL(info) << "Log to File: " << config.log_file;
     config.control_message_warn_rate = pt.get<int>("controlWarnRate", 10);
     BOOST_LOG_TRIVIAL(info) << "Control channel rate warning: " << config.control_message_warn_rate;
+    config.max_duration = pt.get<int>("maxDuration", 0);
+    BOOST_LOG_TRIVIAL(info) << "Maximum Call Duration (seconds): " << config.max_duration;
 
 
     BOOST_FOREACH(boost::property_tree::ptree::value_type  & node,

--- a/trunk-recorder/config.h
+++ b/trunk-recorder/config.h
@@ -26,6 +26,7 @@ struct Config {
         int call_timeout;
         bool log_file;
         int control_message_warn_rate;
+        int max_duration;
         int control_retune_limit;
         bool broadcast_signals;
 };

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -543,6 +543,8 @@ void load_config(string config_file)
     BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
     config.control_retune_limit = pt.get<int>("controlRetuneLimit", 0);
     BOOST_LOG_TRIVIAL(info) << "Control channel retune limit: " << config.control_retune_limit;
+    config.max_duration = pt.get<int>("maxDuration", 0);
+    BOOST_LOG_TRIVIAL(info) << "Maximum Call Duration (seconds): " << config.max_duration;
 
     BOOST_LOG_TRIVIAL(info) << "Frequency format: " << frequencyFormat;
 
@@ -749,8 +751,8 @@ void stop_inactive_recorders() {
           call->reset_idle_count();
         }
 
-        // if no additional recording has happened in the past X periods, stop and open new file
-        if (call->get_idle_count() > 5) {
+        // if no additional recording has happened in the past X periods, or the call has gone on for longer than max_duration, stop and open new file
+        if (call->get_idle_count() > 5 || ( call->get_current_length() > config.max_duration && config.max_duration > 0 )) {
           Recorder * recorder = call->get_recorder();
           call->end_call();
           stats.send_call_end(call);


### PR DESCRIPTION
This implements enhancement #197 - if the length of call audio exceeds a user-specified duration, it will end the call and start a new one where it left off. If no duration is specified it will default to 0 (the current behavior). To clear up the confusion from #197, the duration is measured by the length of active transmission/audio, not real-time.

I didn't actually implement the change (see the co-author), but I've been using it for a couple months now on https://openmhz.com/system/chi_cpd to split up long calls.

Fixes #197