### PR TITLE
Make defaultMode only affect smartnet systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Here are the different arguments:
    - **decodeFSync** - *(Optional, For conventional systems)* enable the Fleet Sync signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
    - **decodeStar** - *(Optional, For conventional systems)* enable the Star signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
    - **decodeTPS** - *(Optional, For conventional systems)* enable the Motorola Tactical Public Safety (aka FDNY Fireground) signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
- - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile**. The options are *digital* or *analog*. The default is *analog*. This argument is global and not system-specific, and only affects `smartnet` systems as `p25` systems don't have analog talkpaths.
+ - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile**. The options are *digital* or *analog*. The default is *digital*. This argument is global and not system-specific, and only affects Type II `smartnet` trunking systems which can have both analog and digital talkpaths whereas `p25` trunking systems don't have analog talkpaths.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Here are the different arguments:
    - **decodeFSync** - *(Optional, For conventional systems)* enable the Fleet Sync signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
    - **decodeStar** - *(Optional, For conventional systems)* enable the Star signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
    - **decodeTPS** - *(Optional, For conventional systems)* enable the Motorola Tactical Public Safety (aka FDNY Fireground) signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
- - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile** the options are *digital* or *analog*.
+ - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile**. The options are *digital* or *analog*. The default is *analog*. This argument is global and not system-specific, and only affects `smartnet` systems as `p25` systems don't have analog talkpaths.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Here are the different arguments:
  - **systems** - An array of JSON objects that define the trunking systems that will be recorded. The following options are used to configure each System.
    - **control_channels** - *(For trunked systems)* an array of the control channel frequencies for the system, in Hz. The frequencies will automatically be cycled through if the system moves to an alternate channel.
    - **channels** - *(For conventional systems)* an array of the channel frequencies, in Hz, used for the system. The channels get assigned a virtual talkgroup number based upon their position in the array. Squelch levels need to be specified for the Source(s) being used.
-   - **alphatags** - *(Optional, For conventional systems)* an array of the alpha tags, these will be outputed to the logfiles *talkgroupDisplayFormat* is set to include tags. Alpha tags will be applied to the *channels* in the order the values appear in the array. 
+   - **alphatags** - *(Optional, For conventional systems)* an array of the alpha tags, these will be outputed to the logfiles *talkgroupDisplayFormat* is set to include tags. Alpha tags will be applied to the *channels* in the order the values appear in the array.
    - **type** - the type of trunking system. The options are *smartnet*, *p25*,  *conventional* & *conventionalP25*.
    - **talkgroupsFile** - this is a CSV file that provides information about the talkgroups. It determines whether a talkgroup is analog or digital, and what priority it should have. This file should be located in the same directory as the trunk-recorder executable.
    - **unitTagsFile** - this is a CSV files that provides information about the unit tags. It allows a Unit ID to be assigned a name. This file should be located in the same directory as the trunk-recorder executable. The format is 2 columns, the first being the decimal number of the Unit ID, the second is the Unit Name,
@@ -129,9 +129,9 @@ Here are the different arguments:
    - **bandplanSpacing** - [SmartNet, 400_custom only] this is the channel spacing, specified in Hz. Typically this is *25000*.
    - **bandplanOffset** - [SmartNet, 400_custom only] this is the offset used to calculate frequencies.
    - **talkgroupDisplayFormat** - the display format for talkgroups in the console and log file. the options are *id*, *id_tag*, *tag_id*. The default is *id*. [*id_tag* and *tag_id* is only valid if **talkgroupsFile** is specified]
-   - **delayCreateOutput** - [conventionalP25 only] this will delay the creation of the output file until there is activity, The options are *true* or *false*, without quotes. The default is *false*. 
-   - **hideEncrypted** - hide encrypted talkgroups log entries, The options are *true* or *false*, without quotes. The default is *false*. 
-   - **hideUnknownTalkgroups** - hide unknown talkgroups from log, The options are *true* or *false*, without quotes. The default is *false*. 
+   - **delayCreateOutput** - [conventionalP25 only] this will delay the creation of the output file until there is activity, The options are *true* or *false*, without quotes. The default is *false*.
+   - **hideEncrypted** - hide encrypted talkgroups log entries, The options are *true* or *false*, without quotes. The default is *false*.
+   - **hideUnknownTalkgroups** - hide unknown talkgroups from log, The options are *true* or *false*, without quotes. The default is *false*.
    - **decodeMDC** - *(Optional, For conventional systems)* enable the MDC-1200 signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
    - **decodeFSync** - *(Optional, For conventional systems)* enable the Fleet Sync signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
    - **decodeStar** - *(Optional, For conventional systems)* enable the Star signaling decoder. The options are *true* or *false*, without quotes. The default is *false*.
