### PR TITLE
Type II CC Message Handler Rewrite

### DIFF
--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -481,14 +481,14 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
   // Adding the logic to test for this might be nice to have (test could be "if we got here,
   // this OSW is is missing a header or other OSWs that comprise a valid message -
   // test if we know this OSW command though, and if we do, discard the OSW and move on")
-  BOOST_LOG_TRIVIAL(warning)
-      << "[" << system->get_short_name()
-      << "] [Unknown OSW!] [ "
-      << std::hex << stack[0].cmd << " " << std::hex << stack[0].grp << " " << std::hex << stack[0].full_address << "  |  "
-      << std::hex << stack[1].cmd << " " << std::hex << stack[1].grp << " " << std::hex << stack[1].full_address << "  |  "
-      << std::hex << stack[2].cmd << " " << std::hex << stack[2].grp << " " << std::hex << stack[2].full_address << "  | >"
-      << std::hex << stack[3].cmd << " " << std::hex << stack[3].grp << " " << std::hex << stack[3].full_address << "< |  "
-      << std::hex << stack[4].cmd << " " << std::hex << stack[4].grp << " " << std::hex << stack[4].full_address << " ]";
+  // BOOST_LOG_TRIVIAL(warning)
+  //     << "[" << system->get_short_name()
+  //     << "] [Unknown OSW!] [ "
+  //     << std::hex << stack[0].cmd << " " << std::hex << stack[0].grp << " " << std::hex << stack[0].full_address << "  |  "
+  //     << std::hex << stack[1].cmd << " " << std::hex << stack[1].grp << " " << std::hex << stack[1].full_address << "  |  "
+  //     << std::hex << stack[2].cmd << " " << std::hex << stack[2].grp << " " << std::hex << stack[2].full_address << "  | >"
+  //     << std::hex << stack[3].cmd << " " << std::hex << stack[3].grp << " " << std::hex << stack[3].full_address << "< |  "
+  //     << std::hex << stack[4].cmd << " " << std::hex << stack[4].grp << " " << std::hex << stack[4].full_address << " ]";
   message.message_type = UNKNOWN;
   messages.push_back(message);
   return messages;

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -373,105 +373,98 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
         messages.push_back(message);
         return messages;
       }
-      if (stack[2].cmd == OSW_EXTENDED_FCN) {
-        // we have a 2-OSW message, process it.
-        ++numConsumed;
-        // we have an extended function
-        // lots of possibilities here: reg, dereg, patch/msel, Sys ID, etc.
-        // For now use if statements, but some sort of lookup table for function
-        // type may be more useful in the future.
-        if (stack[2].full_address == 0x2021) {
-          // Patch Termination
-          // BOOST_LOG_TRIVIAL(warning)
-          //     << "[" << system->get_short_name() << "] [patch/msel termination] TG $"
-          //     << std::hex << stack[3].full_address;
-          message.message_type = UNKNOWN;
-          message.talkgroup    = stack[3].full_address;
-          messages.push_back(message);
-          return messages;
-        }
-        if (stack[2].full_address == 0x261b) {
-          // Registration
-          // BOOST_LOG_TRIVIAL(warning)
-          //     << "[" << system->get_short_name() << "] [  registration] RID $"
-          //     << std::hex << stack[3].full_address;
-          message.message_type = REGISTRATION;
-          message.source       = stack[3].full_address;
-          messages.push_back(message);
-          return messages;
-        }
-        if (stack[2].full_address == 0x261c) {
-          // Dereg
-          // BOOST_LOG_TRIVIAL(warning)
-          //     << "[" << system->get_short_name() << "] [deregistration] RID $"
-          //     << std::hex << stack[3].full_address;
-          message.message_type = DEREGISTRATION;
-          message.source       = stack[3].full_address;
-          messages.push_back(message);
-          return messages;
-        }
-        if (stack[2].full_address == 0x2a69) {
-          // Data Channel announcement
-          // when we start storing Sys ID in active run memory, test to make sure
-          // the full address of the header is the Sys ID
-          messages.push_back(message);
-          return messages;
-        }
-        if (stack[2].full_address == 0x2c47) {
-          // Busy Override Deny
-          // BOOST_LOG_TRIVIAL(warning)
-          //     << "[" << system->get_short_name() << "] [busy override deny] RID $"
-          //     << std::hex << stack[3].full_address;
-          message.message_type = UNKNOWN;
-          message.source       = stack[3].full_address;
-          messages.push_back(message);
-          return messages;
-        }
-        if (stack[2].full_address == 0x2c65) {
-          // Access Deny
-          // BOOST_LOG_TRIVIAL(warning)
-          //     << "[" << system->get_short_name() << "] [deny ($2c65)] RID $"
-          //     << std::hex << stack[3].full_address;
-          message.message_type = UNKNOWN;
-          message.source       = stack[3].full_address;
-          messages.push_back(message);
-          return messages;
-        }
-        if ((0 <= (stack[2].full_address - 0x2800)) && ((stack[2].full_address - 0x2800) < 0x2f7)) {
-          // System ID
-          // BOOST_LOG_TRIVIAL(warning)
-          //     << "[" << system->get_short_name() << "] [Sys ID] SID $"
-          //     << std::hex << stack[3].full_address
-          //     << ", CC $" << std::hex << stack[2].full_address - 0x2800
-          //     << " -> " << getfreq(stack[2].full_address - 0x2800, system);
-          message.message_type = SYSID;
-          message.freq         = getfreq(stack[2].full_address - 0x2800, system);
-          message.sys_id       = stack[3].full_address;
-          messages.push_back(message);
-          return messages;
-        }
-      }
-      // further work needs to be done on patches/msels
-      if (stack[2].cmd == 0x340) {
-        // we have a patch
-        ++numConsumed;
+    }
+    if (stack[2].cmd == OSW_EXTENDED_FCN) {
+      // we have a 2-OSW message, process it.
+      ++numConsumed;
+      // we have an extended function
+      // lots of possibilities here: reg, dereg, patch/msel, Sys ID, etc.
+      // For now use if statements, but some sort of lookup table for function
+      // type may be more useful in the future.
+      if (stack[2].full_address == 0x2021) {
+        // Patch Termination
+        // BOOST_LOG_TRIVIAL(warning)
+        //     << "[" << system->get_short_name() << "] [patch/msel termination] TG $"
+        //     << std::hex << stack[3].full_address;
         message.message_type = UNKNOWN;
+        message.talkgroup    = stack[3].full_address;
         messages.push_back(message);
         return messages;
       }
-      if (stack[2].cmd == OSW_TY2_AFFILIATION) {
-        // we have an affiliation
-        ++numConsumed;
+      if (stack[2].full_address == 0x261b) {
+        // Registration
         // BOOST_LOG_TRIVIAL(warning)
-        //     << "[" << system->get_short_name() << "] [affiliation] RID $"
-        //     << std::hex << stack[3].full_address
-        //     << " TG $" << std::hex << stack[2].full_address;
-        message.message_type = AFFILIATION;
-        message.talkgroup    = stack[2].full_address;
+        //     << "[" << system->get_short_name() << "] [  registration] RID $"
+        //     << std::hex << stack[3].full_address;
+        message.message_type = REGISTRATION;
         message.source       = stack[3].full_address;
         messages.push_back(message);
         return messages;
       }
+      if (stack[2].full_address == 0x261c) {
+        // Dereg
+        // BOOST_LOG_TRIVIAL(warning)
+        //     << "[" << system->get_short_name() << "] [deregistration] RID $"
+        //     << std::hex << stack[3].full_address;
+        message.message_type = DEREGISTRATION;
+        message.source       = stack[3].full_address;
+        messages.push_back(message);
+        return messages;
+      }
+      if (stack[2].full_address == 0x2c47) {
+        // Busy Override Deny
+        // BOOST_LOG_TRIVIAL(warning)
+        //     << "[" << system->get_short_name() << "] [busy override deny] RID $"
+        //     << std::hex << stack[3].full_address;
+        message.message_type = UNKNOWN;
+        message.source       = stack[3].full_address;
+        messages.push_back(message);
+        return messages;
+      }
+      if (stack[2].full_address == 0x2c65) {
+        // Access Deny
+        // BOOST_LOG_TRIVIAL(warning)
+        //     << "[" << system->get_short_name() << "] [deny ($2c65)] RID $"
+        //     << std::hex << stack[3].full_address;
+        message.message_type = UNKNOWN;
+        message.source       = stack[3].full_address;
+        messages.push_back(message);
+        return messages;
+      }
+      if ((0 <= (stack[2].full_address - 0x2800)) && ((stack[2].full_address - 0x2800) < 0x2f7)) {
+        // System ID
+        // BOOST_LOG_TRIVIAL(warning)
+        //     << "[" << system->get_short_name() << "] [Sys ID] SID $"
+        //     << std::hex << stack[3].full_address
+        //     << ", CC $" << std::hex << stack[2].full_address - 0x2800
+        //     << " -> " << getfreq(stack[2].full_address - 0x2800, system);
+        message.message_type = SYSID;
+        message.freq         = getfreq(stack[2].full_address - 0x2800, system);
+        message.sys_id       = stack[3].full_address;
+        messages.push_back(message);
+        return messages;
+      }
+    }
+    // further work needs to be done on patches/msels
+    if (stack[2].cmd == 0x340) {
+      // we have a patch
+      ++numConsumed;
+      message.message_type = UNKNOWN;
+      messages.push_back(message);
+      return messages;
+    }
+    if (stack[2].cmd == OSW_TY2_AFFILIATION) {
+      // we have an affiliation
+      ++numConsumed;
+      // BOOST_LOG_TRIVIAL(warning)
+      //     << "[" << system->get_short_name() << "] [affiliation] RID $"
+      //     << std::hex << stack[3].full_address
+      //     << " TG $" << std::hex << stack[2].full_address;
+      message.message_type = AFFILIATION;
+      message.talkgroup    = stack[2].full_address;
+      message.source       = stack[3].full_address;
+      messages.push_back(message);
+      return messages;
     }
   }
 
