### PR TITLE
Clear analog source list on call end, adding support for P25 conventional source ID logging

### DIFF
--- a/lib/gr_blocks/nonstop_wavfile_sink.h
+++ b/lib/gr_blocks/nonstop_wavfile_sink.h
@@ -72,6 +72,9 @@ public:
 	 */
 	virtual void set_bits_per_sample(int bits_per_sample) = 0;
 	virtual double length_in_seconds() = 0;
+
+	virtual void set_call(Call* call) {};
+	virtual void end_call() {};
 };
 
 } /* namespace blocks */

--- a/lib/gr_blocks/nonstop_wavfile_sink.h
+++ b/lib/gr_blocks/nonstop_wavfile_sink.h
@@ -74,7 +74,6 @@ public:
 	virtual double length_in_seconds() = 0;
 
 	virtual void set_call(Call* call) {};
-	virtual void end_call() {};
 };
 
 } /* namespace blocks */

--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
@@ -213,6 +213,25 @@ bool nonstop_wavfile_sink_impl::stop()
   return true;
 }
 
+void nonstop_wavfile_sink_impl::log_p25_metadata(long unitId, const char* system_type, bool emergency)
+{
+  if (d_current_call == NULL) {
+    BOOST_LOG_TRIVIAL(debug) << "Unable to log: " << system_type << " : " << unitId << ", no current call.";
+  }
+  else {
+    BOOST_LOG_TRIVIAL(debug) << "Logging " << system_type << " : " << unitId << " to current call.";
+    d_current_call->add_signal_source(unitId, system_type, emergency ? SignalType::Emergency : SignalType::Normal);
+  }
+}
+
+void nonstop_wavfile_sink_impl::set_call(Call* call) {
+  d_current_call = call;
+ }
+
+void nonstop_wavfile_sink_impl::end_call() {
+  set_call(NULL);
+}
+
 int nonstop_wavfile_sink_impl::work(int noutput_items,  gr_vector_const_void_star& input_items,  gr_vector_void_star& output_items) {
   
   gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this
@@ -238,17 +257,19 @@ int nonstop_wavfile_sink_impl::dowork(int noutput_items,  gr_vector_const_void_s
   pmt::pmt_t this_key(pmt::intern("src_id"));
   get_tags_in_range(tags, 0, nitems_read(0), nitems_read(0) + noutput_items);
 
+  unsigned pos = 0;
+  //long curr_src_id = 0;
+
   for (unsigned int i = 0; i < tags.size(); i++) {
-    if (pmt::eq(this_key, tags[i].key)) {      
-      /*
-      long src_id  = pmt::to_long(tags[i].value);      
-      unsigned pos = d_sample_count + (tags[i].offset - nitems_read(0));      
-      double   sec = (double)pos  / (double)d_sample_rate;
+    if (pmt::eq(this_key, tags[i].key) && d_current_call->get_system_type() == "conventionalP25") {
+      long src_id  = pmt::to_long(tags[i].value);
+      pos = d_sample_count + (tags[i].offset - nitems_read(0));
+      // double   sec = (double)pos  / (double)d_sample_rate;
       if (curr_src_id != src_id) {
-        add_source(src_id, sec);
-        BOOST_LOG_TRIVIAL(trace) << " [" << i << "]-[ " << src_id << " : Pos - " << pos << " offset: " << tags[i].offset - nitems_read(0) << " : " << sec << " ] " << std::endl;
+        log_p25_metadata(src_id, d_current_call->get_system_type().c_str(), false);
+        // BOOST_LOG_TRIVIAL(info) << " [" << i << "]-[ " << src_id << " : Pos - " << pos << " offset: " << tags[i].offset - nitems_read(0) << " : " << sec << " ] " << std::endl;
         curr_src_id = src_id;
-      }*/
+      }
     }
   }
 

--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
@@ -187,6 +187,7 @@ nonstop_wavfile_sink_impl::close()
   }
 
   close_wav();
+  set_call(NULL);
 }
 
 void