@@ -143,13 +143,13 @@ Here are the different arguments:
  - **frequencyFormat** - the display format for frequencies to display in the console and log file. The options are *exp*, *mhz* & *hz*. The default is *exp*.
  - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.
  - **statusAsString** - Show status as strings instead of numeric values The options are *true* or *false*, without quotes. The default is *true*.
- - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently. [JSON format of messages](STATUS-JSON.md) 
+ - **statusServer** - The URL for a WebSocket connect. Trunk Recorder will send JSON formatted update message to this address. HTTPS is currently not supported, but will be in the future. OpenMHz does not support this currently. [JSON format of messages](STATUS-JSON.md)
  - **broadcastSignals** - *(Optional)* Broadcast decoded signals to the status server. The default is *false*.
  - **uploadServer** - *(Optional)* The URL for uploading to OpenMHz. The default is an empty string. See the Config tab for your system in OpenMHz to find what the value should be.
  - **broadcastifyCallsServer** - *(Optional)* The URL for uploading to Broadcastify Calls. The default is an empty string. Refer to [Broadcastify's wiki](https://wiki.radioreference.com/index.php/Broadcastify-Calls-API) for the upload URL.
  - **logLevel** - *(Optional)* the logging level to display in the console and log file. The options are *trace*, *debug*, *info*, *warning*, *error* & *fatal*. The default is *info*.
  - **debugRecorder** - Will attach a debug recorder to each Source. The debug recorder will allow you to examine the channel of a call be recorded. There is a single Recorder per Source. It will monitor a recording and when it is done, it will monitor the next recording started. The information is sent over a network connection and can be viewed using the `udp-debug.grc` graph in GnuRadio Companion. The setting is either *true* or *false* and the default is *false*.
- - **debugRecorderPort** - The network port that the Debug Recorders will start on. For each Source an additional Debug Recorder will be added and the port used will be one higher than the last one. For example the ports for a system with 3 Sources would be: 1234, 12345, 1236. The default value is *1234*. 
+ - **debugRecorderPort** - The network port that the Debug Recorders will start on. For each Source an additional Debug Recorder will be added and the port used will be one higher than the last one. For example the ports for a system with 3 Sources would be: 1234, 12345, 1236. The default value is *1234*.
  - **debugRecorderAddress** - The network address of the computer that will be monitoring the Debug Recorders. UDP packets will be sent from Trunk Recorder to this computer. The default is *"127.0.0.1"* which is the address used for monitoring on the same computer as Trunk Recorder.
 
 

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -132,7 +132,7 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
     BOOST_LOG_TRIVIAL(info) << "Upload Server: " << config.upload_server;
     config.bcfy_calls_server = pt.get<std::string>("broadcastifyCallsServer", "");
     BOOST_LOG_TRIVIAL(info) << "Broadcastify Calls Server: " << config.bcfy_calls_server;
-    default_mode = pt.get<std::string>("defaultMode", "digital");
+    default_mode = pt.get<std::string>("defaultMode", "analog");
     BOOST_LOG_TRIVIAL(info) << "Default Mode: " << default_mode;
     config.call_timeout = pt.get<int>("callTimeout", 3);
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -132,7 +132,7 @@ Config load_config(std::string config_file, std::vector<Source *> &sources, std:
     BOOST_LOG_TRIVIAL(info) << "Upload Server: " << config.upload_server;
     config.bcfy_calls_server = pt.get<std::string>("broadcastifyCallsServer", "");
     BOOST_LOG_TRIVIAL(info) << "Broadcastify Calls Server: " << config.bcfy_calls_server;
-    default_mode = pt.get<std::string>("defaultMode", "analog");
+    default_mode = pt.get<std::string>("defaultMode", "digital");
     BOOST_LOG_TRIVIAL(info) << "Default Mode: " << default_mode;
     config.call_timeout = pt.get<int>("callTimeout", 3);
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -533,7 +533,7 @@ void load_config(string config_file)
     BOOST_LOG_TRIVIAL(info) << "Instance Id: " << config.instance_id;
     config.broadcast_signals = pt.get<bool>("broadcastSignals", false);
     BOOST_LOG_TRIVIAL(info) << "Broadcast Signals: " << config.broadcast_signals;
-    default_mode = pt.get<std::string>("defaultMode", "analog");
+    default_mode = pt.get<std::string>("defaultMode", "digital");
     BOOST_LOG_TRIVIAL(info) << "Default Mode: " << default_mode;
     config.call_timeout = pt.get<int>("callTimeout", 3);
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -533,7 +533,7 @@ void load_config(string config_file)
     BOOST_LOG_TRIVIAL(info) << "Instance Id: " << config.instance_id;
     config.broadcast_signals = pt.get<bool>("broadcastSignals", false);
     BOOST_LOG_TRIVIAL(info) << "Broadcast Signals: " << config.broadcast_signals;
-    default_mode = pt.get<std::string>("defaultMode", "digital");
+    default_mode = pt.get<std::string>("defaultMode", "analog");
     BOOST_LOG_TRIVIAL(info) << "Default Mode: " << default_mode;
     config.call_timeout = pt.get<int>("callTimeout", 3);
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;
@@ -650,7 +650,9 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
         BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " << FormatFreq(call->get_freq()) << "\tTG not in Talkgroup File ";
 
         // A talkgroup was not found from the talkgroup file.
-          if (default_mode == "analog") {
+        // Use an analog recorder if this is a Type II trunk and defaultMode is analog.
+        // All other cases use a digital recorder.
+          if ((default_mode == "analog") && (sys->get_system_type() == "smartnet")) {
             recorder = source->get_analog_recorder(2);
           } else {
             recorder = source->get_digital_recorder(2);


### PR DESCRIPTION
## Summary

P25 trunks don't use analog talkpaths. Therefore, `defaultMode` should only
steer `smartnet` systems. Since there are 4 cases where only 1 is affected:

```
- TII, default ana -> record analog
- TII, default dig -> record digital
- P25, default ana -> record digital (ignore defaultMode)
- P25, default dig -> record digital (ignore defaultMode)
```

this pull request adds `get_system_type() == "smartnet"` with the existing
`default_mode == "analog"` test.

I can't speak authoritatively for P25 trunks of all manufacturers and haven't
read specs in ages, but can say that ASTRO25 systems (and subscribers I've
experience with) don't support analog. This also includes failsoft operation -
only TII lets you choose failsoft signal type and secure operation, and that's
done on a subscriber basis. In normal operation on TII, both subscriber
programming and system talkgroup configuration must be in lockstep.

`defaultMode` now defaults to `analog`. This is potentially a breaking change
for existing configurations that listen to unknown TII trunks with only digital
use, and have not included `defaultMode` in their configuration. Users may need
to be informed on update.

I haven't thoroughly familiarized myself with the codebase, but my quick read
over `main.cc` is that `find/get_talkgroup` is used in trunking calls only, so
this change shouldn't affect any `conventional`/`conventionalP25` systems.

## Improvements

In a better world, `defaultMode` should be a system key and not a global knob.
`trunk-recorder` should respect differing `defaultMode` for separate TII trunks.
A default `defaultMode` of `digital` would work fine for trunks that provision
all their talkgroups as digital, but such a system is an exception and not the
norm. `0A08` is the only trunk I can think off the top of my head that was a TII
trunk that was mostly (if not exclusively) ASTRO.

In an ideal world, handling of channel grant status bits should be implemented
and `defaultMode` be retired. Unknown talkgroups can potentially be used in
either mode. Even with known fleetmapped talkgroups already provisioned as one
or the other, and TII trunks being legacy with changes likely not happening in
this day and age, it's still plausible that trunks on life support can add
additional digital talkpaths and change the mode of existing talkgroups.

These are improvements for consideration that should be created as a new issue,
but I'm not familiar with the social norms of this project to know if that's
acceptable or not.

## Testing

This PR has been tested working with the following:

```
$ uname -a
Linux ubuntu 5.3.0-53-generic #47~18.04.1-Ubuntu SMP Thu May 7 13:10:50 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ apt list ... # not included since this was a small change
```

```
$ cat test-config.json
{
  "sources": [
    {
      "center": ,
      "rate": ,
      "squelch": -55,
      "error": 0,
      "gain": 15,
      "digitalRecorders": 32,
      "digitalLevels": 8,
      "modulation": "qpsk",
      "analogRecorders": 16,
      "analogLevels": 8,
      "debugRecorders": 0,
      "driver": "osmosdr",
      "device": "rtl=n,buflen=65536"
    }
  ],
  "systems": [
    "irrelevant conventional systems elided",
    {
      "shortName": "SYS.SITE",
      "type": "smartnet",
      "control_channels": [],
      "bandplan": "",
      "bandplanBase": ,
      "bandplanHigh": ,
      "bandplanSpacing": ,
      "bandplanOffset": ,
      "talkgroupsFile": "empty.csv"
    },
    {
      "shortName": "WACN-SYS.RFSS-SITE",
      "type": "p25",
      "control_channels": [],
      "talkgroupsFile": "empty.csv",
    }
  ],
  "defaultMode": "analog"
}
```