@@ -488,14 +481,14 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
   // Adding the logic to test for this might be nice to have (test could be "if we got here,
   // this OSW is is missing a header or other OSWs that comprise a valid message -
   // test if we know this OSW command though, and if we do, discard the OSW and move on")
-  BOOST_LOG_TRIVIAL(warning)
-      << "[" << system->get_short_name()
-      << "] [Unknown OSW!] [ "
-      << std::hex << stack[0].cmd << " " << std::hex << stack[0].grp << " " << std::hex << stack[0].full_address << "  |  "
-      << std::hex << stack[1].cmd << " " << std::hex << stack[1].grp << " " << std::hex << stack[1].full_address << "  |  "
-      << std::hex << stack[2].cmd << " " << std::hex << stack[2].grp << " " << std::hex << stack[2].full_address << "  | >"
-      << std::hex << stack[3].cmd << " " << std::hex << stack[3].grp << " " << std::hex << stack[3].full_address << "< |  "
-      << std::hex << stack[4].cmd << " " << std::hex << stack[4].grp << " " << std::hex << stack[4].full_address << " ]";
+  // BOOST_LOG_TRIVIAL(warning)
+  //     << "[" << system->get_short_name()
+  //     << "] [Unknown OSW!] [ "
+  //     << std::hex << stack[0].cmd << " " << std::hex << stack[0].grp << " " << std::hex << stack[0].full_address << "  |  "
+  //     << std::hex << stack[1].cmd << " " << std::hex << stack[1].grp << " " << std::hex << stack[1].full_address << "  |  "
+  //     << std::hex << stack[2].cmd << " " << std::hex << stack[2].grp << " " << std::hex << stack[2].full_address << "  | >"
+  //     << std::hex << stack[3].cmd << " " << std::hex << stack[3].grp << " " << std::hex << stack[3].full_address << "< |  "
+  //     << std::hex << stack[4].cmd << " " << std::hex << stack[4].grp << " " << std::hex << stack[4].full_address << " ]";
   message.message_type = UNKNOWN;
   messages.push_back(message);
   return messages;

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -74,7 +74,7 @@ bool SmartnetParser::is_chan_outbound(int cmd, System *sys) {
   } else if (sys->get_bandfreq() == 400) {
     //
     if (cmd >= sys->get_bandplan_offset() &&
-        cmd <= sys->get_bandplan_offset() + 380) {
+        cmd <  sys->get_bandplan_offset() + 380) {
       return true;
     } else {
       return false;
@@ -88,7 +88,7 @@ bool SmartnetParser::is_chan_inbound_obt(int cmd, System *sys) {
 }
 
 bool SmartnetParser::is_first_normal() {
-  
+
 }
 
 

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -4,120 +4,127 @@
 using namespace std;
 SmartnetParser::SmartnetParser() {
   lastaddress = 0;
-  lastcmd     = 0;
-  numStacked  = 0;
+  lastcmd = 0;
+  numStacked = 0;
   numConsumed = 0;
 }
 
 bool SmartnetParser::is_chan(int cmd, System *sys) {
-    if(sys->get_bandfreq() == 800) {
-      if((cmd >= OSW_CHAN_BAND_1_MIN && cmd <= OSW_CHAN_BAND_1_MAX) || \
-         (cmd >= OSW_CHAN_BAND_2_MIN && cmd <= OSW_CHAN_BAND_2_MAX) || \
-         (cmd == OSW_CHAN_BAND_3) || \
-         (cmd >= OSW_CHAN_BAND_4_MIN && cmd <= OSW_CHAN_BAND_4_MAX)) {
-            return true;
-         }
-    } else if(sys->get_bandfreq() == 400) {
-        if(cmd >= sys->get_bandplan_offset() && cmd <= sys->get_bandplan_offset() + 380) {
-            return true;
-        } else {
-            return false;
-        }
+  if (sys->get_bandfreq() == 800) {
+    if ((cmd >= OSW_CHAN_BAND_1_MIN && cmd <= OSW_CHAN_BAND_1_MAX) ||
+        (cmd >= OSW_CHAN_BAND_2_MIN && cmd <= OSW_CHAN_BAND_2_MAX) ||
+        (cmd == OSW_CHAN_BAND_3) ||
+        (cmd >= OSW_CHAN_BAND_4_MIN && cmd <= OSW_CHAN_BAND_4_MAX)) {
+      return true;
     }
-    return false;
+  } else if (sys->get_bandfreq() == 400) {
+    if (cmd >= sys->get_bandplan_offset() &&
+        cmd <= sys->get_bandplan_offset() + 380) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  return false;
 }
 
 double SmartnetParser::getfreq(int cmd, System *sys) {
-    double freq = 0.0;
-    std::string band = sys->get_bandplan();
-    if(sys->get_bandfreq() == 800) {
-        /*
-          BANDPLAN 800Mhz:
-          800_standard * Is default base plan
-          800_splinter
-          800_reband
-        */
-        if(cmd < 0 || cmd > 0x3FE)
-            return freq;
-        if(cmd <= 0x2CF) {
-            if(band == "800_reband" && cmd >= 0x1B8 && cmd <= 0x22F) { /* Re Banded Site */
-                freq = 851.0250 + (0.025 * ((double) (cmd-0x1B8)));
-            } else if(band == "800_splinter" && cmd <= 0x257) { /* Splinter Site */
-                freq = 851.0 + (0.025 * ((double) cmd));
-            } else {
-                freq = 851.0125 + (0.025 * ((double) cmd));
-            }
-        } else if(cmd <= 0x2f7) {
-            freq = 866.0000 + (0.025 * ((double) (cmd-0x2D0)));
-        } else if(cmd >= 0x32F && cmd <= 0x33F ) {
-            freq = 867.0000 + (0.025 * ((double) (cmd-0x32F)));
-        } else if( cmd == 0x3BE) {
-            freq = 868.9750;
-        } else if (cmd >= 0x3C1 && cmd <= 0x3FE) {
-            freq = 867.4250 + (0.025 * ((double) (cmd-0x3C1)));
-        }
-    } else if (sys->get_bandfreq() == 400) {
-          /*double test_freq;
-          //Step * (channel - low) + Base
-          if ((cmd >= 0x17c) && (cmd < 0x2b0)) {
-            test_freq = ((cmd - 380) * 25000)  + 489087500;
-          } else {
-            test_freq = 0;
-          }*/
-
-        double high_cmd = sys->get_bandplan_offset() + (sys->get_bandplan_high() - sys->get_bandplan_base()) / sys->get_bandplan_spacing();
-
-        if((cmd >= sys->get_bandplan_offset()) && (cmd < high_cmd)) { // (cmd <= sys->get_bandplan_base() + sys->get_bandplan_offset() )) {
-            freq = sys->get_bandplan_base() + (sys->get_bandplan_spacing() * (cmd - sys->get_bandplan_offset() ));
-        }
-        //cout << "Orig: " <<fixed <<test_freq << " Freq: " << freq << endl;
+  double freq = 0.0;
+  std::string band = sys->get_bandplan();
+  if (sys->get_bandfreq() == 800) {
+    /*
+      BANDPLAN 800Mhz:
+      800_standard * Is default base plan
+      800_splinter
+      800_reband
+    */
+    if (cmd < 0 || cmd > 0x3FE)
+      return freq;
+    if (cmd <= 0x2CF) {
+      if (band == "800_reband" && cmd >= 0x1B8 &&
+          cmd <= 0x22F) { /* Re Banded Site */
+        freq = 851.0250 + (0.025 * ((double)(cmd - 0x1B8)));
+      } else if (band == "800_splinter" && cmd <= 0x257) { /* Splinter Site */
+        freq = 851.0 + (0.025 * ((double)cmd));
+      } else {
+        freq = 851.0125 + (0.025 * ((double)cmd));
+      }
+    } else if (cmd <= 0x2f7) {
+      freq = 866.0000 + (0.025 * ((double)(cmd - 0x2D0)));
+    } else if (cmd >= 0x32F && cmd <= 0x33F) {
+      freq = 867.0000 + (0.025 * ((double)(cmd - 0x32F)));
+    } else if (cmd == 0x3BE) {
+      freq = 868.9750;
+    } else if (cmd >= 0x3C1 && cmd <= 0x3FE) {
+      freq = 867.4250 + (0.025 * ((double)(cmd - 0x3C1)));
     }
+  } else if (sys->get_bandfreq() == 400) {
+    /*double test_freq;
+    //Step * (channel - low) + Base
+    if ((cmd >= 0x17c) && (cmd < 0x2b0)) {
+      test_freq = ((cmd - 380) * 25000)  + 489087500;
+    } else {
+      test_freq = 0;
+    }*/
+
+    double high_cmd = sys->get_bandplan_offset() +
+                      (sys->get_bandplan_high() - sys->get_bandplan_base()) /
+                          sys->get_bandplan_spacing();
+
+    if ((cmd >= sys->get_bandplan_offset()) &&
+        (cmd < high_cmd)) { // (cmd <= sys->get_bandplan_base() +
+                            // sys->get_bandplan_offset() )) {
+      freq = sys->get_bandplan_base() +
+             (sys->get_bandplan_spacing() * (cmd - sys->get_bandplan_offset()));
+    }
+    // cout << "Orig: " <<fixed <<test_freq << " Freq: " << freq << endl;
+  }
   return freq * 1000000;
 }
 
-
-std::vector<TrunkMessage>SmartnetParser::parse_message(std::string s, System *system) {
+std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
+                                                        System *system) {
   std::vector<TrunkMessage> messages;
   TrunkMessage message;
 
-
-  //char tempArea[512];
-  //unsigned short blockNum;
-  //char banktype;
-  //unsigned short tt1, tt2;
-  //static unsigned int ott1, ott2;
+  // char tempArea[512];
+  // unsigned short blockNum;
+  // char banktype;
+  // unsigned short tt1, tt2;
+  // static unsigned int ott1, ott2;
 
   // print_osw(s);
   message.message_type = UNKNOWN;
-  message.encrypted    = false;
-  message.phase2_tdma         = false;
+  message.encrypted = false;
+  message.phase2_tdma = false;
   message.tdma_slot = 0;
-  message.source       = 0;
-  message.sys_id        = 0;
+  message.source = 0;
+  message.sys_id = 0;
   message.sys_num = system->get_sys_num();
-  message.emergency    = false;
+  message.emergency = false;
 
   std::vector<std::string> x;
   boost::split(x, s, boost::is_any_of(","), boost::token_compress_on);
 
-if (x.size()<3) {
-  BOOST_LOG_TRIVIAL(error) << "SmartNet Parser recieved invalid message." << x.size();
+  if (x.size() < 3) {
+    BOOST_LOG_TRIVIAL(error)
+        << "SmartNet Parser recieved invalid message." << x.size();
     return messages;
-}
+  }
 
-  int  full_address = atoi(x[0].c_str());
-  int  status       = full_address & 0x000F;
-  long address      = full_address & 0xFFF0;
-  int  groupflag    = atoi(x[1].c_str());
-  int  command      = atoi(x[2].c_str());
+  int full_address = atoi(x[0].c_str());
+  int status = full_address & 0x000F;
+  long address = full_address & 0xFFF0;
+  int groupflag = atoi(x[1].c_str());
+  int command = atoi(x[2].c_str());
 
   struct osw_stru bosw;
-  bosw.id           = address;
+  bosw.id = address;
   bosw.full_address = full_address;
-  bosw.address      = address;
-  bosw.status       = status;
-  bosw.grp          = groupflag;
-  bosw.cmd          = command;
+  bosw.address = address;
+  bosw.status = status;
+  bosw.grp = groupflag;
+  bosw.cmd = command;
 
   // struct osw_stru* Inposw = &bosw;
   cout.precision(0);
@@ -150,8 +157,7 @@ if (x.size()<3) {
     break;
   }
 
-  if (numStacked < 5)
-  {
+  if (numStacked < 5) {
     ++numStacked;
   }
 
@@ -204,93 +210,114 @@ if (x.size()<3) {
           }
    */
 
-	// BOOST_LOG_TRIVIAL(info) << "MSG [ TG: " << dec << stack[0].full_address << "] \t CMD: ( " << hex << stack[0].cmd << " - \t" << hex << stack[1].cmd << " - \t " << hex << stack[2].cmd   << " ] " << " Grp: [ " << stack[0].grp << " - \t " << stack[1].grp << " - \t " << stack[2].grp << " ]";
+  // BOOST_LOG_TRIVIAL(info) << "MSG [ TG: " << dec << stack[0].full_address <<
+  // "] \t CMD: ( " << hex << stack[0].cmd << " - \t" << hex << stack[1].cmd <<
+  // " - \t " << hex << stack[2].cmd   << " ] " << " Grp: [ " << stack[0].grp <<
+  // " - \t " << stack[1].grp << " - \t " << stack[2].grp << " ]";
 
   if (((command >= 0x340) && (command <= 0x34E)) || (command == 0x350)) {
-    BOOST_LOG_TRIVIAL(info) << "Patching Command: " << hex << command << " Freq: " << FormatFreq(message.freq) << " Talkgroup: " << dec << address  << endl;
+    BOOST_LOG_TRIVIAL(info) << "Patching Command: " << hex << command
+                            << " Freq: " << FormatFreq(message.freq)
+                            << " Talkgroup: " << dec << address << endl;
   }
 
   if ((address & 0xfc00) == 0x2800) {
-    message.sys_id        = lastaddress;
+    message.sys_id = lastaddress;
     message.message_type = SYSID;
     messages.push_back(message);
     return messages;
   }
 
-
-  if (is_chan(stack[0].cmd, system) && stack[0].grp && getfreq(stack[0].cmd, system)) {
+  if (is_chan(stack[0].cmd, system) && stack[0].grp &&
+      getfreq(stack[0].cmd, system)) {
     message.talkgroup = stack[0].full_address;
-    message.freq      = getfreq(stack[0].cmd, system);
+    message.freq = getfreq(stack[0].cmd, system);
 
     if ((stack[1].cmd == 0x308) || (stack[1].cmd == 0x321)) {
-      //cout << "NEW GRANT!! CMD1: " << fixed << hex << stack[1].cmd << " 0add: " << dec <<  stack[0].address << " 0full_add: " << stack[0].full_address  << " 1add: " << stack[1].address << " 1full_add: " << stack[1].full_address  << endl;
+      // cout << "NEW GRANT!! CMD1: " << fixed << hex << stack[1].cmd << " 0add:
+      // " << dec <<  stack[0].address << " 0full_add: " << stack[0].full_address
+      // << " 1add: " << stack[1].address << " 1full_add: " <<
+      // stack[1].full_address  << endl;
       message.message_type = GRANT;
-      message.source       = stack[1].full_address;
-    } else  if (stack[1].cmd == 0x320) {
-      BOOST_LOG_TRIVIAL(info) << "Non-Grant with source 0x" << stack[1].full_address << " " << std::dec << stack[1].full_address <<
-                             " on TG 0x" << std::hex << stack[0].full_address << " " << std::dec << stack[0].full_address;
+      message.source = stack[1].full_address;
+    } else if (stack[1].cmd == 0x320) {
+      BOOST_LOG_TRIVIAL(info)
+          << "Non-Grant with source 0x" << stack[1].full_address << " "
+          << std::dec << stack[1].full_address << " on TG 0x" << std::hex
+          << stack[0].full_address << " " << std::dec << stack[0].full_address;
       message.message_type = UNKNOWN;
-      message.source       = 0;
+      message.source = 0;
       return messages;
-      }
-    else {
+    } else {
       message.message_type = UPDATE;
-      //cout << "NEW UPDATE [ Freq: " << fixed << getfreq(stack[0].cmd) << " CMD0: " << hex << stack[0].cmd << " CMD1: " << hex << stack[1].cmd << " CMD2: " << hex << stack[2].cmd   << " ] " << " Grp: " << stack[0].grp << " Grp1: " << stack[1].grp << endl;
+      // cout << "NEW UPDATE [ Freq: " << fixed << getfreq(stack[0].cmd) << "
+      // CMD0: " << hex << stack[0].cmd << " CMD1: " << hex << stack[1].cmd << "
+      // CMD2: " << hex << stack[2].cmd   << " ] " << " Grp: " << stack[0].grp <<
+      // " Grp1: " << stack[1].grp << endl;
     }
 
     messages.push_back(message);
     return messages;
   }
   message.talkgroup = address;
-  message.freq      = getfreq(command, system);
+  message.freq = getfreq(command, system);
 
   // cout << "Command: " << hex << command << " Last CMD: 0x" <<  hex <<
   // lastcmd << " Freq: " << message.freq << " Talkgroup: " << dec << address
   // << " Last Address: " << dec << lastaddress<< endl;
 
-/*
-  if ((stack[2].cmd == 0x0320) && (stack[1].cmd == OSW_EXTENDED_FCN) && groupflag)
-  {
-    numConsumed = 3;
+  /*
+    if ((stack[2].cmd == 0x0320) && (stack[1].cmd == OSW_EXTENDED_FCN) &&
+  groupflag)
+    {
+      numConsumed = 3;
 
-    cout << "uhf/vhf equivalent of 308/320/30b" << endl;
-    cout << "Freq: " << fixed << getfreq(stack[0].cmd) << " 0add: " << dec <<  stack[0].address << " 0full_add: " << stack[0].full_address  << " 1add: " << stack[1].address << " 1full_add: " << stack[1].full_address  << endl;
+      cout << "uhf/vhf equivalent of 308/320/30b" << endl;
+      cout << "Freq: " << fixed << getfreq(stack[0].cmd) << " 0add: " << dec <<
+  stack[0].address << " 0full_add: " << stack[0].full_address  << " 1add: " <<
+  stack[1].address << " 1full_add: " << stack[1].full_address  << endl;
 
-    // Channel Grant
-    message.message_type = GRANT;
-    message.source       = lastaddress;
+      // Channel Grant
+      message.message_type = GRANT;
+      message.source       = lastaddress;
 
-    // Check Status
-    cout << "Grant Command: " << hex << command << " Last CMD: 0x" <<  hex << lastcmd << " Freq: " << fixed <<  message.freq << " Talkgroup: " << dec << address << " Source: " << dec << lastaddress << " 1st: " << (address & 0x2000) << " 2nd: " <<  (address & 0x0800) << " grp: " << groupflag << endl;
+      // Check Status
+      cout << "Grant Command: " << hex << command << " Last CMD: 0x" <<  hex <<
+  lastcmd << " Freq: " << fixed <<  message.freq << " Talkgroup: " << dec <<
+  address << " Source: " << dec << lastaddress << " 1st: " << (address & 0x2000)
+  << " 2nd: " <<  (address & 0x0800) << " grp: " << groupflag << endl;
 
-    cout << "Status: " << status << endl;
+      cout << "Status: " << status << endl;
 
-    if ((status == 2) || (status == 4) || (status == 5)) {
-      message.emergency = true;
-    } else if (status >= 8) { // Ignore DES Encryption
-      message.message_type = UNKNOWN;
-    }
-  } else  {
-    // Call continuation
-    if (groupflag) {
-      message.talkgroup    = full_address;
-      message.message_type = UPDATE;
-      cout << "UPDATE [ Freq: " << fixed << getfreq(command) << " TG: " << dec << address << " Full: " << dec << full_address << " CMD: " << hex << command << " Last CMD: " << hex << stack[1].cmd  << " ] Last CMD: " << hex << lastcmd << " GRoup: " << groupflag << endl;
+      if ((status == 2) || (status == 4) || (status == 5)) {
+        message.emergency = true;
+      } else if (status >= 8) { // Ignore DES Encryption
+        message.message_type = UNKNOWN;
+      }
+    } else  {
+      // Call continuation
+      if (groupflag) {
+        message.talkgroup    = full_address;
+        message.message_type = UPDATE;
+        cout << "UPDATE [ Freq: " << fixed << getfreq(command) << " TG: " << dec
+  << address << " Full: " << dec << full_address << " CMD: " << hex << command
+  << " Last CMD: " << hex << stack[1].cmd  << " ] Last CMD: " << hex << lastcmd
+  << " GRoup: " << groupflag << endl;
+      }
     }
   }
-}
 
-if (command == 0x03c0) {
-  message.message_type = STATUS;
+  if (command == 0x03c0) {
+    message.message_type = STATUS;
 
-  // cout << "Status Command: " << hex << command << " Last CMD: 0x" <<  hex
-  // << lastcmd << " Freq: " << message.freq << " Talkgroup: " << dec <<
-  // address << " Last Address: " << dec << lastaddress<< endl;
+    // cout << "Status Command: " << hex << command << " Last CMD: 0x" <<  hex
+    // << lastcmd << " Freq: " << message.freq << " Talkgroup: " << dec <<
+    // address << " Last Address: " << dec << lastaddress<< endl;
 
-  // parse_status(command, address,groupflag);
-}
-*/
+    // parse_status(command, address,groupflag);
+  }
+  */
 
-messages.push_back(message);
-return messages;
+  messages.push_back(message);
+  return messages;
 }

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -11,8 +11,10 @@ SmartnetParser::SmartnetParser() {
 
 bool SmartnetParser::is_chan(int cmd, System *sys) {
     if(sys->get_bandfreq() == 800) {
-        if((cmd >= 0 && cmd <= 0x2F7) || (cmd >= 0x32f && cmd <= 0x33F) ||
-           (cmd >= 0x3c1 && cmd <= 0x3FE) ||cmd == 0x3BE ) {
+      if((cmd >= OSW_CHAN_BAND_1_MIN && cmd <= OSW_CHAN_BAND_1_MAX) || \
+         (cmd >= OSW_CHAN_BAND_2_MIN && cmd <= OSW_CHAN_BAND_2_MAX) || \
+         (cmd == OSW_CHAN_BAND_3) || \
+         (cmd >= OSW_CHAN_BAND_4_MIN && cmd <= OSW_CHAN_BAND_4_MAX)) {
             return true;
          }
     } else if(sys->get_bandfreq() == 400) {
@@ -225,12 +227,12 @@ if (x.size()<3) {
       message.message_type = GRANT;
       message.source       = stack[1].full_address;
     } else  if (stack[1].cmd == 0x320) {
-      BOOST_LOG_TRIVIAL(info) << "Non-Grant with source 0x" << stack[1].full_address << " " << std::dec << stack[1].full_address << 
+      BOOST_LOG_TRIVIAL(info) << "Non-Grant with source 0x" << stack[1].full_address << " " << std::dec << stack[1].full_address <<
                              " on TG 0x" << std::hex << stack[0].full_address << " " << std::dec << stack[0].full_address;
       message.message_type = UNKNOWN;
       message.source       = 0;
       return messages;
-      }        
+      }
     else {
       message.message_type = UPDATE;
       //cout << "NEW UPDATE [ Freq: " << fixed << getfreq(stack[0].cmd) << " CMD0: " << hex << stack[0].cmd << " CMD1: " << hex << stack[1].cmd << " CMD2: " << hex << stack[2].cmd   << " ] " << " Grp: " << stack[0].grp << " Grp1: " << stack[1].grp << endl;

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -88,7 +88,7 @@ bool SmartnetParser::is_chan_inbound_obt(int cmd, System *sys) {
 }
 
 bool SmartnetParser::is_first_normal(int cmd, System *sys) {
-  if (sys->get_bandfreq == 800) {
+  if (sys->get_bandfreq() == 800) {
     // anything "800" should be replaced with 8/9 compatible switching
     return ((cmd == OSW_FIRST_NORMAL) || \
             (cmd == OSW_FIRST_ASTRO));
@@ -302,15 +302,14 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
       ++numConsumed;
       if (stack[1].cmd == OSW_EXTENDED_FCN) {
         // we have a 3-OSW message.
+
+        // if we don't have a valid 3-OSW message but the second OSW
+        // is still a OSW_SECOND_NORMAL, then we want to know about it in development.
+        // we'll still consume 2-OSWs because we incremented after checking OSW_SECOND_NORMAL.
         ++numConsumed;
         message.message_type = UNKNOWN;
         messages.push_back(message);
         return messages;
-      } else {
-        // if we don't have a valid 3-OSW message but the second OSW
-        // is still a OSW_SECOND_NORMAL, then we want to know about it in development.
-        // breaking out will only have us consume (and discard) 2-OSWs.
-        break;
       }
     }
     if (stack[2].cmd == OSW_EXTENDED_FCN) {

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -87,8 +87,18 @@ bool SmartnetParser::is_chan_inbound_obt(int cmd, System *sys) {
   return cmd < sys->get_bandplan_offset();
 }
 
-bool SmartnetParser::is_first_normal() {
-
+bool SmartnetParser::is_first_normal(int cmd, SYstem *sys) {
+  if (sys->get_bandfreq == 800) {
+    // anything "800" should be replaced with 8/9 compatible switching
+    return ((cmd == OSW_FIRST_NORMAL) || \
+            (cmd == OSW_FIRST_ASTRO));
+  } else {
+    // if we're looking at an OBT trunk, inbound channel commands are first normals too
+    // anything "400" should be replaced as "OBT" in the future =/
+    return (is_chan_obt_inbound(cmd, sys) || \
+            (cmd == OSW_FIRST_NORMAL) || \
+            (cmd == OSW_FIRST_ASTRO));
+  }
 }
 
 

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -481,14 +481,14 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
   // Adding the logic to test for this might be nice to have (test could be "if we got here,
   // this OSW is is missing a header or other OSWs that comprise a valid message -
   // test if we know this OSW command though, and if we do, discard the OSW and move on")
-  // BOOST_LOG_TRIVIAL(warning)
-  //     << "[" << system->get_short_name()
-  //     << "] [Unknown OSW!] [ "
-  //     << std::hex << stack[0].cmd << " " << std::hex << stack[0].grp << " " << std::hex << stack[0].full_address << "  |  "
-  //     << std::hex << stack[1].cmd << " " << std::hex << stack[1].grp << " " << std::hex << stack[1].full_address << "  |  "
-  //     << std::hex << stack[2].cmd << " " << std::hex << stack[2].grp << " " << std::hex << stack[2].full_address << "  | >"
-  //     << std::hex << stack[3].cmd << " " << std::hex << stack[3].grp << " " << std::hex << stack[3].full_address << "< |  "
-  //     << std::hex << stack[4].cmd << " " << std::hex << stack[4].grp << " " << std::hex << stack[4].full_address << " ]";
+  BOOST_LOG_TRIVIAL(warning)
+      << "[" << system->get_short_name()
+      << "] [Unknown OSW!] [ "
+      << std::hex << stack[0].cmd << " " << std::hex << stack[0].grp << " " << std::hex << stack[0].full_address << "  |  "
+      << std::hex << stack[1].cmd << " " << std::hex << stack[1].grp << " " << std::hex << stack[1].full_address << "  |  "
+      << std::hex << stack[2].cmd << " " << std::hex << stack[2].grp << " " << std::hex << stack[2].full_address << "  | >"
+      << std::hex << stack[3].cmd << " " << std::hex << stack[3].grp << " " << std::hex << stack[3].full_address << "< |  "
+      << std::hex << stack[4].cmd << " " << std::hex << stack[4].grp << " " << std::hex << stack[4].full_address << " ]";
   message.message_type = UNKNOWN;
   messages.push_back(message);
   return messages;

--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -87,7 +87,7 @@ bool SmartnetParser::is_chan_inbound_obt(int cmd, System *sys) {
   return cmd < sys->get_bandplan_offset();
 }
 
-bool SmartnetParser::is_first_normal(int cmd, SYstem *sys) {
+bool SmartnetParser::is_first_normal(int cmd, System *sys) {
   if (sys->get_bandfreq == 800) {
     // anything "800" should be replaced with 8/9 compatible switching
     return ((cmd == OSW_FIRST_NORMAL) || \

--- a/trunk-recorder/systems/smartnet_parser.h
+++ b/trunk-recorder/systems/smartnet_parser.h
@@ -12,28 +12,28 @@
 
 #include <boost/log/trivial.hpp>
 
-#define OSW_BACKGROUND_IDLE     0x02f8
-#define OSW_FIRST_CODED_PC      0x0304
-#define OSW_FIRST_NORMAL        0x0308
-#define OSW_FIRST_TY2AS1        0x0309
-#define OSW_EXTENDED_FCN        0x030b
-#define OSW_AFFIL_FCN           0x030d
-#define OSW_TY2_AFFILIATION     0x0310
-#define OSW_TY1_STATUS_MIN      0x0310
-#define OSW_TY2_MESSAGE         0x0311
-#define OSW_TY1_STATUS_MAX      0x0317
-#define OSW_TY1_ALERT           0x0318
-#define OSW_TY1_EMERGENCY       0x0319
-#define OSW_TY2_CALL_ALERT      0x0319
-#define OSW_FIRST_ASTRO         0x0321
-#define OSW_SYSTEM_CLOCK        0x0322
-#define OSW_SCAN_MARKER         0x032b
-#define OSW_EMERG_ANNC          0x032e
-#define OSW_AMSS_ID_MIN         0x0360
-#define OSW_AMSS_ID_MAX         0x039f
-#define OSW_CW_ID               0x03a0
-#define OSW_SYS_NETSTAT         0x03bf
-#define OSW_SYS_STATUS          0x03c0
+#define OSW_BACKGROUND_IDLE     0x2f8
+#define OSW_FIRST_CODED_PC      0x304
+#define OSW_FIRST_NORMAL        0x308
+#define OSW_FIRST_TY2AS1        0x309
+#define OSW_EXTENDED_FCN        0x30b
+#define OSW_AFFIL_FCN           0x30d
+#define OSW_TY2_AFFILIATION     0x310
+#define OSW_TY1_STATUS_MIN      0x310
+#define OSW_TY2_MESSAGE         0x311
+#define OSW_TY1_STATUS_MAX      0x317
+#define OSW_TY1_ALERT           0x318
+#define OSW_TY1_EMERGENCY       0x319
+#define OSW_TY2_CALL_ALERT      0x319
+#define OSW_FIRST_ASTRO         0x321
+#define OSW_SYSTEM_CLOCK        0x322
+#define OSW_SCAN_MARKER         0x32b
+#define OSW_EMERG_ANNC          0x32e
+#define OSW_AMSS_ID_MIN         0x360
+#define OSW_AMSS_ID_MAX         0x39f
+#define OSW_CW_ID               0x3a0
+#define OSW_SYS_NETSTAT         0x3bf
+#define OSW_SYS_STATUS          0x3c0
 
 struct osw_stru{
 	unsigned short cmd;

--- a/trunk-recorder/systems/smartnet_parser.h
+++ b/trunk-recorder/systems/smartnet_parser.h
@@ -85,9 +85,11 @@ public:
 	short numStacked;
 	short numConsumed;
 	SmartnetParser();
-	double getfreq(int cmd, System *system);
 	void print_osw(std::string s);
-	bool is_chan(int cmd, System *system);
+	double getfreq(int cmd, System *system);
+	bool is_chan_outbound(int cmd, System *system);
+	bool is_chan_inbound_obt(int cmd, System *system);
+	bool is_first_normal(int cmd, System *system);
 	std::vector<TrunkMessage> parse_message(std::string s, System *system);
 };
 #endif

--- a/trunk-recorder/systems/smartnet_parser.h
+++ b/trunk-recorder/systems/smartnet_parser.h
@@ -12,28 +12,58 @@
 
 #include <boost/log/trivial.hpp>
 
+// OSW commands range from $000 to $3ff
+// Within this range are 4 ranges for channel indicators
+// 		$000-$2f7 (760 channels)
+// 		$32f-$33f ( 17 channels)
+//    $3be      (  1 channel )
+//    $3c1-$3fe ( 62 channels)
+// Channels are pre-defined for 8/9 trunks. If an OBT trunk, the first range gets
+// used to to indicate both inbound and outbound channels, with radio programming
+// determining frequencies.
+//    from $000-$2f7 (760 channels)
+//         $000-$17b (380 channels) OBT inbound channels
+//         $17c-$2f7 (380 channels) OBT outbound channels
+#define OSW_MIN                 0x000
+#define OSW_CHAN_BAND_1_MIN     0x000 // Bandplan Range 1, also used for OBT channelization
+#define OSW_CHAN_BAND_1_MAX     0x2f7 // Bandplan Range 1, also used for OBT channelization
+
 #define OSW_BACKGROUND_IDLE     0x2f8
 #define OSW_FIRST_CODED_PC      0x304
 #define OSW_FIRST_NORMAL        0x308
-#define OSW_FIRST_TY2AS1        0x309
+#define OSW_FIRST_TY2AS1        0x309 // Unused - we don't support Type I trunks (or in this case, Type IIi)
 #define OSW_EXTENDED_FCN        0x30b
 #define OSW_AFFIL_FCN           0x30d
 #define OSW_TY2_AFFILIATION     0x310
-#define OSW_TY1_STATUS_MIN      0x310
+#define OSW_TY1_STATUS_MIN      0x310 // Unused - we don't support Type I trunks
 #define OSW_TY2_MESSAGE         0x311
-#define OSW_TY1_STATUS_MAX      0x317
-#define OSW_TY1_ALERT           0x318
-#define OSW_TY1_EMERGENCY       0x319
+#define OSW_TY1_STATUS_MAX      0x317 // Unused - we don't support Type I trunks
+#define OSW_TY1_ALERT           0x318 // Unused - we don't support Type I trunks
+#define OSW_TY1_EMERGENCY       0x319 // Unused - we don't support Type I trunks
 #define OSW_TY2_CALL_ALERT      0x319
 #define OSW_FIRST_ASTRO         0x321
 #define OSW_SYSTEM_CLOCK        0x322
 #define OSW_SCAN_MARKER         0x32b
 #define OSW_EMERG_ANNC          0x32e
+
+#define OSW_CHAN_BAND_2_MIN     0x32f // Bandplan Range 2
+#define OSW_CHAN_BAND_2_MAX     0x33f // Bandplan Range 2
+
+// The following command range ($340-$3bd) wastes 64 commands for AMSS site #
 #define OSW_AMSS_ID_MIN         0x360
 #define OSW_AMSS_ID_MAX         0x39f
+
 #define OSW_CW_ID               0x3a0
+
+#define OSW_CHAN_BAND_3         0x3be // Bandplan "Range" 3
+
 #define OSW_SYS_NETSTAT         0x3bf
 #define OSW_SYS_STATUS          0x3c0
+
+#define OSW_CHAN_BAND_4_MIN     0x3c1 // Bandplan Range 4
+#define OSW_CHAN_BAND_4_MAX     0x3fe // Bandplan Range 4
+
+#define OSW_MAX                 0x3ff
 
 struct osw_stru{
 	unsigned short cmd;

--- a/trunk-recorder/systems/smartnet_parser.h
+++ b/trunk-recorder/systems/smartnet_parser.h
@@ -41,6 +41,7 @@
 #define OSW_TY1_ALERT           0x318 // Unused - we don't support Type I trunks
 #define OSW_TY1_EMERGENCY       0x319 // Unused - we don't support Type I trunks
 #define OSW_TY2_CALL_ALERT      0x319
+#define OSW_SECOND_NORMAL       0x320
 #define OSW_FIRST_ASTRO         0x321
 #define OSW_SYSTEM_CLOCK        0x322
 #define OSW_SCAN_MARKER         0x32b


### PR DESCRIPTION
## Summary

The existing `smartnet_parser` is difficult to follow and was crafted with a
specific focus on pulling out `group call grant/continue`s. Even then, it was
clearly made with a focus on 800/900 systems. The parser also fails also to
properly obtain full context `group call grant`s on OBT systems, only being able
to see them as `group call continue`s and therefore unable to obtain subscriber
IDs.

This is also not a good base for building up support for 1-OSW messages other
than these, as well as messages comprised of more than 1 OSW.

This pull request aims to make this parser not just easy to understand, but also
lay in the groundwork for future enhancements like patch/msel and subscriber
(registration/deregistration/group affiliation) awareness, and system
information and discovery.

I don't have much C++ under my belt lately, so please forgive (and point out)
any ghastly errors or rookie mistakes.

Please take a look, and let me know if there's any clarification I can provide
or questions I can answer.

Thank you.

## Improvements

There are definitely better ways to match messages (tables with ranges?). But
for the time being, I've focused initially on full message handling and parity
for existing captured messages (group call grants and continues).

I hope that by resetting the stage, future contributions that will do better
matching will be easier.

Additionally, there's tasks (housekeeping and bigger) to take care of. Those
include but are not limited to:

- renaming `400` to `OBT` (except for 400-specific bandplans of course)
- using just the talkgroup as the talkgroup instead of `full_address` which
    includes the status nibble. This has always been infuriating for me, seeing
    the same exact resource come up as different talkgroups because a non-0
    status is in effect.
- using hex and not decimal or scanner-land decimal (I call this *16) for TGs.
  This is especially apparent on systems operating as one, e.g. a Type II
  SmartZone trunk using an ASTRO25 core as its zone controller through a SmartX
  site converter. This is a common occurrence especially for larger systems so a
  customer can purchase and upgrade to a P25 system slowly instead of having to
  perform a giant forklift operation. This will allow the use of 1 talkgroup
  file scanning two sites of differing types that are basically the same. (In
  fact, since the legacy system believes the A25 core it's using to be its own
  native zone controller, they **are** the same!)

  Type II talkgroup 16 (in scanner-land decimal) is not the same as P25
  talkgroup 16 (in regular decimal). Since popular scanner websites are
  willing to provide both decimal and hex talkgroup values, and decimal values
  are not the same, the obvious answer is to use the value that does!
  If that isn't reason enough, seeing as we're listening to binary systems...
  This will definitely break various integrations, and so shims will have to
  be inserted in things like uploaders to upload talkgroups as what they
  currently are.
- `trunk-recorder/call.cc: Call::add_signaling_source()` treats any ID of 0
    as not a source. Use something else and update initial source values in
    all parsers accordingly.

---

## Testing

This PR has been tested working with the following:

```
$ uname -a
Linux ubuntu 5.4.0-42-generic #46~18.04.1-Ubuntu SMP Fri Jul 10 07:21:24 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ apt list gnuradio gnuradio-dev libuhd-dev libgnuradio-uhd3.7.11
gnuradio/bionic,now 3.7.11-10 amd64 [installed]
gnuradio-dev/bionic,now 3.7.11-10 amd64 [installed]
libgnuradio-uhd3.7.11/bionic,now 3.7.11-10 amd64 [installed]
libuhd-dev/bionic,now 3.10.3.0-2 amd64 [installed]

$ apt list gr-osmosdr libosmosdr0
Listing... Done
gr-osmosdr/bionic,now 0.1.4-14build1 amd64 [installed]
libosmosdr0/bionic,now 0.1.8.effcaa7-7 amd64 [installed]

$ apt list git cmake make build-essential libboost-all-dev libusb-1.0-0.dev
Listing... Done
build-essential/bionic,now 12.4ubuntu1 amd64 [installed]
cmake/bionic-updates,now 3.10.2-1ubuntu2.18.04.1 amd64 [installed]
git/bionic-updates,bionic-security,now 1:2.17.1-1ubuntu0.7 amd64 [installed]
libboost-all-dev/bionic,now 1.65.1.0ubuntu1 amd64 [installed]
make/bionic,now 4.1-9.1ubuntu1 amd64 [installed]

$ apt list ffmpeg fdkaac sox libaacs0 libcppunit-dev libcppunit-1.14-0 libvo-aacenc0 libssl-dev openssl curl libcurl3-gnutls libcurl4 libcurl4-openssl-dev
Listing... Done
curl/bionic-updates,bionic-security,now 7.58.0-2ubuntu3.9 amd64 [installed]
fdkaac/bionic,now 0.6.3-1 amd64 [installed]
ffmpeg/bionic-updates,bionic-security,now 7:3.4.8-0ubuntu0.2 amd64 [installed]
libaacs0/bionic,now 0.9.0-1 amd64 [installed]
libcppunit-1.14-0/bionic,now 1.14.0-3 amd64 [installed]
libcppunit-dev/bionic,now 1.14.0-3 amd64 [installed]
libcurl3-gnutls/bionic-updates,bionic-security,now 7.58.0-2ubuntu3.9 amd64 [installed]
libcurl4/bionic-updates,bionic-security,now 7.58.0-2ubuntu3.9 amd64 [installed]
libcurl4-openssl-dev/bionic-updates,bionic-security,now 7.58.0-2ubuntu3.9 amd64 [installed]
libssl-dev/bionic-updates,bionic-security,now 1.1.1-1ubuntu2.1~18.04.6 amd64 [installed]
libvo-aacenc0/bionic,now 0.1.3-1 amd64 [installed]
openssl/bionic-updates,bionic-security,now 1.1.1-1ubuntu2.1~18.04.6 amd64 [installed]
sox/bionic-updates,bionic-security,now 14.4.2-3ubuntu0.18.04.1 amd64 [installed]
```

And with 2 Type II systems, one OBT, and one 800:

```
$ cat test-config-obt.json
{
  "sources": [...],
  "systems": [
    {
      "shortName": "",
      "apiKey": "",
      "type": "smartnet",
      "control_channels": [],
      "bandplan": "400_custom",
      "bandplanBase": ,
      "bandplanHigh": ,
      "bandplanSpacing": ,
      "bandplanOffset": ,
      "recordUnknown": true,
    }
  ],
  "defaultMode": "analog",
  "frequencyFormat": "mhz",
  "uploadServer": "https://api.openmhz.com",
  "logFile": true,
  "logLevel": "debug"
}
$ cat test-config-800.json
{
  "sources": [...],
  "systems": [
    {
      "shortName": "",
      "apiKey": "",
      "type": "smartnet",
      "control_channels": [],
      "bandplan": "800_standard",
      "recordUnknown": true,
    }
  ],
  "defaultMode": "analog",
  "frequencyFormat": "mhz",
  "uploadServer": "https://api.openmhz.com",
  "logFile": true,
  "logLevel": "debug"
}
```