### PR TITLE
Docker: Set the config file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN cmake . && make -j`nproc` && cp recorder /recorder
 
 USER nobody
 
-CMD ["/recorder"]
+CMD ["/recorder", "--config=/app/config.json"]


### PR DESCRIPTION
Fixes issue realized by @jquagga in #365. Once merged, I’ll update the `docker-compose.yml` example in the wiki too.