@@ -227,10 +228,6 @@ void nonstop_wavfile_sink_impl::log_p25_metadata(long unitId, const char* system
 void nonstop_wavfile_sink_impl::set_call(Call* call) {
   d_current_call = call;
  }
-
-void nonstop_wavfile_sink_impl::end_call() {
-  set_call(NULL);
-}
 
 int nonstop_wavfile_sink_impl::work(int noutput_items,  gr_vector_const_void_star& input_items,  gr_vector_void_star& output_items) {
   

--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.h
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.h
@@ -42,9 +42,11 @@ private:
 	int d_normalize_shift;
 	int d_normalize_fac;
 	bool d_use_float;
+	long curr_src_id;
 
-  	char current_filename[255];
+	char current_filename[255];
 
+	Call* d_current_call;
 protected:
 	
 	unsigned d_sample_count;
@@ -112,6 +114,11 @@ public:
 	virtual int work(int noutput_items,
 	         gr_vector_const_void_star &input_items,
 	         gr_vector_void_star &output_items);
+
+	void set_call(Call* call);
+	void end_call();
+
+	void log_p25_metadata(long unitId, const char* system_type, bool emergency);
 
 };
 

--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.h
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.h
@@ -116,7 +116,6 @@ public:
 	         gr_vector_void_star &output_items);
 
 	void set_call(Call* call);
-	void end_call();
 
 	void log_p25_metadata(long unitId, const char* system_type, bool emergency);
 

