### PR TITLE
Updated audioplayer.php

### DIFF
--- a/audioplayer.php
+++ b/audioplayer.php
@@ -68,6 +68,7 @@ try {
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="format-detection" content="telephone=no">
         <title>Trunk Player</title>
         <link href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/flatly/bootstrap.min.css" rel="stylesheet" integrity="sha384-mhpbKVUOPCSocLzx2ElRISIORFRwr1ZbO9bAlowgM5kO7hnpRBe+brVj8NNPUiFs" crossorigin="anonymous">
         <link href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/flatly/bootstrap.min.css" rel="stylesheet" integrity="sha384-mhpbKVUOPCSocLzx2ElRISIORFRwr1ZbO9bAlowgM5kO7hnpRBe+brVj8NNPUiFs" crossorigin="anonymous" media="(prefers-color-scheme: light)">
@@ -98,11 +99,6 @@ try {
                     </div>
                 </form>
                 <div class="row">
-                    <div class="form-group col-lg-12">
-                        <audio preload="none" controls>
-                            Sorry, your browser does not support HTML5 audio.
-                        </audio>
-                    </div>
                     <div class="form-group col-lg-12">Click on a row to begin sequential playback, click file size to download</div>
                 </div>
             </div>
@@ -130,6 +126,15 @@ try {
                     </tr>
 <?php   endforeach; ?>
             </table>
+            <br />
+            <br />
+            <br />
+            <br />
+            <nav class="navbar fixed-bottom navbar-expand-sm navbar-light bg-light">
+                 <audio preload="none" controls>
+                    Sorry, your browser does not support HTML5 audio.
+                 </audio>
+            </nav>
         </div>
         <script>
             window.onload = _ => {

--- a/audioplayer.php
+++ b/audioplayer.php
@@ -1,13 +1,14 @@
 <?php
-$FileType = '.wav';
+$FileType = '.m4a';
 
-$system = (empty($_GET['system'])) ? NULL : $_GET['system'];
+$system = (empty($_GET['system'])) ? null : $_GET['system'];
 $date   = (isset($_GET['date'])) ? new DateTimeImmutable($_GET['date']) : new DateTimeImmutable();
-$tg     = (empty($_GET['tg'])) ? NULL : $_GET['tg'];
+$tg     = (empty($_GET['tg'])) ? null : $_GET['tg'];
 
 $CONFIG = (function (string $configFilePath = './config.json') {
-    if (!file_exists($configFilePath))
+    if (!file_exists($configFilePath)) {
         return false;
+    }
 
     return json_decode(file_get_contents($configFilePath));
 })();
@@ -15,8 +16,9 @@ $CONFIG = (function (string $configFilePath = './config.json') {
 $TGFile = function (string $tgFilePath): array {
     $return = [];
 
-    if (!file_exists($tgFilePath))
+    if (!file_exists($tgFilePath)) {
         return $return;
+    }
 
     foreach (file($tgFilePath) as $line) {
         [$DEC, $HEX, $Mode, $AlphaTag, $Description, $Tag, $Group, $Priority] = str_getcsv($line);
@@ -31,54 +33,45 @@ foreach ($CONFIG->systems as $system) {
     $TGS += $TGFile($system->talkgroupsFile);
 }
 
-$MHz = function (float $MHz): string {
-    switch (TRUE) {
-        case $MHz >= 136 AND $MHz <= 174:
-            return 'text-primary'; # VHF
-        case $MHz >= 380 AND $MHz <= 520:
-            return 'text-danger';  # UHF
-        case $MHz >= 764 AND $MHz <= 870:
-            return 'text-warning'; # 700
-        case $MHz >= 896 AND $MHz <= 901:
-        case $MHz >= 935 AND $MHz <= 940:
-            return 'text-success'; # 800
-        default:
-            return 'null';
-    }
-};
-
 $files = [];
-try  {
-    foreach (new DirectoryIterator("{$CONFIG->captureDir}/{$date->format('Y/n/j')}/") as $file) {
-        $EXT = '.' . $file->getExtension();
-        if ($EXT != $FileType)
-            continue;
+try {
+    foreach ($CONFIG->systems as $system) {
+        $SHORTNAME = "{$system->shortName}";
+        foreach (new DirectoryIterator("{$CONFIG->captureDir}/$SHORTNAME/{$date->format('Y/n/j')}/") as $file) {
+            $EXT = '.' . $file->getExtension();
+            if ($EXT != $FileType) {
+                continue;
+            }
 
-        $Basename = $file->getBasename($EXT);
-        [$TGID, $TIME, $FREQ] = preg_split('/[-_]/', $Basename);
-        if ($TGID != $tg AND $tg !== NULL)
-            continue;
+            $Basename = $file->getBasename($EXT);
+            [$TGID, $TIME, $FREQ] = preg_split('/[-_]/', $Basename);
 
-        if ($file->getSize() < 1024)
-            continue;   # Filtered because they will produce an error when attempting playback.
+            if ($TGID != $tg and $tg !== null) {
+                continue;
+            }
 
-        $files[$file->getMTime()] = [$Basename, round($file->getSize() / 1024), $TGID, $TIME, $FREQ / 1000000];
+            if ($file->getSize() < 1024) {
+                continue;
+            }   # Filtered because they will produce an error when attempting playback.
+
+            $files[$TIME . $FREQ] = [$Basename, round($file->getSize() / 1024), $TGID, $TIME, $FREQ / 1000000, $SHORTNAME];
+        }
     }
     ksort($files);
 } catch (UnexpectedValueException $e) {
     $error = 'No directory found for that date.';
 }
 
-$path = substr(realpath($CONFIG->captureDir), strlen($_SERVER['DOCUMENT_ROOT']));
-
 ?>
 <!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>Trunk Player</title>
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+        <link href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/flatly/bootstrap.min.css" rel="stylesheet" integrity="sha384-mhpbKVUOPCSocLzx2ElRISIORFRwr1ZbO9bAlowgM5kO7hnpRBe+brVj8NNPUiFs" crossorigin="anonymous">
+        <link href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/flatly/bootstrap.min.css" rel="stylesheet" integrity="sha384-mhpbKVUOPCSocLzx2ElRISIORFRwr1ZbO9bAlowgM5kO7hnpRBe+brVj8NNPUiFs" crossorigin="anonymous" media="(prefers-color-scheme: light)">
+        <link href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/darkly/bootstrap.min.css" rel="stylesheet" integrity="sha384-Bo21yfmmZuXwcN/9vKrA5jPUMhr7znVBBeLxT9MA4r2BchhusfJ6+n8TLGUcRAtL" crossorigin="anonymous" media="(prefers-color-scheme: dark)">
     </head>
     <body>
         <div class="container">
@@ -100,7 +93,7 @@ $path = substr(realpath($CONFIG->captureDir), strlen($_SERVER['DOCUMENT_ROOT']))
                         </div>
                         <div class="form-group col-lg-4">
                             <label class="form-control-label">Controls</label>
-                            <button class="btn btn-outline-success btn-block" type="submit">View</button>
+                            <button class="btn btn-outline-success btn-block" type="submit">Filter</button>
                         </div>
                     </div>
                 </form>
@@ -128,12 +121,12 @@ $path = substr(realpath($CONFIG->captureDir), strlen($_SERVER['DOCUMENT_ROOT']))
                         <th colspan="4"><?=$error?></th>
                     </tr>
 <?php   endif;  ?>
-<?php   foreach ($files as $FileTime => [$FileName, $FileSize, $TGID, $TIME, $FREQ]):   ?>
+<?php   foreach ($files as $FileTime => [$FileName, $FileSize, $TGID, $TIME, $FREQ, $SHORTNAME]):   ?>
                     <tr>
-                        <td><?=date("H:i:s", $FileTime)?></td>
+                        <td><?=date("H:i:s", $TIME)?></td>
                         <td><?=($TGS[$TGID]) ?? $TGID?></td>
-                        <td class="<?=$MHz($FREQ)?>"><?=sprintf("%3.4f", $FREQ)?></td>
-                        <td><a href="<?="{$path}/{$date->format('Y/n/j')}/{$FileName}{$FileType}"?>"><?=$FileSize?>k</a></td>
+                        <td><?=sprintf("%3.4f", $FREQ)?></td>
+                        <td><a href="<?="{$CONFIG->captureDir}/{$SHORTNAME}/{$date->format('Y/n/j')}/{$FileName}{$FileType}"?>"><?=$FileSize?>k</a></td>
                     </tr>
 <?php   endforeach; ?>
             </table>
@@ -169,35 +162,15 @@ $path = substr(realpath($CONFIG->captureDir), strlen($_SERVER['DOCUMENT_ROOT']))
                     if (tr[index])
                         tr[index].click();
                 }, false);
+
             }
         </script>
         <style>
-            html, body {
-                background: #012;
-                color: #FFF;
-            }
             #interface, audio {
                 width: 100%;
             }
             table {
                 text-align: center;
-            }
-            input, select, textarea {
-                color: #fff !important;
-                background-color: #1a1c22 !important;
-                border-color: #434857 !important;
-            }
-            tbody tr {
-                cursor: pointer;
-            }
-            a {
-                color: #FA0;
-            }
-            a:hover {
-                color: #FC0;
-            }
-            a:active {
-                color: #FF0;
             }
         </style>
     </body>


### PR DESCRIPTION
So I figured I would pass this along for consideration.  I don't think the existing audioplayer.php works with the semi-standard configuration of trunk-recorder these days.  I did some modifications to get it to handle multiple systems and modify the $files array to not use mtime to get the script showing all of my entries.  I bumped bootstrap to 4.5 and went with the media trick to have a "dark mode".  That part may not be desirable as it changes the overall appearance of the page to a more standard black text on white (or white text on black).  But I liked it.  

This should work from the trunk-recorder directory with the standard ```php -S 127.0.0.1:8080``` option and I also have a docker-compose I can share which lets it use nginx / php-fpm to interact with the trunk-recorder-docker setup and serve out those files.  

I know it's no longer "the way" but I've wanted this working for a long time as I think it's a handy, lightweight way of checking on what my system is "hearing" without logging into one of the services.  

![screenshot-fs8](https://user-images.githubusercontent.com/54859414/85182934-21abe100-b258-11ea-8c9b-b620bf5e26ae.png)

-----


* Updating the player to support multiple systems / the new media path.
* Index files by time and frequency, rather than on MTIME (which can be the same for several files causing them to be invisible)
* Update bootstrap to 4.5 and configure flatly / darkly for a bright and night mode to match the browser
* Link to the m4a files instead of the wav files
* php linter changes