### PR TITLE
Improve Docker Build Github Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
             --build-arg VERSION=${VERSION} \
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
-            ${TAGS} --file ./test/Dockerfile ./test
+            ${TAGS} --file ./Dockerfile .
       -
         name: Set up Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,14 @@
 name: buildx
 
 on:
+  schedule:
+    - cron: '0 10 * * *' # everyday at 10am
   pull_request:
     branches: master
   push:
     branches: master
     tags:
+      - v*
 
 jobs:
   buildx:
@@ -15,19 +18,73 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Prepare
+        id: prepare
+        run: |
+          DOCKER_IMAGE=robotastic/trunk-recorder
+          DOCKER_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          VERSION=edge
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          fi
+
+          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+          fi
+
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
+            --build-arg VERSION=${VERSION} \
+            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+            --build-arg VCS_REF=${GITHUB_SHA::8} \
+            ${TAGS} --file ./test/Dockerfile ./test
+      -
         name: Set up Docker Buildx
-        id: buildx
         uses: crazy-max/ghaction-docker-buildx@v3
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
         with:
-          buildx-version: latest
-          qemu-version: latest
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       -
-        name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
-      -
-        name: Run Buildx
+        name: Docker Buildx (build)
         run: |
           docker buildx build \
-            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 \
-            --output "type=image,push=false" \
-            --file ./Dockerfile ./
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache" \
+            --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Login
+        if: success() && github.event_name != 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      -
+        name: Docker Buildx (push)
+        if: success() && github.event_name != 'pull_request'
+        run: |
+          docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Check Manifest
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+      -
+        name: Clear
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          rm -f ${HOME}/.docker/config.json


### PR DESCRIPTION
This will do a few things:

* On `push` event, Docker image `robotastic/trunk-recorder:edge` is **built** and **pushed** on DockerHub.
* On `pull_request` event, Docker image `robotastic/trunk-recorder:edge` is **built**.
* On `schedule` event, Docker image `robotastic/trunk-recorder:nightly` is **built** and **pushed** on DockerHub.
* On `push tags` event, Docker image `robotastic/trunk-recorder:<version>` and `robotastic/trunk-recorder:latest` is **built** and **pushed** on DockerHub.

It also uses the built in Github Actions cache functionality to speed up build times.

Continuation of #365, 692c852a313a9b2e36eff84de84a9789b2938ab9 and 2263cd224a43c8046a8d433f05a2471ed9f48c93

@robotastic You'll need to set two [new secrets](https://github.com/robotastic/trunk-recorder/settings/secrets/new) before this works:

- `DOCKER_USERNAME` to your Docker Hub username or email
- `DOCKER_PASSWORD` to your Docker Hub password