--- a/trunk-recorder/call.cc
+++ b/trunk-recorder/call.cc
@@ -442,7 +442,7 @@ bool Call::add_source(long src) {
 void Call::update(TrunkMessage message) {
   last_update = time(NULL);
   if ((message.freq != this->curr_freq) || (message.talkgroup != this->talkgroup)) {
-    BOOST_LOG_TRIVIAL(error) << "[" << sys->get_short_name() << "]\tCall Update, messge mismatch - Call TG: " << get_talkgroup() << "\t Call Freq: " << get_freq() << "\tMsg Tg: " << message.talkgroup << "\tMsg Freq: " << message.freq;
+    BOOST_LOG_TRIVIAL(error) << "[" << sys->get_short_name() << "]\tCall Update, message mismatch - Call TG: " << get_talkgroup() << "\t Call Freq: " << get_freq() << "\tMsg Tg: " << message.talkgroup << "\tMsg Freq: " << message.freq;
   } else {
     add_source(message.source);
   }

--- a/trunk-recorder/call.cc
+++ b/trunk-recorder/call.cc
@@ -322,6 +322,11 @@ std::vector<Call_Source> Call::get_source_list() {
   return src_list;
 }
 
+void Call::clear_src_list() {
+  src_list.clear();
+  src_list.shrink_to_fit();
+}
+
 long Call::get_source_count() {
   if ((state == recording) && !recorder) {
     BOOST_LOG_TRIVIAL(error) << "Call::get_source_count State is recording, but no recorder assigned!";
@@ -498,6 +503,10 @@ char * Call::get_sigmf_filename() {
 
 char * Call::get_debug_filename() {
   return debug_filename;
+}
+
+std::string Call::get_system_type() {
+  return sys->get_system_type().c_str();
 }
 
 void Call::set_talkgroup_tag(std::string tag){

--- a/trunk-recorder/call.h
+++ b/trunk-recorder/call.h
@@ -106,11 +106,13 @@ public:
 								std::string get_talkgroup_display();
 								void set_talkgroup_display_format(std::string format);
 								void set_talkgroup_tag(std::string tag);
+								void clear_src_list();
 								boost::property_tree::ptree get_stats();
 
 								bool add_signal_source(long src, const char* signaling_type, gr::blocks::SignalType signal);
 								
 								std::string get_talkgroup_tag();
+								std::string get_system_type();
 								double get_final_length();
 
 								System* get_system();

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -437,8 +437,8 @@ void load_config(string config_file)
       }
 
       Source *source = new Source(center, rate, error, driver, device, &config);
-      BOOST_LOG_TRIVIAL(info) << "Max Freqency: " << FormatFreq(source->get_max_hz());
-      BOOST_LOG_TRIVIAL(info) << "Min Freqency: " << FormatFreq(source->get_min_hz());
+      BOOST_LOG_TRIVIAL(info) << "Max Frequency: " << FormatFreq(source->get_max_hz());
+      BOOST_LOG_TRIVIAL(info) << "Min Frequency: " << FormatFreq(source->get_min_hz());
 
       if (if_gain != 0) {
         gain_set = true;
@@ -901,10 +901,10 @@ void handle_call(TrunkMessage message, System *sys) {
           int retuned = retune_recorder(message, call);
 
           if (!retuned) {
-            // we want to keep this call recordering, and now start a recording of the new call on another recorder
+            // we want to keep this call recording and now start a recording of the new call on another recorder
             call_found = false;
             retune_failed = true;
-            ++it; // go on to the next call, remember there maybe two calls
+            ++it; // go on to the next call, remember there may be two calls
           } else {
             // if you did retune, update the call info
             BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " << FormatFreq(call->get_freq()) << "\tUpdate Retuning - New Freq: " << FormatFreq(message.freq) << "\tElapsed: " << call->elapsed() << "s \tSince update: " << call->since_last_update() << "s";

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -319,7 +319,8 @@ void analog_recorder::start(Call *call) {
   this->call = call;
 
   setup_decoders_for_system(call->get_system());
-  
+
+  call->clear_src_list();
   talkgroup = call->get_talkgroup();
   chan_freq = call->get_freq();
 

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -555,6 +555,7 @@ void p25_recorder::start(Call *call) {
     wav_sink->open(call->get_filename());
     state = active;
     valve->set_enabled(true);
+    wav_sink->set_call(call);
     recording_count++;
   } else {
     BOOST_LOG_TRIVIAL(error) << "p25_recorder.cc: Trying to Start an already Active Logger!!!";

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -126,6 +126,7 @@ protected:
   bool   qpsk_mod;
 
   gr::op25_repeater::p25_frame_assembler::sptr op25_frame_assembler;
+  gr::op25_repeater::gardner_costas_cc::sptr costas_clock;
   gr::blocks::nonstop_wavfile_sink::sptr wav_sink;
   gr::blocks::copy::sptr valve;
   //gr::blocks::multiply_const_ss::sptr levels;
@@ -199,7 +200,6 @@ private:
   gr::op25_repeater::fsk4_demod_ff::sptr fsk4_demod;
 
   gr::op25_repeater::fsk4_slicer_fb::sptr slicer;
-  gr::op25_repeater::gardner_costas_cc::sptr costas_clock;
 
 };
 

--- a/trunk-recorder/recorders/p25conventional_recorder.cc
+++ b/trunk-recorder/recorders/p25conventional_recorder.cc
@@ -35,6 +35,7 @@ void p25conventional_recorder::start(Call *call) {
     timestamp = time(NULL);
     starttime = time(NULL);
 
+    call->clear_src_list();
     talkgroup = call->get_talkgroup();
     short_name = call->get_short_name();
     chan_freq      = call->get_freq();
@@ -82,6 +83,7 @@ void p25conventional_recorder::start(Call *call) {
     }
     state = active;
     valve->set_enabled(true);
+    wav_sink->set_call(call);
   } else {
     BOOST_LOG_TRIVIAL(error) << "p25conventional_recorder.cc: Trying to Start an already Active Logger!!!";
   }

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -582,7 +582,7 @@ Source::Source(double c, double r, double e, std::string drv, std::string dev, C
     osmo_src->set_sample_rate(rate);
     actual_rate = osmo_src->get_sample_rate();
     BOOST_LOG_TRIVIAL(info) << "Actual sample rate: " << FormatSamplingRate(actual_rate);
-    BOOST_LOG_TRIVIAL(info) << "Tunning to " <<  FormatFreq(center + error);
+    BOOST_LOG_TRIVIAL(info) << "Tuning to " <<  FormatFreq(center + error);
     osmo_src->set_center_freq(center + error, 0);
     gain_names = osmo_src->get_gain_names();
     std::string gain_list;
@@ -619,7 +619,7 @@ Source::Source(double c, double r, double e, std::string drv, std::string dev, C
     usrp_src->set_samp_rate(rate);
     actual_rate = usrp_src->get_samp_rate();
     BOOST_LOG_TRIVIAL(info) << "Actual sample rate: " << FormatSamplingRate(actual_rate);
-    BOOST_LOG_TRIVIAL(info) << "Tunning to " << FormatFreq(center + error);
+    BOOST_LOG_TRIVIAL(info) << "Tuning to " << FormatFreq(center + error);
     usrp_src->set_center_freq(center + error, 0);
 
 


### PR DESCRIPTION
This PR does pretty much what the title says:

1. The analog source logging wasn't getting cleared on call end, so they kept piling up. This fixes that bug.
2. While there was source logging for P25 trunking systems, there wasn't for P25 conventional systems - this adds that feature.

The changes are a subset of those in #322.

I've tested this on an analog system as well as a P25 conventional one and verified on both the source ID logging works as expected, starting fresh for each new call.

I did have to make https://github.com/robotastic/trunk-recorder/commit/4365f1b7459eb612f241437b513a970839960889 to fix a compile error introduced by https://github.com/robotastic/trunk-recorder/commit/a7a645ca7f9f096563ac8da616b58d50609571c6.

Fixes #307
Fixes #142