### PR TITLE
Conventional systems with channels that can't be covered by any source don't get TGs numbered right

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1381,7 +1381,6 @@ bool monitor_system() {
   for (vector<System *>::iterator sys_it = systems.begin();
        sys_it != systems.end(); sys_it++) {
     System *system = *sys_it;
-    // bool    source_found = false;
 
     if ((system->get_system_type() == "conventional") ||
         (system->get_system_type() == "conventionalP25")) {
@@ -1400,11 +1399,6 @@ bool monitor_system() {
 
           if ((source->get_min_hz() <= channel) &&
               (source->get_max_hz() >= channel)) {
-            // There's no control channel in conventional resources...
-            // The source can cover the System's control channel
-            system->set_source(source);
-            system_added = true;
-
             channel_added = true;
             if (source->get_squelch_db() == 0) {
               BOOST_LOG_TRIVIAL(error)
@@ -1458,11 +1452,13 @@ bool monitor_system() {
         if (!channel_added) {
           BOOST_LOG_TRIVIAL(warning)
               << "[" << system->get_short_name()
-              << "]\t Unable to find a source for this conventional channel! Channel not added: " << FormatFreq(channel)
+              << "]\t Unable to find a source for this conventional channel! "
+                 "Channel not added: " << FormatFreq(channel)
               << " Talkgroup: " << tg_iterate_index;
         }
       }
     } else {
+      // If it's not a conventional system, then it's a trunking system
       double control_channel_freq = system->get_current_control_channel();
       BOOST_LOG_TRIVIAL(info) << "[" << system->get_short_name()
                               << "]\tStarted with Control Channel: "

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1456,7 +1456,7 @@ bool monitor_system() {
           }
         }
         if (channel_added) {
-          BOOST_LOG_TRIVIAL(error)
+          BOOST_LOG_TRIVIAL(warning)
               << "[" << system->get_short_name()
               << "]\t Unable to find a source for this conventional channel! Channel not added: " << FormatFreq(channel)
               << " Talkgroup: " << tg_iterate_index;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1391,8 +1391,9 @@ bool monitor_system() {
       for (vector<double>::iterator chan_it = channels.begin();
            chan_it != channels.end(); chan_it++) {
         double channel = *chan_it;
-
         ++tg_iterate_index;
+        int channel_added = false;
+
         for (vector<Source *>::iterator src_it = sources.begin();
              src_it != sources.end(); src_it++) {
           source = *src_it;
@@ -1404,6 +1405,7 @@ bool monitor_system() {
             // system->set_source(source);
             // system_added = true;
 
+            channel_added = true;
             if (source->get_squelch_db() == 0) {
               BOOST_LOG_TRIVIAL(error)
                   << "[" << system->get_short_name()
@@ -1452,6 +1454,12 @@ bool monitor_system() {
             // break out of the for loop
             break;
           }
+        }
+        if (channel_added) {
+          BOOST_LOG_TRIVIAL(info)
+              << "[" << system->get_short_name()
+              << "]\t Unable to find a source for this conventional channel! Channel not added: " << FormatFreq(channel)
+              << " Talkgroup: " << tg_iterate_index;
         }
       }
     } else {

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1386,12 +1386,13 @@ bool monitor_system() {
     if ((system->get_system_type() == "conventional") ||
         (system->get_system_type() == "conventionalP25")) {
       std::vector<double> channels = system->get_channels();
-      int tg_iterate_index = 1;
+      int tg_iterate_index = 0;
 
       for (vector<double>::iterator chan_it = channels.begin();
            chan_it != channels.end(); chan_it++) {
         double channel = *chan_it;
 
+        ++tg_iterate_index;
         for (vector<Source *>::iterator src_it = sources.begin();
              src_it != sources.end(); src_it++) {
           source = *src_it;
@@ -1420,7 +1421,6 @@ bool monitor_system() {
                 << " Talkgroup: " << talkgroup;
             Call_conventional *call =
                 new Call_conventional(talkgroup, channel, system, config);
-            tg_iterate_index++;
             Talkgroup *talkgroup =
                 system->find_talkgroup(call->get_talkgroup());
 

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1455,7 +1455,7 @@ bool monitor_system() {
             break;
           }
         }
-        if (channel_added) {
+        if (!channel_added) {
           BOOST_LOG_TRIVIAL(warning)
               << "[" << system->get_short_name()
               << "]\t Unable to find a source for this conventional channel! Channel not added: " << FormatFreq(channel)

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1398,9 +1398,10 @@ bool monitor_system() {
 
           if ((source->get_min_hz() <= channel) &&
               (source->get_max_hz() >= channel)) {
+            // There's no control channel in conventional resources...
             // The source can cover the System's control channel
-            system->set_source(source);
-            system_added = true;
+            // system->set_source(source);
+            // system_added = true;
 
             if (source->get_squelch_db() == 0) {
               BOOST_LOG_TRIVIAL(error)
@@ -1412,6 +1413,7 @@ bool monitor_system() {
               system_added = true;
             }
 
+            // This source can be used for this channel (and a squelch is set)
             BOOST_LOG_TRIVIAL(info)
                 << "[" << system->get_short_name()
                 << "]\tMonitoring Conventional Channel: " << FormatFreq(channel)

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1418,9 +1418,9 @@ bool monitor_system() {
             BOOST_LOG_TRIVIAL(info)
                 << "[" << system->get_short_name()
                 << "]\tMonitoring Conventional Channel: " << FormatFreq(channel)
-                << " Talkgroup: " << talkgroup;
+                << " Talkgroup: " << tg_iterate_index;
             Call_conventional *call =
-                new Call_conventional(talkgroup, channel, system, config);
+                new Call_conventional(tg_iterate_index, channel, system, config);
             Talkgroup *talkgroup =
                 system->find_talkgroup(call->get_talkgroup());
 

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1450,7 +1450,7 @@ bool monitor_system() {
           }
         }
         if (!channel_added) {
-          BOOST_LOG_TRIVIAL(warning)
+          BOOST_LOG_TRIVIAL(error)
               << "[" << system->get_short_name()
               << "]\t Unable to find a source for this conventional channel! "
                  "Channel not added: " << FormatFreq(channel)

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1,82 +1,80 @@
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/xml_parser.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/log/trivial.hpp>
+#include <boost/foreach.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/log/attributes/named_scope.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
-#include <boost/log/sources/logger.hpp>
-#include <boost/log/utility/setup/file.hpp>
-#include <boost/log/utility/setup/console.hpp>
-#include <boost/log/utility/setup/common_attributes.hpp>
-#include <boost/log/support/date_time.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
 #include <boost/log/sinks/text_file_backend.hpp>
 #include <boost/log/sinks/text_ostream_backend.hpp>
-#include <boost/log/attributes/named_scope.hpp>
-#include <boost/program_options.hpp>
+#include <boost/log/sources/logger.hpp>
+#include <boost/log/support/date_time.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/file.hpp>
 #include <boost/math/constants/constants.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/classification.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 #include <boost/tokenizer.hpp>
-#include <boost/intrusive_ptr.hpp>
-#include <boost/foreach.hpp>
 
-
-#include <iostream>
 #include <cassert>
 #include <exception>
-#include <iostream>
-#include <sstream>
-#include <string>
 #include <fstream>
+#include <iostream>
+#include <signal.h>
+#include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
-#include <signal.h>
-#include <time.h>
+#include <string>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
+#include "config.h"
 #include "recorder_globals.h"
 #include "source.h"
-#include "config.h"
 
-#include "recorders/recorder.h"
+#include "recorders/analog_recorder.h"
 #include "recorders/p25_recorder.h"
 #include "recorders/p25conventional_recorder.h"
-#include "recorders/analog_recorder.h"
+#include "recorders/recorder.h"
 
-#include "systems/system.h"
-#include "systems/smartnet_trunking.h"
-#include "systems/p25_trunking.h"
-#include "systems/smartnet_parser.h"
 #include "systems/p25_parser.h"
+#include "systems/p25_trunking.h"
 #include "systems/parser.h"
+#include "systems/smartnet_parser.h"
+#include "systems/smartnet_trunking.h"
+#include "systems/system.h"
 
 #include <osmosdr/source.h>
 
-#include <gnuradio/uhd/usrp_source.h>
-#include <gnuradio/msg_queue.h>
-#include <gnuradio/message.h>
+#include "formatter.h"
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/gr_complex.h>
+#include <gnuradio/message.h>
+#include <gnuradio/msg_queue.h>
 #include <gnuradio/top_block.h>
-#include "formatter.h"
+#include <gnuradio/uhd/usrp_source.h>
 
 using namespace std;
-namespace logging  = boost::log;
+namespace logging = boost::log;
 namespace keywords = boost::log::keywords;
-namespace src      = boost::log::sources;
-namespace sinks    = boost::log::sinks;
+namespace src = boost::log::sources;
+namespace sinks = boost::log::sinks;
 int Recorder::rec_counter = 0;
 
 std::vector<Source *> sources;
 std::vector<System *> systems;
-std::map<long, long>  unit_affiliations;
+std::map<long, long> unit_affiliations;
 
 std::vector<Call *> calls;
-gr::top_block_sptr  tb;
+gr::top_block_sptr tb;
 gr::msg_queue::sptr msg_queue;
 
 volatile sig_atomic_t exit_flag = 0;
@@ -85,16 +83,15 @@ P25Parser *p25_parser;
 Config config;
 string default_mode;
 
-#include <websocketpp/config/asio_no_tls_client.hpp>
 #include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_no_tls_client.hpp>
 
 // This header pulls in the WebSocket++ abstracted thread support that will
 // select between boost::thread and std::thread based on how the build system
 // is configured.
-#include <websocketpp/common/thread.hpp>
 #include "uploaders/stat_socket.h"
+#include <websocketpp/common/thread.hpp>
 stat_socket stats;
-
 
 void exit_interupt(int sig) { // can be called asynchronously
   exit_flag = 1;              // set flag
@@ -109,54 +106,45 @@ unsigned GCD(unsigned u, unsigned v) {
   return u;
 }
 
-std::vector<float>design_filter(double interpolation, double deci) {
-  float beta                = 5.0;
-  float trans_width         = 0.5 - 0.4;
+std::vector<float> design_filter(double interpolation, double deci) {
+  float beta = 5.0;
+  float trans_width = 0.5 - 0.4;
   float mid_transition_band = 0.5 - trans_width / 2;
 
   std::vector<float> result = gr::filter::firdes::low_pass(
-    interpolation,
-    1,
-    mid_transition_band / interpolation,
-    trans_width / interpolation,
-    gr::filter::firdes::WIN_KAISER,
-    beta
-    );
+      interpolation, 1, mid_transition_band / interpolation,
+      trans_width / interpolation, gr::filter::firdes::WIN_KAISER, beta);
 
   return result;
 }
 
-void set_logging_level(std::string log_level)
-{
-    boost::log::trivial::severity_level sev_level = boost::log::trivial::info;
+void set_logging_level(std::string log_level) {
+  boost::log::trivial::severity_level sev_level = boost::log::trivial::info;
 
-    if (log_level == "trace")
-        sev_level = boost::log::trivial::trace;
-    else if (log_level == "debug")
-        sev_level = boost::log::trivial::debug;
-    else if (log_level == "info")
-        sev_level = boost::log::trivial::info;
-    else if (log_level == "warning")
-        sev_level = boost::log::trivial::warning;
-    else if (log_level == "error")
-        sev_level = boost::log::trivial::error;
-    else if (log_level == "fatal")
-        sev_level = boost::log::trivial::fatal;
-    else
-    {
-        BOOST_LOG_TRIVIAL(error) << "set_logging_level: Unknown logging level: " << log_level;
-        return;
-    }
+  if (log_level == "trace")
+    sev_level = boost::log::trivial::trace;
+  else if (log_level == "debug")
+    sev_level = boost::log::trivial::debug;
+  else if (log_level == "info")
+    sev_level = boost::log::trivial::info;
+  else if (log_level == "warning")
+    sev_level = boost::log::trivial::warning;
+  else if (log_level == "error")
+    sev_level = boost::log::trivial::error;
+  else if (log_level == "fatal")
+    sev_level = boost::log::trivial::fatal;
+  else {
+    BOOST_LOG_TRIVIAL(error)
+        << "set_logging_level: Unknown logging level: " << log_level;
+    return;
+  }
 
-    logging::core::get()->set_filter
-    (
-        logging::trivial::severity >= sev_level
+  logging::core::get()->set_filter(logging::trivial::severity >= sev_level
 
-    );
+  );
 
-    boost::log::core::get()->set_filter(
-        boost::log::trivial::severity >= sev_level
-    );
+  boost::log::core::get()->set_filter(boost::log::trivial::severity >=
+                                      sev_level);
 }
 
 /**
@@ -164,49 +152,54 @@ void set_logging_level(std::string log_level)
  * Description: <#description#>
  * Parameters: <#parameters#>
  */
-void load_config(string config_file)
-{
+void load_config(string config_file) {
   string system_modulation;
-  int    sys_count = 0;
-  int    source_count = 0;
+  int sys_count = 0;
+  int source_count = 0;
 
-  try
-  {
+  try {
     // const std::string json_filename = "config.json";
 
     boost::property_tree::ptree pt;
     boost::property_tree::read_json(config_file, pt);
-    BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\n     Trunk Recorder\n-------------------------------------\n";
-    BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\nSYSTEMS\n-------------------------------------\n";
+    BOOST_LOG_TRIVIAL(info)
+        << "\n-------------------------------------\n     Trunk "
+           "Recorder\n-------------------------------------\n";
+    BOOST_LOG_TRIVIAL(info)
+        << "\n-------------------------------------\nSYSTEMS\n-----------------"
+           "--------------------\n";
 
-    std::string frequencyFormatString = pt.get<std::string>("frequencyFormat", "exp");
+    std::string frequencyFormatString =
+        pt.get<std::string>("frequencyFormat", "exp");
 
-    if (boost::iequals(frequencyFormatString, "mhz")){
+    if (boost::iequals(frequencyFormatString, "mhz")) {
       frequencyFormat = 1;
-    } else if (boost::iequals(frequencyFormatString, "hz")){
+    } else if (boost::iequals(frequencyFormatString, "hz")) {
       frequencyFormat = 2;
     } else {
       frequencyFormat = 0;
     }
 
-    config.debug_recorder   = pt.get<bool>("debugRecorder", 0);
-    config.debug_recorder_address = pt.get<std::string>("debugRecorderAddress", "127.0.0.1");
+    config.debug_recorder = pt.get<bool>("debugRecorder", 0);
+    config.debug_recorder_address =
+        pt.get<std::string>("debugRecorderAddress", "127.0.0.1");
     config.debug_recorder_port = pt.get<int>("debugRecorderPort", 1234);
 
-    BOOST_FOREACH(boost::property_tree::ptree::value_type  & node,
-                  pt.get_child("systems"))
-    {
+    BOOST_FOREACH (boost::property_tree::ptree::value_type &node,
+                   pt.get_child("systems")) {
       // each system should have a unique index value;
       System *system = new System(sys_count++);
 
       std::stringstream default_script;
-      unsigned long     sys_id;
-      unsigned long     wacn;
-      unsigned long     nac;
+      unsigned long sys_id;
+      unsigned long wacn;
+      unsigned long nac;
       default_script << "sys_" << sys_count;
 
-      BOOST_LOG_TRIVIAL(info) << "\n\nSystem Number: " << sys_count << "\n-------------------------------------\n";
-      system->set_short_name(node.second.get<std::string>("shortName", default_script.str()));
+      BOOST_LOG_TRIVIAL(info) << "\n\nSystem Number: " << sys_count
+                              << "\n-------------------------------------\n";
+      system->set_short_name(
+          node.second.get<std::string>("shortName", default_script.str()));
       BOOST_LOG_TRIVIAL(info) << "Short Name: " << system->get_short_name();
 
       system->set_system_type(node.second.get<std::string>("type"));
@@ -214,8 +207,8 @@ void load_config(string config_file)
 
       if (system->get_system_type() == "conventional") {
         BOOST_LOG_TRIVIAL(info) << "Conventional Channels: ";
-        BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("channels"))
-        {
+        BOOST_FOREACH (boost::property_tree::ptree::value_type &sub_node,
+                       node.second.get_child("channels")) {
           double channel = sub_node.second.get<double>("", 0);
 
           BOOST_LOG_TRIVIAL(info) << "  " << FormatFreq(channel);
@@ -223,11 +216,10 @@ void load_config(string config_file)
         }
 
         BOOST_LOG_TRIVIAL(info) << "Alpha Tags: ";
-        if (node.second.count("alphatags") != 0)
-        {
+        if (node.second.count("alphatags") != 0) {
           int alphaIndex = 1;
-          BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("alphatags"))
-          {
+          BOOST_FOREACH (boost::property_tree::ptree::value_type &sub_node,
+                         node.second.get_child("alphatags")) {
             std::string alphaTag = sub_node.second.get<std::string>("", "");
             BOOST_LOG_TRIVIAL(info) << "  " << alphaTag;
             system->talkgroups->add(alphaIndex, alphaTag);
@@ -235,10 +227,10 @@ void load_config(string config_file)
           }
         }
 
-      }  else if (system->get_system_type() == "conventionalP25") {
+      } else if (system->get_system_type() == "conventionalP25") {
         BOOST_LOG_TRIVIAL(info) << "Conventional Channels: ";
-        BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("channels"))
-        {
+        BOOST_FOREACH (boost::property_tree::ptree::value_type &sub_node,
+                       node.second.get_child("channels")) {
           double channel = sub_node.second.get<double>("", 0);
 
           BOOST_LOG_TRIVIAL(info) << "  " << FormatFreq(channel);
@@ -246,11 +238,10 @@ void load_config(string config_file)
         }
 
         BOOST_LOG_TRIVIAL(info) << "Alpha Tags: ";
-        if (node.second.count("alphatags") != 0)
-        {
+        if (node.second.count("alphatags") != 0) {
           int alphaIndex = 1;
-          BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("alphatags"))
-          {
+          BOOST_FOREACH (boost::property_tree::ptree::value_type &sub_node,
+                         node.second.get_child("alphatags")) {
             std::string alphaTag = sub_node.second.get<std::string>("", "");
             BOOST_LOG_TRIVIAL(info) << "  " << alphaTag;
             system->talkgroups->add(alphaIndex, alphaTag);
@@ -258,13 +249,16 @@ void load_config(string config_file)
           }
         }
 
-        system->set_delaycreateoutput(node.second.get<bool>("delayCreateOutput", false));
-        BOOST_LOG_TRIVIAL(info) << "delayCreateOutput: " << system->get_delaycreateoutput();
+        system->set_delaycreateoutput(
+            node.second.get<bool>("delayCreateOutput", false));
+        BOOST_LOG_TRIVIAL(info)
+            << "delayCreateOutput: " << system->get_delaycreateoutput();
 
-      } else if ((system->get_system_type() == "smartnet") || (system->get_system_type() == "p25")) {
+      } else if ((system->get_system_type() == "smartnet") ||
+                 (system->get_system_type() == "p25")) {
         BOOST_LOG_TRIVIAL(info) << "Control Channels: ";
-        BOOST_FOREACH(boost::property_tree::ptree::value_type  & sub_node, node.second.get_child("control_channels"))
-        {
+        BOOST_FOREACH (boost::property_tree::ptree::value_type &sub_node,
+                       node.second.get_child("control_channels")) {
           double control_channel = sub_node.second.get<double>("", 0);
 
           BOOST_LOG_TRIVIAL(info) << "  " << FormatFreq(control_channel);
@@ -277,46 +271,63 @@ void load_config(string config_file)
 
       system->set_api_key(node.second.get<std::string>("apiKey", ""));
       BOOST_LOG_TRIVIAL(info) << "API Key: " << system->get_api_key();
-      system->set_bcfy_api_key(node.second.get<std::string>("broadcastifyApiKey", ""));
-      BOOST_LOG_TRIVIAL(info) << "Broadcastify API Key: " << system->get_bcfy_api_key();
-      system->set_bcfy_system_id(node.second.get<int>("broadcastifySystemId", 0));
-      BOOST_LOG_TRIVIAL(info) << "Broadcastify Calls System ID: " << system->get_bcfy_system_id();
+      system->set_bcfy_api_key(
+          node.second.get<std::string>("broadcastifyApiKey", ""));
+      BOOST_LOG_TRIVIAL(info)
+          << "Broadcastify API Key: " << system->get_bcfy_api_key();
+      system->set_bcfy_system_id(
+          node.second.get<int>("broadcastifySystemId", 0));
+      BOOST_LOG_TRIVIAL(info)
+          << "Broadcastify Calls System ID: " << system->get_bcfy_system_id();
 
-      system->set_upload_script(node.second.get<std::string>("uploadScript", ""));
+      system->set_upload_script(
+          node.second.get<std::string>("uploadScript", ""));
       BOOST_LOG_TRIVIAL(info) << "Upload Script: " << config.upload_script;
       system->set_call_log(node.second.get<bool>("callLog", true));
       BOOST_LOG_TRIVIAL(info) << "Call Log: " << system->get_call_log();
       system->set_audio_archive(node.second.get<bool>("audioArchive", true));
-      BOOST_LOG_TRIVIAL(info) << "Audio Archive: " << system->get_audio_archive();
-      system->set_talkgroups_file(node.second.get<std::string>("talkgroupsFile", ""));
-      BOOST_LOG_TRIVIAL(info) << "Talkgroups File: " << system->get_talkgroups_file();
-      system->set_unit_tags_file(node.second.get<std::string>("unitTagsFile", ""));
-      BOOST_LOG_TRIVIAL(info) << "Unit Tags File: " << system->get_unit_tags_file();
+      BOOST_LOG_TRIVIAL(info)
+          << "Audio Archive: " << system->get_audio_archive();
+      system->set_talkgroups_file(
+          node.second.get<std::string>("talkgroupsFile", ""));
+      BOOST_LOG_TRIVIAL(info)
+          << "Talkgroups File: " << system->get_talkgroups_file();
+      system->set_unit_tags_file(
+          node.second.get<std::string>("unitTagsFile", ""));
+      BOOST_LOG_TRIVIAL(info)
+          << "Unit Tags File: " << system->get_unit_tags_file();
       system->set_record_unknown(node.second.get<bool>("recordUnknown", true));
-      BOOST_LOG_TRIVIAL(info) << "Record Unknown Talkgroups: " << system->get_record_unknown();
+      BOOST_LOG_TRIVIAL(info)
+          << "Record Unknown Talkgroups: " << system->get_record_unknown();
       system->set_mdc_enabled(node.second.get<bool>("decodeMDC", false));
       BOOST_LOG_TRIVIAL(info) << "Decode MDC: " << system->get_mdc_enabled();
       system->set_fsync_enabled(node.second.get<bool>("decodeFSync", false));
-      BOOST_LOG_TRIVIAL(info) << "Decode FSync: " << system->get_fsync_enabled();
+      BOOST_LOG_TRIVIAL(info)
+          << "Decode FSync: " << system->get_fsync_enabled();
       system->set_star_enabled(node.second.get<bool>("decodeStar", false));
       BOOST_LOG_TRIVIAL(info) << "Decode Star: " << system->get_star_enabled();
       system->set_tps_enabled(node.second.get<bool>("decodeTPS", false));
       BOOST_LOG_TRIVIAL(info) << "Decode TPS: " << system->get_tps_enabled();
-      std::string talkgroup_display_format_string = node.second.get<std::string>("talkgroupDisplayFormat", "Id");
-      if (boost::iequals(talkgroup_display_format_string, "id_tag")){
-        system->set_talkgroup_display_format(System::talkGroupDisplayFormat_id_tag);
-      } else if (boost::iequals(talkgroup_display_format_string, "tag_id")){
-        system->set_talkgroup_display_format(System::talkGroupDisplayFormat_tag_id);
-      } else{
+      std::string talkgroup_display_format_string =
+          node.second.get<std::string>("talkgroupDisplayFormat", "Id");
+      if (boost::iequals(talkgroup_display_format_string, "id_tag")) {
+        system->set_talkgroup_display_format(
+            System::talkGroupDisplayFormat_id_tag);
+      } else if (boost::iequals(talkgroup_display_format_string, "tag_id")) {
+        system->set_talkgroup_display_format(
+            System::talkGroupDisplayFormat_tag_id);
+      } else {
         system->set_talkgroup_display_format(System::talkGroupDisplayFormat_id);
       }
-      BOOST_LOG_TRIVIAL(info) << "Talkgroup Display Format: " << talkgroup_display_format_string;
+      BOOST_LOG_TRIVIAL(info)
+          << "Talkgroup Display Format: " << talkgroup_display_format_string;
 
       sys_id = node.second.get<unsigned long>("sysId", 0);
-      nac    = node.second.get<unsigned long>("nac", 0);
-      wacn   = node.second.get<unsigned long>("wacn", 0);
+      nac = node.second.get<unsigned long>("nac", 0);
+      wacn = node.second.get<unsigned long>("wacn", 0);
       system->set_xor_mask(sys_id, wacn, nac);
-      system->set_bandplan(node.second.get<std::string>("bandplan", "800_standard"));
+      system->set_bandplan(
+          node.second.get<std::string>("bandplan", "800_standard"));
       system->set_bandfreq(800); // Default to 800
 
       if (boost::starts_with(system->get_bandplan(), "400")) {
@@ -324,100 +335,132 @@ void load_config(string config_file)
       }
       system->set_bandplan_base(node.second.get<double>("bandplanBase", 0.0));
       system->set_bandplan_high(node.second.get<double>("bandplanHigh", 0.0));
-      system->set_bandplan_spacing(node.second.get<double>("bandplanSpacing", 0.0));
+      system->set_bandplan_spacing(
+          node.second.get<double>("bandplanSpacing", 0.0));
       system->set_bandplan_offset(node.second.get<int>("bandplanOffset", 0));
 
       if (system->get_system_type() == "smartnet") {
-        BOOST_LOG_TRIVIAL(info) << "Smartnet bandplan: " << system->get_bandplan();
+        BOOST_LOG_TRIVIAL(info)
+            << "Smartnet bandplan: " << system->get_bandplan();
         BOOST_LOG_TRIVIAL(info) << "Smartnet band: " << system->get_bandfreq();
 
-        if (system->get_bandplan_base() || system->get_bandplan_spacing() || system->get_bandplan_offset()) {
-          BOOST_LOG_TRIVIAL(info) << "Smartnet bandplan base freq: " << system->get_bandplan_base();
-          BOOST_LOG_TRIVIAL(info) << "Smartnet bandplan high freq: " << system->get_bandplan_high();
-          BOOST_LOG_TRIVIAL(info) << "Smartnet bandplan spacing: " << system->get_bandplan_spacing();
-          BOOST_LOG_TRIVIAL(info) << "Smartnet bandplan offset: " << system->get_bandplan_offset();
+        if (system->get_bandplan_base() || system->get_bandplan_spacing() ||
+            system->get_bandplan_offset()) {
+          BOOST_LOG_TRIVIAL(info)
+              << "Smartnet bandplan base freq: " << system->get_bandplan_base();
+          BOOST_LOG_TRIVIAL(info)
+              << "Smartnet bandplan high freq: " << system->get_bandplan_high();
+          BOOST_LOG_TRIVIAL(info) << "Smartnet bandplan spacing: "
+                                  << system->get_bandplan_spacing();
+          BOOST_LOG_TRIVIAL(info)
+              << "Smartnet bandplan offset: " << system->get_bandplan_offset();
         }
       }
 
-      system->set_hideEncrypted(node.second.get<bool>("hideEncrypted", system->get_hideEncrypted()));
-      BOOST_LOG_TRIVIAL(info) << "Hide Encrypted Talkgroups: " << system->get_hideEncrypted();
-      system->set_hideUnknown(node.second.get<bool>("hideUnknownTalkgroups", system->get_hideUnknown()));
-      BOOST_LOG_TRIVIAL(info) << "Hide Unknown Talkgroups: " << system->get_hideUnknown();
+      system->set_hideEncrypted(
+          node.second.get<bool>("hideEncrypted", system->get_hideEncrypted()));
+      BOOST_LOG_TRIVIAL(info)
+          << "Hide Encrypted Talkgroups: " << system->get_hideEncrypted();
+      system->set_hideUnknown(node.second.get<bool>("hideUnknownTalkgroups",
+                                                    system->get_hideUnknown()));
+      BOOST_LOG_TRIVIAL(info)
+          << "Hide Unknown Talkgroups: " << system->get_hideUnknown();
       system->set_min_duration(node.second.get<double>("minDuration", 0));
-      BOOST_LOG_TRIVIAL(info) << "Minimum Call Duration (in seconds): " << system->get_min_duration();
-
-
+      BOOST_LOG_TRIVIAL(info) << "Minimum Call Duration (in seconds): "
+                              << system->get_min_duration();
 
       systems.push_back(system);
       BOOST_LOG_TRIVIAL(info);
     }
 
-    BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\nSOURCES\n-------------------------------------\n";
-    BOOST_FOREACH(boost::property_tree::ptree::value_type  & node,
-                  pt.get_child("sources"))
-    {
-      bool   qpsk_mod       = true;
-      bool   gain_set       = false;
-      int    silence_frames = node.second.get<int>("silenceFrames", 0);
-      double center         = node.second.get<double>("center", 0);
-      double rate           = node.second.get<double>("rate", 0);
-      double error          = node.second.get<double>("error", 0);
-      double ppm            = node.second.get<double>("ppm", 0);
-      bool   agc            = node.second.get<bool>("agc", false);
-      int    gain           = node.second.get<double>("gain", 0);
-      int    if_gain        = node.second.get<double>("ifGain", 0);
-      int    bb_gain        = node.second.get<double>("bbGain", 0);
-      int    mix_gain       = node.second.get<double>("mixGain", 0);
-      int    lna_gain       = node.second.get<double>("lnaGain", 0);
-      int    pga_gain       = node.second.get<double>("pgaGain", 0);
-      int    tia_gain       = node.second.get<double>("tiaGain", 0);
-      int    vga1_gain      = node.second.get<double>("vga1Gain", 0);
-      int    vga2_gain      = node.second.get<double>("vga2Gain", 0);
+    BOOST_LOG_TRIVIAL(info)
+        << "\n\n-------------------------------------\nSOURCES\n---------------"
+           "----------------------\n";
+    BOOST_FOREACH (boost::property_tree::ptree::value_type &node,
+                   pt.get_child("sources")) {
+      bool qpsk_mod = true;
+      bool gain_set = false;
+      int silence_frames = node.second.get<int>("silenceFrames", 0);
+      double center = node.second.get<double>("center", 0);
+      double rate = node.second.get<double>("rate", 0);
+      double error = node.second.get<double>("error", 0);
+      double ppm = node.second.get<double>("ppm", 0);
+      bool agc = node.second.get<bool>("agc", false);
+      int gain = node.second.get<double>("gain", 0);
+      int if_gain = node.second.get<double>("ifGain", 0);
+      int bb_gain = node.second.get<double>("bbGain", 0);
+      int mix_gain = node.second.get<double>("mixGain", 0);
+      int lna_gain = node.second.get<double>("lnaGain", 0);
+      int pga_gain = node.second.get<double>("pgaGain", 0);
+      int tia_gain = node.second.get<double>("tiaGain", 0);
+      int vga1_gain = node.second.get<double>("vga1Gain", 0);
+      int vga2_gain = node.second.get<double>("vga2Gain", 0);
       double digital_levels = node.second.get<double>("digitalLevels", 1.0);
-      double analog_levels  = node.second.get<double>("analogLevels", 8.0);
-      double squelch_db     = node.second.get<double>("squelch", 0);
+      double analog_levels = node.second.get<double>("analogLevels", 8.0);
+      double squelch_db = node.second.get<double>("squelch", 0);
 
-      std::string antenna   = node.second.get<string>("antenna", "");
+      std::string antenna = node.second.get<string>("antenna", "");
       int digital_recorders = node.second.get<int>("digitalRecorders", 0);
-      int sigmf_recorders   = node.second.get<int>("sigmfRecorders", 0);
-      int analog_recorders  = node.second.get<int>("analogRecorders", 0);
+      int sigmf_recorders = node.second.get<int>("sigmfRecorders", 0);
+      int analog_recorders = node.second.get<int>("analogRecorders", 0);
 
       std::string driver = node.second.get<std::string>("driver", "");
 
       if ((driver != "osmosdr") && (driver != "usrp")) {
-        BOOST_LOG_TRIVIAL(error) << "Driver specified in config.json not recognized, needs to be osmosdr or usrp";
+        BOOST_LOG_TRIVIAL(error) << "Driver specified in config.json not "
+                                    "recognized, needs to be osmosdr or usrp";
       }
 
       std::string device = node.second.get<std::string>("device", "");
-      BOOST_LOG_TRIVIAL(info) << "Driver: " << node.second.get<std::string>("driver",  "");
-      BOOST_LOG_TRIVIAL(info) << "Center: " << FormatFreq(node.second.get<double>("center", 0));
-      BOOST_LOG_TRIVIAL(info) << "Rate: " << FormatSamplingRate(node.second.get<double>("rate", 0));
-      BOOST_LOG_TRIVIAL(info) << "Error: " << node.second.get<double>("error", 0);
-      BOOST_LOG_TRIVIAL(info) << "PPM Error: " <<  node.second.get<double>("ppm", 0);
-      BOOST_LOG_TRIVIAL(info) << "Auto gain control: " << node.second.get<bool>("agc", false);
+      BOOST_LOG_TRIVIAL(info)
+          << "Driver: " << node.second.get<std::string>("driver", "");
+      BOOST_LOG_TRIVIAL(info)
+          << "Center: " << FormatFreq(node.second.get<double>("center", 0));
+      BOOST_LOG_TRIVIAL(info)
+          << "Rate: " << FormatSamplingRate(node.second.get<double>("rate", 0));
+      BOOST_LOG_TRIVIAL(info)
+          << "Error: " << node.second.get<double>("error", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "PPM Error: " << node.second.get<double>("ppm", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "Auto gain control: " << node.second.get<bool>("agc", false);
       BOOST_LOG_TRIVIAL(info) << "Gain: " << node.second.get<double>("gain", 0);
-      BOOST_LOG_TRIVIAL(info) << "IF Gain: " << node.second.get<double>("ifGain", 0);
-      BOOST_LOG_TRIVIAL(info) << "BB Gain: " << node.second.get<double>("bbGain", 0);
-      BOOST_LOG_TRIVIAL(info) << "LNA Gain: " << node.second.get<double>("lnaGain", 0);
-      BOOST_LOG_TRIVIAL(info) << "PGA Gain: " << node.second.get<double>("pgaGain", 0);
-      BOOST_LOG_TRIVIAL(info) << "TIA Gain: " << node.second.get<double>("tiaGain", 0);
-      BOOST_LOG_TRIVIAL(info) << "MIX Gain: " << node.second.get<double>("mixGain", 0);
-      BOOST_LOG_TRIVIAL(info) << "VGA1 Gain: " << node.second.get<double>("vga1Gain", 0);
-      BOOST_LOG_TRIVIAL(info) << "VGA2 Gain: " << node.second.get<double>("vga2Gain", 0);
-      BOOST_LOG_TRIVIAL(info) << "Squelch: " << node.second.get<double>("squelch", 0);
-      BOOST_LOG_TRIVIAL(info) << "Idle Silence: " << node.second.get<bool>("idleSilence", 0);
-      BOOST_LOG_TRIVIAL(info) << "Digital Recorders: " << node.second.get<int>("digitalRecorders", 0);
-      BOOST_LOG_TRIVIAL(info) << "Debug Recorder: " << node.second.get<bool>("debugRecorder",  0);
-      BOOST_LOG_TRIVIAL(info) << "SigMF Recorders: " << node.second.get<int>("sigmfRecorders",  0);
-      BOOST_LOG_TRIVIAL(info) << "Analog Recorders: " << node.second.get<int>("analogRecorders",  0);
+      BOOST_LOG_TRIVIAL(info)
+          << "IF Gain: " << node.second.get<double>("ifGain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "BB Gain: " << node.second.get<double>("bbGain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "LNA Gain: " << node.second.get<double>("lnaGain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "PGA Gain: " << node.second.get<double>("pgaGain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "TIA Gain: " << node.second.get<double>("tiaGain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "MIX Gain: " << node.second.get<double>("mixGain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "VGA1 Gain: " << node.second.get<double>("vga1Gain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "VGA2 Gain: " << node.second.get<double>("vga2Gain", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "Squelch: " << node.second.get<double>("squelch", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "Idle Silence: " << node.second.get<bool>("idleSilence", 0);
+      BOOST_LOG_TRIVIAL(info) << "Digital Recorders: "
+                              << node.second.get<int>("digitalRecorders", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "Debug Recorder: " << node.second.get<bool>("debugRecorder", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "SigMF Recorders: " << node.second.get<int>("sigmfRecorders", 0);
+      BOOST_LOG_TRIVIAL(info)
+          << "Analog Recorders: " << node.second.get<int>("analogRecorders", 0);
 
-      boost::optional<std::string> mod_exists = node.second.get_optional<std::string>("modulation");
+      boost::optional<std::string> mod_exists =
+          node.second.get_optional<std::string>("modulation");
 
       if (mod_exists) {
         system_modulation = node.second.get<std::string>("modulation");
 
-        if (boost::iequals(system_modulation, "qpsk"))
-        {
+        if (boost::iequals(system_modulation, "qpsk")) {
           qpsk_mod = true;
           BOOST_LOG_TRIVIAL(info) << "Modulation: qpsk";
         } else if (boost::iequals(system_modulation, "fsk4")) {
@@ -425,20 +468,24 @@ void load_config(string config_file)
           BOOST_LOG_TRIVIAL(info) << "Modulation: fsk4";
         } else {
           qpsk_mod = true;
-          BOOST_LOG_TRIVIAL(error) << "! System Modulation Not Specified, could be fsk4 or qpsk, assuming qpsk";
+          BOOST_LOG_TRIVIAL(error) << "! System Modulation Not Specified, "
+                                      "could be fsk4 or qpsk, assuming qpsk";
         }
       } else {
         qpsk_mod = true;
       }
 
       if ((ppm != 0) && (error != 0)) {
-        BOOST_LOG_TRIVIAL(info) <<  "Both PPM and Error should not be set at the same time. Setting Error to 0.";
+        BOOST_LOG_TRIVIAL(info) << "Both PPM and Error should not be set at "
+                                   "the same time. Setting Error to 0.";
         error = 0;
       }
 
       Source *source = new Source(center, rate, error, driver, device, &config);
-      BOOST_LOG_TRIVIAL(info) << "Max Frequency: " << FormatFreq(source->get_max_hz());
-      BOOST_LOG_TRIVIAL(info) << "Min Frequency: " << FormatFreq(source->get_min_hz());
+      BOOST_LOG_TRIVIAL(info)
+          << "Max Frequency: " << FormatFreq(source->get_max_hz());
+      BOOST_LOG_TRIVIAL(info)
+          << "Min Frequency: " << FormatFreq(source->get_min_hz());
 
       if (if_gain != 0) {
         gain_set = true;
@@ -486,7 +533,8 @@ void load_config(string config_file)
       }
 
       if (!gain_set) {
-        BOOST_LOG_TRIVIAL(error) << "! No Gain was specified! Things will probably not work";
+        BOOST_LOG_TRIVIAL(error)
+            << "! No Gain was specified! Things will probably not work";
       }
 
       source->set_gain_mode(agc);
@@ -508,23 +556,27 @@ void load_config(string config_file)
       }
       sources.push_back(source);
       source_count++;
-      BOOST_LOG_TRIVIAL(info) <<  "\n-------------------------------------\n\n";
+      BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\n\n";
     }
 
-    BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\nINSTANCE\n-------------------------------------\n";
+    BOOST_LOG_TRIVIAL(info)
+        << "\n\n-------------------------------------\nINSTANCE\n--------------"
+           "-----------------------\n";
 
-    config.capture_dir = pt.get<std::string>("captureDir", boost::filesystem::current_path().string());
+    config.capture_dir = pt.get<std::string>(
+        "captureDir", boost::filesystem::current_path().string());
     size_t pos = config.capture_dir.find_last_of("/");
 
-    if (pos == config.capture_dir.length() - 1)
-    {
+    if (pos == config.capture_dir.length() - 1) {
       config.capture_dir.erase(config.capture_dir.length() - 1);
     }
     BOOST_LOG_TRIVIAL(info) << "Capture Directory: " << config.capture_dir;
     config.upload_server = pt.get<std::string>("uploadServer", "");
     BOOST_LOG_TRIVIAL(info) << "Upload Server: " << config.upload_server;
-    config.bcfy_calls_server = pt.get<std::string>("broadcastifyCallsServer", "");
-    BOOST_LOG_TRIVIAL(info) << "Broadcastify Calls Server: " << config.bcfy_calls_server;
+    config.bcfy_calls_server =
+        pt.get<std::string>("broadcastifyCallsServer", "");
+    BOOST_LOG_TRIVIAL(info)
+        << "Broadcastify Calls Server: " << config.bcfy_calls_server;
     config.status_server = pt.get<std::string>("statusServer", "");
     BOOST_LOG_TRIVIAL(info) << "Status Server: " << config.status_server;
     config.instance_key = pt.get<std::string>("instanceKey", "");
@@ -532,17 +584,21 @@ void load_config(string config_file)
     config.instance_id = pt.get<std::string>("instanceId", "");
     BOOST_LOG_TRIVIAL(info) << "Instance Id: " << config.instance_id;
     config.broadcast_signals = pt.get<bool>("broadcastSignals", false);
-    BOOST_LOG_TRIVIAL(info) << "Broadcast Signals: " << config.broadcast_signals;
+    BOOST_LOG_TRIVIAL(info)
+        << "Broadcast Signals: " << config.broadcast_signals;
     default_mode = pt.get<std::string>("defaultMode", "digital");
     BOOST_LOG_TRIVIAL(info) << "Default Mode: " << default_mode;
     config.call_timeout = pt.get<int>("callTimeout", 3);
-    BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;
+    BOOST_LOG_TRIVIAL(info)
+        << "Call Timeout (seconds): " << config.call_timeout;
     config.log_file = pt.get<bool>("logFile", false);
     BOOST_LOG_TRIVIAL(info) << "Log to File: " << config.log_file;
     config.control_message_warn_rate = pt.get<int>("controlWarnRate", 10);
-    BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
+    BOOST_LOG_TRIVIAL(info)
+        << "Control channel warning rate: " << config.control_message_warn_rate;
     config.control_retune_limit = pt.get<int>("controlRetuneLimit", 0);
-    BOOST_LOG_TRIVIAL(info) << "Control channel retune limit: " << config.control_retune_limit;
+    BOOST_LOG_TRIVIAL(info)
+        << "Control channel retune limit: " << config.control_retune_limit;
 
     BOOST_LOG_TRIVIAL(info) << "Frequency format: " << frequencyFormat;
 
@@ -551,21 +607,25 @@ void load_config(string config_file)
     std::string log_level = pt.get<std::string>("logLevel", "info");
     BOOST_LOG_TRIVIAL(info) << "Log Level: " << log_level;
     set_logging_level(log_level);
-  }
-  catch (std::exception const& e)
-  {
+  } catch (std::exception const &e) {
     BOOST_LOG_TRIVIAL(error) << "Failed parsing Config: " << e.what();
     exit(1);
   }
   if (config.debug_recorder) {
-      BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\nDEBUG RECORDER\n-------------------------------------\n";
-       BOOST_LOG_TRIVIAL(info) << "  Address: " << config.debug_recorder_address;
+    BOOST_LOG_TRIVIAL(info)
+        << "\n\n-------------------------------------\nDEBUG "
+           "RECORDER\n-------------------------------------\n";
+    BOOST_LOG_TRIVIAL(info) << "  Address: " << config.debug_recorder_address;
 
-      for (vector<Source *>::iterator it = sources.begin(); it != sources.end(); it++) {
-        Source *source = *it;
-        BOOST_LOG_TRIVIAL(info) << "  " << source->get_driver() << " - " << source->get_device() << " [ " << FormatFreq(source->get_center()) << " ]  Port: " << source->get_debug_recorder_port();
-      }
-       BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\n";
+    for (vector<Source *>::iterator it = sources.begin(); it != sources.end();
+         it++) {
+      Source *source = *it;
+      BOOST_LOG_TRIVIAL(info)
+          << "  " << source->get_driver() << " - " << source->get_device()
+          << " [ " << FormatFreq(source->get_center())
+          << " ]  Port: " << source->get_debug_recorder_port();
+    }
+    BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\n";
   }
 }
 
@@ -587,23 +647,26 @@ int get_total_recorders() {
  * Description: <#description#>
  * Parameters: TrunkMessage message
  */
-bool replace(std::string& str, const std::string& from, const std::string& to) {
+bool replace(std::string &str, const std::string &from, const std::string &to) {
   size_t start_pos = str.find(from);
 
-  if (start_pos == std::string::npos) return false;
+  if (start_pos == std::string::npos)
+    return false;
 
   str.replace(start_pos, from.length(), to);
   return true;
 }
 
-void process_signal(long unitId, const char* signaling_type, gr::blocks::SignalType sig_type, Call* call, System* system, Recorder* recorder) {
-    stats.send_signal(unitId, signaling_type, sig_type, call, system, recorder);
+void process_signal(long unitId, const char *signaling_type,
+                    gr::blocks::SignalType sig_type, Call *call, System *system,
+                    Recorder *recorder) {
+  stats.send_signal(unitId, signaling_type, sig_type, call, system, recorder);
 }
 
 bool start_recorder(Call *call, TrunkMessage message, System *sys) {
   Talkgroup *talkgroup = sys->find_talkgroup(call->get_talkgroup());
-  bool source_found    = false;
-  bool recorder_found  = false;
+  bool source_found = false;
+  bool recorder_found = false;
   Recorder *recorder;
   Recorder *debug_recorder;
   Recorder *sigmf_recorder;
@@ -614,14 +677,22 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
 
   if (call->get_encrypted() == true) {
     if (sys->get_hideEncrypted() == false) {
-      BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " <<  FormatFreq(call->get_freq()) << "\t\u001b[31mNot Recording: ENCRYPTED\u001b[0m ";
+      BOOST_LOG_TRIVIAL(info)
+          << "[" << sys->get_short_name()
+          << "]\tTG: " << call->get_talkgroup_display()
+          << "\tFreq: " << FormatFreq(call->get_freq())
+          << "\t\u001b[31mNot Recording: ENCRYPTED\u001b[0m ";
     }
     return false;
   }
 
   if (!talkgroup && (sys->get_record_unknown() == false)) {
     if (sys->get_hideUnknown() == false) {
-      BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " << FormatFreq(call->get_freq()) << "\t\u001b[33mNot Recording: TG not in Talkgroup File\u001b[0m ";
+      BOOST_LOG_TRIVIAL(info)
+          << "[" << sys->get_short_name()
+          << "]\tTG: " << call->get_talkgroup_display()
+          << "\tFreq: " << FormatFreq(call->get_freq())
+          << "\t\u001b[33mNot Recording: TG not in Talkgroup File\u001b[0m ";
     }
     return false;
   }
@@ -632,33 +703,37 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
     call->set_talkgroup_tag("-");
   }
 
-  for (vector<Source *>::iterator it = sources.begin(); it != sources.end(); it++) {
+  for (vector<Source *>::iterator it = sources.begin(); it != sources.end();
+       it++) {
     Source *source = *it;
 
     if ((source->get_min_hz() <= call->get_freq()) &&
         (source->get_max_hz() >= call->get_freq())) {
       source_found = true;
 
-      if (talkgroup)
-      {
+      if (talkgroup) {
         if (talkgroup->mode == 'A') {
           recorder = source->get_analog_recorder(talkgroup->get_priority());
         } else {
           recorder = source->get_digital_recorder(talkgroup->get_priority());
         }
       } else {
-        BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " << FormatFreq(call->get_freq()) << "\tTG not in Talkgroup File ";
+        BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name()
+                                << "]\tTG: " << call->get_talkgroup_display()
+                                << "\tFreq: " << FormatFreq(call->get_freq())
+                                << "\tTG not in Talkgroup File ";
 
         // A talkgroup was not found from the talkgroup file.
-        // Use an analog recorder if this is a Type II trunk and defaultMode is analog.
-        // All other cases use a digital recorder.
-          if ((default_mode == "analog") && (sys->get_system_type() == "smartnet")) {
-            recorder = source->get_analog_recorder(2);
-          } else {
-            recorder = source->get_digital_recorder(2);
-          }
+        // Use an analog recorder if this is a Type II trunk and defaultMode is
+        // analog. All other cases use a digital recorder.
+        if ((default_mode == "analog") &&
+            (sys->get_system_type() == "smartnet")) {
+          recorder = source->get_analog_recorder(2);
+        } else {
+          recorder = source->get_digital_recorder(2);
+        }
       }
-      //int total_recorders = get_total_recorders();
+      // int total_recorders = get_total_recorders();
 
       if (recorder) {
         if (message.meta.length()) {
@@ -709,26 +784,35 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
   }
 
   if (!source_found) {
-    BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " << FormatFreq(call->get_freq()) << "\t\u001b[36mNot Recording: no source covering Freq\u001b[0m";
+    BOOST_LOG_TRIVIAL(info)
+        << "[" << sys->get_short_name()
+        << "]\tTG: " << call->get_talkgroup_display()
+        << "\tFreq: " << FormatFreq(call->get_freq())
+        << "\t\u001b[36mNot Recording: no source covering Freq\u001b[0m";
     return false;
   }
   return false;
 }
 
 void process_message_queues() {
-    for (std::vector<System*>::iterator it = systems.begin(); it != systems.end(); ++it) {
-        System* sys = (System*)*it;
+  for (std::vector<System *>::iterator it = systems.begin();
+       it != systems.end(); ++it) {
+    System *sys = (System *)*it;
 
-        for (std::vector<analog_recorder_sptr>::iterator arit = sys->conventional_recorders.begin(); arit != sys->conventional_recorders.end(); ++arit) {
-            analog_recorder_sptr ar = (analog_recorder_sptr)*arit;
-            ar->process_message_queues();
-        }
-
-        for (std::vector<p25conventional_recorder_sptr>::iterator pit = sys->conventionalP25_recorders.begin(); pit != sys->conventionalP25_recorders.end(); ++pit) {
-            p25conventional_recorder_sptr pr = (p25conventional_recorder_sptr)*pit;
-            pr->process_message_queues();
-        }
+    for (std::vector<analog_recorder_sptr>::iterator arit =
+             sys->conventional_recorders.begin();
+         arit != sys->conventional_recorders.end(); ++arit) {
+      analog_recorder_sptr ar = (analog_recorder_sptr)*arit;
+      ar->process_message_queues();
     }
+
+    for (std::vector<p25conventional_recorder_sptr>::iterator pit =
+             sys->conventionalP25_recorders.begin();
+         pit != sys->conventionalP25_recorders.end(); ++pit) {
+      p25conventional_recorder_sptr pr = (p25conventional_recorder_sptr)*pit;
+      pr->process_message_queues();
+    }
+  }
 }
 
 void stop_inactive_recorders() {
@@ -740,7 +824,9 @@ void stop_inactive_recorders() {
     if (call->is_conventional() && call->get_recorder()) {
       // if any recording has happened
       if (call->get_current_length() > 0) {
-        BOOST_LOG_TRIVIAL(trace) << "Recorder: " <<  call->get_current_length() << " Idle: " << call->get_recorder()->is_idle() << " Count: " << call->get_idle_count();
+        BOOST_LOG_TRIVIAL(trace) << "Recorder: " << call->get_current_length()
+                                 << " Idle: " << call->get_recorder()->is_idle()
+                                 << " Count: " << call->get_idle_count();
 
         // means that the squelch is on and it has stopped recording
         if (call->get_recorder()->is_idle()) {
@@ -751,9 +837,10 @@ void stop_inactive_recorders() {
           call->reset_idle_count();
         }
 
-        // if no additional recording has happened in the past X periods, stop and open new file
+        // if no additional recording has happened in the past X periods, stop
+        // and open new file
         if (call->get_idle_count() > 5) {
-          Recorder * recorder = call->get_recorder();
+          Recorder *recorder = call->get_recorder();
           call->end_call();
           stats.send_call_end(call);
           call->restart_call();
@@ -768,7 +855,7 @@ void stop_inactive_recorders() {
         if (call->get_state() == recording) {
           ended_recording = true;
         }
-        Recorder * recorder = call->get_recorder();
+        Recorder *recorder = call->get_recorder();
         call->end_call();
         stats.send_call_end(call);
         if (recorder != NULL) {
@@ -781,7 +868,6 @@ void stop_inactive_recorders() {
       } // if rx is active
     }   // foreach loggers
   }
-
 
   if (ended_recording) {
     stats.send_calls_active(calls);
@@ -798,18 +884,24 @@ void print_status() {
   BOOST_LOG_TRIVIAL(info) << "Currently Active Calls: " << calls.size();
 
   for (vector<Call *>::iterator it = calls.begin(); it != calls.end(); it++) {
-    Call *call         = *it;
+    Call *call = *it;
     Recorder *recorder = call->get_recorder();
-    BOOST_LOG_TRIVIAL(info) << "TG: " << call->get_talkgroup_display() << " Freq: " << FormatFreq(call->get_freq()) << " Elapsed: " << call->elapsed() << " State: " << FormatState(call->get_state());
+    BOOST_LOG_TRIVIAL(info) << "TG: " << call->get_talkgroup_display()
+                            << " Freq: " << FormatFreq(call->get_freq())
+                            << " Elapsed: " << call->elapsed()
+                            << " State: " << FormatState(call->get_state());
 
     if (recorder) {
-      BOOST_LOG_TRIVIAL(info) << "\t[ " << recorder->get_num() << " ] State: " << FormatState(recorder->get_state());
+      BOOST_LOG_TRIVIAL(info)
+          << "\t[ " << recorder->get_num()
+          << " ] State: " << FormatState(recorder->get_state());
     }
   }
 
   BOOST_LOG_TRIVIAL(info) << "Recorders: ";
 
-  for (vector<Source *>::iterator it = sources.begin(); it != sources.end(); it++) {
+  for (vector<Source *>::iterator it = sources.begin(); it != sources.end();
+       it++) {
     Source *source = *it;
     source->print_recorders();
   }
@@ -817,24 +909,31 @@ void print_status() {
 
 bool retune_recorder(TrunkMessage message, Call *call) {
   Recorder *recorder = call->get_recorder();
-  Source   *source   = recorder->get_source();
-
+  Source *source = recorder->get_source();
 
   if (call->get_phase2_tdma() != message.phase2_tdma) {
     BOOST_LOG_TRIVIAL(info) << "\t - Retune failed, TDMA Mismatch! ";
-    BOOST_LOG_TRIVIAL(info) << "\t - Message - \tTMDA: " << message.phase2_tdma << " \tSlot: " << message.tdma_slot << "\tCall - \tTMDA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot();
-    BOOST_LOG_TRIVIAL(info) << "\t - Starting a new recording using a new recorder";
+    BOOST_LOG_TRIVIAL(info) << "\t - Message - \tTMDA: " << message.phase2_tdma
+                            << " \tSlot: " << message.tdma_slot
+                            << "\tCall - \tTMDA: " << call->get_phase2_tdma()
+                            << "\tSlot: " << call->get_tdma_slot();
+    BOOST_LOG_TRIVIAL(info)
+        << "\t - Starting a new recording using a new recorder";
     return false;
   }
 
   if (call->get_tdma_slot() != message.tdma_slot) {
-    BOOST_LOG_TRIVIAL(info) << "\t - Message - \tTMDA: " << message.phase2_tdma << " \tSlot: " << message.tdma_slot << "\tCall - \tTMDA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot();
+    BOOST_LOG_TRIVIAL(info) << "\t - Message - \tTMDA: " << message.phase2_tdma
+                            << " \tSlot: " << message.tdma_slot
+                            << "\tCall - \tTMDA: " << call->get_phase2_tdma()
+                            << "\tSlot: " << call->get_tdma_slot();
     recorder->set_tdma_slot(message.tdma_slot);
     call->set_tdma_slot(message.tdma_slot);
   }
 
   if (message.freq != call->get_freq()) {
-    if ((source->get_min_hz() <= message.freq) && (source->get_max_hz() >= message.freq)) {
+    if ((source->get_min_hz() <= message.freq) &&
+        (source->get_max_hz() >= message.freq)) {
       recorder->tune_freq(message.freq);
 
       // only set the call freq, if the recorder can be retuned.
@@ -843,14 +942,14 @@ bool retune_recorder(TrunkMessage message, Call *call) {
       call->set_phase2_tdma(message.phase2_tdma);
       call->set_tdma_slot(message.tdma_slot);
 
-
       if (call->get_debug_recording() == true) {
         call->get_debug_recorder()->tune_offset(message.freq);
       }
       return true;
     } else {
-      // TODO: Find the source that has the frequency on it, update our recorder to use that source for the rest of the call
-      //Couldn't find a source that covers it
+      // TODO: Find the source that has the frequency on it, update our recorder
+      // to use that source for the rest of the call
+      // Couldn't find a source that covers it
       return false;
     }
   }
@@ -858,7 +957,7 @@ bool retune_recorder(TrunkMessage message, Call *call) {
 }
 
 void current_system_status(TrunkMessage message, System *sys) {
-  if (sys->update_status(message)){
+  if (sys->update_status(message)) {
     stats.send_system(sys);
   }
 }
@@ -880,37 +979,50 @@ void group_affiliation(long unit, long talkgroup) {
 }
 
 void handle_call(TrunkMessage message, System *sys) {
-  bool call_found        = false;
-  bool call_retune       = false;
+  bool call_found = false;
+  bool call_retune = false;
   bool recording_started = false;
-  bool retune_failed     = false;
+  bool retune_failed = false;
 
-
-/* Notes: it is possible for 2 Calls to exist for the same talkgroup on different freq. This happens when a Talkgroup starts on a freq
-  that current recorder can't retune to. In this case, the current orig Talkgroup reocrder will keep going on the old freq, while a new
-  recorder is start on a source that can cover that freq. This makes sure any of the remaining transmission that it is in the buffer
-  of the original recorder gets flushed. */
+  /* Notes: it is possible for 2 Calls to exist for the same talkgroup on
+    different freq. This happens when a Talkgroup starts on a freq that current
+    recorder can't retune to. In this case, the current orig Talkgroup reocrder
+    will keep going on the old freq, while a new recorder is start on a source
+    that can cover that freq. This makes sure any of the remaining transmission
+    that it is in the buffer of the original recorder gets flushed. */
 
   for (vector<Call *>::iterator it = calls.begin(); it != calls.end();) {
     Call *call = *it;
 
-    if ((call->get_talkgroup() == message.talkgroup) && (call->get_sys_num() == message.sys_num)) {
+    if ((call->get_talkgroup() == message.talkgroup) &&
+        (call->get_sys_num() == message.sys_num)) {
       call_found = true;
 
-      // Check to make sure the Freq and TDMA info match up with what is being currenty recorded
-      if ((call->get_freq() != message.freq) || (call->get_tdma_slot() != message.tdma_slot) || (call->get_phase2_tdma() != message.phase2_tdma)) {
+      // Check to make sure the Freq and TDMA info match up with what is being
+      // currenty recorded
+      if ((call->get_freq() != message.freq) ||
+          (call->get_tdma_slot() != message.tdma_slot) ||
+          (call->get_phase2_tdma() != message.phase2_tdma)) {
         if (call->get_state() == recording) {
-          // see if we can retune the recorder, You may not be able to if the Freq is beyond what the current source can handle
+          // see if we can retune the recorder, You may not be able to if the
+          // Freq is beyond what the current source can handle
           int retuned = retune_recorder(message, call);
 
           if (!retuned) {
-            // we want to keep this call recording and now start a recording of the new call on another recorder
+            // we want to keep this call recording and now start a recording of
+            // the new call on another recorder
             call_found = false;
             retune_failed = true;
             ++it; // go on to the next call, remember there may be two calls
           } else {
             // if you did retune, update the call info
-            BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " << FormatFreq(call->get_freq()) << "\tUpdate Retuning - New Freq: " << FormatFreq(message.freq) << "\tElapsed: " << call->elapsed() << "s \tSince update: " << call->since_last_update() << "s";
+            BOOST_LOG_TRIVIAL(info)
+                << "[" << sys->get_short_name()
+                << "]\tTG: " << call->get_talkgroup_display()
+                << "\tFreq: " << FormatFreq(call->get_freq())
+                << "\tUpdate Retuning - New Freq: " << FormatFreq(message.freq)
+                << "\tElapsed: " << call->elapsed()
+                << "s \tSince update: " << call->since_last_update() << "s";
             call->update(message);
             call_retune = true;
             break;
@@ -925,21 +1037,22 @@ void handle_call(TrunkMessage message, System *sys) {
         }
       } else {
 
-        // everything about the current recording matches, simply update the info
+        // everything about the current recording matches, simply update the
+        // info
         call->update(message);
         break;
       }
     } else {
       ++it;
-      // the talkgroup for the call being looked at doesn't match, look at the next one.
+      // the talkgroup for the call being looked at doesn't match, look at the
+      // next one.
     }
   }
 
-
-
   if (!call_found) {
     if (retune_failed) {
-      BOOST_LOG_TRIVIAL(info) << "\t - Retune failed, starting a new recording using a new source";
+      BOOST_LOG_TRIVIAL(info)
+          << "\t - Retune failed, starting a new recording using a new source";
     }
     Call *call = new Call(message, sys, config);
     recording_started = start_recorder(call, message, sys);
@@ -954,28 +1067,29 @@ void handle_call(TrunkMessage message, System *sys) {
 void unit_check() {
   std::map<long, long> talkgroup_totals;
   std::map<long, long>::iterator it;
-  char   shell_command[200];
+  char shell_command[200];
   time_t starttime = time(NULL);
-  tm    *ltm       = localtime(&starttime);
-  char   unit_filename[160];
+  tm *ltm = localtime(&starttime);
+  char unit_filename[160];
 
   std::stringstream path_stream;
 
-  path_stream << boost::filesystem::current_path().string() <<  "/" << 1900 +  ltm->tm_year << "/" << 1 + ltm->tm_mon << "/" << ltm->tm_mday;
+  path_stream << boost::filesystem::current_path().string() << "/"
+              << 1900 + ltm->tm_year << "/" << 1 + ltm->tm_mon << "/"
+              << ltm->tm_mday;
 
   boost::filesystem::create_directories(path_stream.str());
-
 
   for (it = unit_affiliations.begin(); it != unit_affiliations.end(); ++it) {
     talkgroup_totals[it->second]++;
   }
 
-  sprintf(unit_filename, "%s/%ld-unit_check.json", path_stream.str().c_str(), starttime);
+  sprintf(unit_filename, "%s/%ld-unit_check.json", path_stream.str().c_str(),
+          starttime);
 
   ofstream myfile(unit_filename);
 
-  if (myfile.is_open())
-  {
+  if (myfile.is_open()) {
     myfile << "{\n";
     myfile << "\"talkgroups\": {\n";
 
@@ -986,15 +1100,17 @@ void unit_check() {
       myfile << "\"" << it->first << "\": " << it->second;
     }
     myfile << "\n}\n}\n";
-    sprintf(shell_command, "./unit_check.sh %s > /dev/null 2>&1 &", unit_filename);
+    sprintf(shell_command, "./unit_check.sh %s > /dev/null 2>&1 &",
+            unit_filename);
     system(shell_command);
-    //int rc = system(shell_command);
+    // int rc = system(shell_command);
     myfile.close();
   }
 }
 
-void handle_message(std::vector<TrunkMessage>messages, System *sys) {
-  for (std::vector<TrunkMessage>::iterator it = messages.begin(); it != messages.end(); it++) {
+void handle_message(std::vector<TrunkMessage> messages, System *sys) {
+  for (std::vector<TrunkMessage>::iterator it = messages.begin();
+       it != messages.end(); it++) {
     TrunkMessage message = *it;
 
     switch (message.message_type) {
@@ -1031,10 +1147,11 @@ void handle_message(std::vector<TrunkMessage>messages, System *sys) {
   }
 }
 
-System* find_system(int sys_num) {
+System *find_system(int sys_num) {
   System *sys_match = NULL;
 
-  for (std::vector<System *>::iterator it = systems.begin(); it != systems.end(); ++it) {
+  for (std::vector<System *>::iterator it = systems.begin();
+       it != systems.end(); ++it) {
     System *sys = (System *)*it;
 
     if (sys->get_sys_num() == sys_num) {
@@ -1050,16 +1167,21 @@ System* find_system(int sys_num) {
 }
 
 void retune_system(System *system) {
-  bool source_found            = false;
-  Source *current_source       = system->get_source();
-  double  control_channel_freq = system->get_next_control_channel();
+  bool source_found = false;
+  Source *current_source = system->get_source();
+  double control_channel_freq = system->get_next_control_channel();
 
-  BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "] Retuning to Control Channel: " << FormatFreq(control_channel_freq);
+  BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name()
+                           << "] Retuning to Control Channel: "
+                           << FormatFreq(control_channel_freq);
 
   if ((current_source->get_min_hz() <= control_channel_freq) &&
       (current_source->get_max_hz() >= control_channel_freq)) {
     source_found = true;
-    BOOST_LOG_TRIVIAL(info) << "\t - System Source " << current_source->get_num() << " - Min Freq: " << FormatFreq(current_source->get_min_hz()) << " Max Freq: " << FormatFreq(current_source->get_max_hz());
+    BOOST_LOG_TRIVIAL(info)
+        << "\t - System Source " << current_source->get_num()
+        << " - Min Freq: " << FormatFreq(current_source->get_min_hz())
+        << " Max Freq: " << FormatFreq(current_source->get_max_hz());
     // The source can cover the System's control channel, break out of the
     // For Loop
     if (system->get_system_type() == "smartnet") {
@@ -1070,19 +1192,25 @@ void retune_system(System *system) {
       BOOST_LOG_TRIVIAL(error) << "\t - Unknown system type for Retune";
     }
   } else {
-    for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
+    for (vector<Source *>::iterator src_it = sources.begin();
+         src_it != sources.end(); src_it++) {
       Source *source = *src_it;
 
       if ((source->get_min_hz() <= control_channel_freq) &&
           (source->get_max_hz() >= control_channel_freq)) {
         source_found = true;
-        BOOST_LOG_TRIVIAL(info) << "\t - System Source " << source->get_num() << " - Min Freq: " << FormatFreq(source->get_min_hz()) << " Max Freq: " << FormatFreq(source->get_max_hz());
+        BOOST_LOG_TRIVIAL(info)
+            << "\t - System Source " << source->get_num()
+            << " - Min Freq: " << FormatFreq(source->get_min_hz())
+            << " Max Freq: " << FormatFreq(source->get_max_hz());
 
         if (system->get_system_type() == "smartnet") {
           system->set_source(source);
-          // We must lock the flow graph in order to disconnect and reconnect blocks
+          // We must lock the flow graph in order to disconnect and reconnect
+          // blocks
           tb->lock();
-          tb->disconnect(current_source->get_src_block(), 0, system->smartnet_trunking, 0);
+          tb->disconnect(current_source->get_src_block(), 0,
+                         system->smartnet_trunking, 0);
           tb->connect(source->get_src_block(), 0, system->smartnet_trunking, 0);
           tb->unlock();
           system->smartnet_trunking->set_center(source->get_center());
@@ -1090,9 +1218,11 @@ void retune_system(System *system) {
           system->smartnet_trunking->tune_freq(control_channel_freq);
         } else if (system->get_system_type() == "p25") {
           system->set_source(source);
-          // We must lock the flow graph in order to disconnect and reconnect blocks
+          // We must lock the flow graph in order to disconnect and reconnect
+          // blocks
           tb->lock();
-          tb->disconnect(current_source->get_src_block(), 0, system->p25_trunking, 0);
+          tb->disconnect(current_source->get_src_block(), 0,
+                         system->p25_trunking, 0);
           tb->connect(source->get_src_block(), 0, system->p25_trunking, 0);
           tb->unlock();
           system->p25_trunking->set_center(source->get_center());
@@ -1108,7 +1238,8 @@ void retune_system(System *system) {
     }
   }
   if (!source_found) {
-    BOOST_LOG_TRIVIAL(error) << "\t - Unable to retune System control channel, freq not covered by any source.";
+    BOOST_LOG_TRIVIAL(error) << "\t - Unable to retune System control channel, "
+                                "freq not covered by any source.";
   }
 }
 
@@ -1116,10 +1247,12 @@ void check_message_count(float timeDiff) {
   stats.send_config(sources, systems);
   stats.send_sys_rates(systems, timeDiff);
 
-  for (std::vector<System *>::iterator it = systems.begin(); it != systems.end(); ++it) {
+  for (std::vector<System *>::iterator it = systems.begin();
+       it != systems.end(); ++it) {
     System *sys = (System *)*it;
 
-    if ((sys->system_type != "conventional") && (sys->system_type != "conventionalP25")) {
+    if ((sys->system_type != "conventional") &&
+        (sys->system_type != "conventionalP25")) {
       float msgs_decoded_per_second = sys->message_count / timeDiff;
 
       if (msgs_decoded_per_second < 2) {
@@ -1130,22 +1263,28 @@ void check_message_count(float timeDiff) {
         if (sys->control_channel_count() > 1) {
           retune_system(sys);
         } else {
-          BOOST_LOG_TRIVIAL(error) << "[" << sys->get_short_name() << "]\tThere is only one control channel defined";
+          BOOST_LOG_TRIVIAL(error)
+              << "[" << sys->get_short_name()
+              << "]\tThere is only one control channel defined";
         }
 
         // if it loses track of the control channel, quit after a while
         if (config.control_retune_limit > 0) {
           sys->retune_attempts++;
           if (sys->retune_attempts > config.control_retune_limit) {
-            exit_flag=1;
+            exit_flag = 1;
           }
         }
       } else {
         sys->retune_attempts = 0;
       }
 
-      if (msgs_decoded_per_second < config.control_message_warn_rate || config.control_message_warn_rate == -1) {
-        BOOST_LOG_TRIVIAL(error) << "[" << sys->get_short_name() << "]\t Control Channel Message Decode Rate: " <<  msgs_decoded_per_second << "/sec, count:  " << sys->message_count;
+      if (msgs_decoded_per_second < config.control_message_warn_rate ||
+          config.control_message_warn_rate == -1) {
+        BOOST_LOG_TRIVIAL(error) << "[" << sys->get_short_name()
+                                 << "]\t Control Channel Message Decode Rate: "
+                                 << msgs_decoded_per_second
+                                 << "/sec, count:  " << sys->message_count;
       }
     }
     sys->message_count = 0;
@@ -1157,12 +1296,11 @@ void monitor_messages() {
   int sys_num;
   System *sys;
 
-  time_t lastStatusTime     = time(NULL);
-  time_t lastMsgCountTime   = time(NULL);
+  time_t lastStatusTime = time(NULL);
+  time_t lastMsgCountTime = time(NULL);
   time_t lastTalkgroupPurge = time(NULL);
-  time_t currentTime        = time(NULL);
+  time_t currentTime = time(NULL);
   std::vector<TrunkMessage> trunk_messages;
-
 
   while (1) {
 
@@ -1182,13 +1320,14 @@ void monitor_messages() {
 
     if (msg != 0) {
       sys_num = msg->arg1();
-      sys     = find_system(sys_num);
+      sys = find_system(sys_num);
 
       if (sys) {
         sys->message_count++;
 
         if (sys->get_system_type() == "smartnet") {
-          trunk_messages = smartnet_parser->parse_message(msg->to_string(), sys);
+          trunk_messages =
+              smartnet_parser->parse_message(msg->to_string(), sys);
           handle_message(trunk_messages, sys);
         }
 
@@ -1209,15 +1348,13 @@ void monitor_messages() {
     } else {
       currentTime = time(NULL);
 
-      if ((currentTime - lastTalkgroupPurge) >= 1.0)
-      {
+      if ((currentTime - lastTalkgroupPurge) >= 1.0) {
         stop_inactive_recorders();
         lastTalkgroupPurge = currentTime;
       }
-      boost::this_thread::sleep( boost::posix_time::milliseconds(10) );
-      //usleep(1000 * 10);
+      boost::this_thread::sleep(boost::posix_time::milliseconds(10));
+      // usleep(1000 * 10);
     }
-
 
     currentTime = time(NULL);
 
@@ -1239,21 +1376,24 @@ void monitor_messages() {
 
 bool monitor_system() {
   bool system_added = false;
-  Source *source    = NULL;
+  Source *source = NULL;
 
-  for (vector<System *>::iterator sys_it = systems.begin(); sys_it != systems.end(); sys_it++) {
-    System *system       = *sys_it;
-    //bool    source_found = false;
+  for (vector<System *>::iterator sys_it = systems.begin();
+       sys_it != systems.end(); sys_it++) {
+    System *system = *sys_it;
+    // bool    source_found = false;
 
-
-    if ((system->get_system_type() == "conventional") || (system->get_system_type() == "conventionalP25")) {
+    if ((system->get_system_type() == "conventional") ||
+        (system->get_system_type() == "conventionalP25")) {
       std::vector<double> channels = system->get_channels();
-      int talkgroup                = 1;
+      int talkgroup = 1;
 
-      for (vector<double>::iterator chan_it = channels.begin(); chan_it != channels.end(); chan_it++) {
+      for (vector<double>::iterator chan_it = channels.begin();
+           chan_it != channels.end(); chan_it++) {
         double channel = *chan_it;
 
-        for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
+        for (vector<Source *>::iterator src_it = sources.begin();
+             src_it != sources.end(); src_it++) {
           source = *src_it;
 
           if ((source->get_min_hz() <= channel) &&
@@ -1263,16 +1403,24 @@ bool monitor_system() {
             system_added = true;
 
             if (source->get_squelch_db() == 0) {
-              BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "]\tSquelch needs to be specified for the Source for Conventional Systems";
+              BOOST_LOG_TRIVIAL(error)
+                  << "[" << system->get_short_name()
+                  << "]\tSquelch needs to be specified for the Source for "
+                     "Conventional Systems";
               system_added = false;
             } else {
               system_added = true;
             }
 
-            BOOST_LOG_TRIVIAL(info) << "[" << system->get_short_name() << "]\tMonitoring Conventional Channel: " <<  FormatFreq(channel) << " Talkgroup: " << talkgroup;
-            Call_conventional *call = new Call_conventional(talkgroup, channel, system, config);
+            BOOST_LOG_TRIVIAL(info)
+                << "[" << system->get_short_name()
+                << "]\tMonitoring Conventional Channel: " << FormatFreq(channel)
+                << " Talkgroup: " << talkgroup;
+            Call_conventional *call =
+                new Call_conventional(talkgroup, channel, system, config);
             talkgroup++;
-            Talkgroup *talkgroup = system->find_talkgroup(call->get_talkgroup());
+            Talkgroup *talkgroup =
+                system->find_talkgroup(call->get_talkgroup());
 
             if (talkgroup) {
               call->set_talkgroup_tag(talkgroup->alpha_tag);
@@ -1289,7 +1437,8 @@ bool monitor_system() {
               stats.send_recorder((Recorder *)rec.get());
             } else { // has to be "conventionalP25"
               p25conventional_recorder_sptr rec;
-              rec = source->create_conventionalP25_recorder(tb, system->get_delaycreateoutput());
+              rec = source->create_conventionalP25_recorder(
+                  tb, system->get_delaycreateoutput());
               rec->start(call);
               call->set_recorder((Recorder *)rec.get());
               call->set_state(recording);
@@ -1305,9 +1454,12 @@ bool monitor_system() {
       }
     } else {
       double control_channel_freq = system->get_current_control_channel();
-      BOOST_LOG_TRIVIAL(info) << "[" << system->get_short_name() << "]\tStarted with Control Channel: " << FormatFreq(control_channel_freq);
+      BOOST_LOG_TRIVIAL(info) << "[" << system->get_short_name()
+                              << "]\tStarted with Control Channel: "
+                              << FormatFreq(control_channel_freq);
 
-      for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
+      for (vector<Source *>::iterator src_it = sources.begin();
+           src_it != sources.end(); src_it++) {
         source = *src_it;
 
         if ((source->get_min_hz() <= control_channel_freq) &&
@@ -1317,25 +1469,21 @@ bool monitor_system() {
           system->set_source(source);
 
           if (system->get_system_type() == "smartnet") {
-            // what you really need to do is go through all of the sources to find
-            // the one with the right frequencies
-            system->smartnet_trunking = make_smartnet_trunking(control_channel_freq,
-                                                               source->get_center(),
-                                                               source->get_rate(),
-                                                               msg_queue,
-                                                               system->get_sys_num());
-            tb->connect(source->get_src_block(), 0, system->smartnet_trunking, 0);
+            // what you really need to do is go through all of the sources to
+            // find the one with the right frequencies
+            system->smartnet_trunking = make_smartnet_trunking(
+                control_channel_freq, source->get_center(), source->get_rate(),
+                msg_queue, system->get_sys_num());
+            tb->connect(source->get_src_block(), 0, system->smartnet_trunking,
+                        0);
           }
 
           if (system->get_system_type() == "p25") {
-            // what you really need to do is go through all of the sources to find
-            // the one with the right frequencies
-            system->p25_trunking = make_p25_trunking(control_channel_freq,
-                                                     source->get_center(),
-                                                     source->get_rate(),
-                                                     msg_queue,
-                                                     source->get_qpsk_mod(),
-                                                     system->get_sys_num());
+            // what you really need to do is go through all of the sources to
+            // find the one with the right frequencies
+            system->p25_trunking = make_p25_trunking(
+                control_channel_freq, source->get_center(), source->get_rate(),
+                msg_queue, source->get_qpsk_mod(), system->get_sys_num());
             tb->connect(source->get_src_block(), 0, system->p25_trunking, 0);
           }
 
@@ -1348,70 +1496,65 @@ bool monitor_system() {
   return system_added;
 }
 
-template<class F>
-void add_logs(const F& fmt)
-{
-  boost::shared_ptr< sinks::synchronous_sink< sinks::basic_text_ostream_backend<char > > > sink =
-		boost::log::add_console_log(std::clog, boost::log::keywords::format = fmt);
+template <class F> void add_logs(const F &fmt) {
+  boost::shared_ptr<
+      sinks::synchronous_sink<sinks::basic_text_ostream_backend<char>>>
+      sink = boost::log::add_console_log(std::clog,
+                                         boost::log::keywords::format = fmt);
 
-		std::locale loc = std::locale("C");
+  std::locale loc = std::locale("C");
 
   sink->imbue(loc);
 }
 
-void socket_connected()
-{
+void socket_connected() {
   stats.send_config(sources, systems);
   stats.send_systems(systems);
   stats.send_calls_active(calls);
   std::vector<Recorder *> recorders;
 
-  for (vector<Source *>::iterator it = sources.begin(); it != sources.end(); it++) {
+  for (vector<Source *>::iterator it = sources.begin(); it != sources.end();
+       it++) {
     Source *source = *it;
 
     std::vector<Recorder *> sourceRecorders = source->get_recorders();
 
-    recorders.insert(recorders.end(), sourceRecorders.begin(), sourceRecorders.end());
+    recorders.insert(recorders.end(), sourceRecorders.begin(),
+                     sourceRecorders.end());
   }
 
   stats.send_recorders(recorders);
 }
 
-
-
-int main(int argc, char **argv)
-{
-  //BOOST_STATIC_ASSERT(true) __attribute__((unused));
+int main(int argc, char **argv) {
+  // BOOST_STATIC_ASSERT(true) __attribute__((unused));
   signal(SIGINT, exit_interupt);
-  logging::core::get()->set_filter
-  (
-    logging::trivial::severity >= logging::trivial::info
+  logging::core::get()->set_filter(
+      logging::trivial::severity >= logging::trivial::info
 
   );
 
   boost::log::add_common_attributes();
-  boost::log::core::get()->add_global_attribute("Scope",
-                                                boost::log::attributes::named_scope());
-  boost::log::core::get()->set_filter(
-    boost::log::trivial::severity >= boost::log::trivial::info
-    );
+  boost::log::core::get()->add_global_attribute(
+      "Scope", boost::log::attributes::named_scope());
+  boost::log::core::get()->set_filter(boost::log::trivial::severity >=
+                                      boost::log::trivial::info);
 
-  add_logs(
-    boost::log::expressions::format("[%1%] (%2%)   %3%")
-    % boost::log::expressions::
-    format_date_time<boost::posix_time::ptime>("TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
-    % boost::log::expressions::
-    attr<boost::log::trivial::severity_level>("Severity")
-    % boost::log::expressions::smessage
-    );
+  add_logs(boost::log::expressions::format("[%1%] (%2%)   %3%") %
+           boost::log::expressions::format_date_time<boost::posix_time::ptime>(
+               "TimeStamp", "%Y-%m-%d %H:%M:%S.%f") %
+           boost::log::expressions::attr<boost::log::trivial::severity_level>(
+               "Severity") %
+           boost::log::expressions::smessage);
 
-//boost::log::sinks->imbue(std::locale("C"));
-	//std::locale::global(std::locale("C"));
+  // boost::log::sinks->imbue(std::locale("C"));
+  // std::locale::global(std::locale("C"));
 
   boost::program_options::options_description desc("Options");
-  desc.add_options()
-    ("help,h", "Help screen")
-    ("config", boost::program_options::value<string>()->default_value("./config.json"), "Config File");
+  desc.add_options()("help,h", "Help screen")(
+      "config",
+      boost::program_options::value<string>()->default_value("./config.json"),
+      "Config File");
   boost::program_options::variables_map vm;
   boost::program_options::store(parse_command_line(argc, argv, desc), vm);
   boost::program_options::notify(vm);
@@ -1423,40 +1566,34 @@ int main(int argc, char **argv)
   }
   string config_file = vm["config"].as<string>();
 
-  if (vm.count("config"))
-  {
+  if (vm.count("config")) {
     BOOST_LOG_TRIVIAL(info) << "Using Config file: " << config_file << "\n";
   }
-
 
   tb = gr::make_top_block("Trunking");
   tb->start();
   tb->lock();
-  msg_queue       = gr::msg_queue::make(100);
+  msg_queue = gr::msg_queue::make(100);
   smartnet_parser = new SmartnetParser(); // this has to eventually be generic;
-  p25_parser      = new P25Parser();
-
+  p25_parser = new P25Parser();
 
   std::string uri = "ws://localhost:3005";
-
 
   load_config(config_file);
   stats.initialize(&config, &socket_connected);
   stats.open_stat();
 
   if (config.log_file) {
-    logging::add_file_log(
-      keywords::file_name = "logs/%m-%d-%Y_%H%M_%2N.log",
-      keywords::format = "[%TimeStamp%]: %Message%",
-      keywords::rotation_size = 10 * 1024 * 1024,
-      keywords::time_based_rotation = sinks::file::rotation_at_time_point(0, 0, 0),
-      keywords::auto_flush = true);
+    logging::add_file_log(keywords::file_name = "logs/%m-%d-%Y_%H%M_%2N.log",
+                          keywords::format = "[%TimeStamp%]: %Message%",
+                          keywords::rotation_size = 10 * 1024 * 1024,
+                          keywords::time_based_rotation =
+                              sinks::file::rotation_at_time_point(0, 0, 0),
+                          keywords::auto_flush = true);
   }
-
 
   if (monitor_system()) {
     tb->unlock();
-
 
     monitor_messages();
 
@@ -1467,7 +1604,8 @@ int main(int argc, char **argv)
     tb->stop();
     tb->wait();
   } else {
-    BOOST_LOG_TRIVIAL(error) << "Unable to setup a System to record, exiting..." <<  std::endl;
+    BOOST_LOG_TRIVIAL(error)
+        << "Unable to setup a System to record, exiting..." << std::endl;
   }
 
   return 1;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1456,7 +1456,7 @@ bool monitor_system() {
           }
         }
         if (channel_added) {
-          BOOST_LOG_TRIVIAL(info)
+          BOOST_LOG_TRIVIAL(error)
               << "[" << system->get_short_name()
               << "]\t Unable to find a source for this conventional channel! Channel not added: " << FormatFreq(channel)
               << " Talkgroup: " << tg_iterate_index;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1402,8 +1402,8 @@ bool monitor_system() {
               (source->get_max_hz() >= channel)) {
             // There's no control channel in conventional resources...
             // The source can cover the System's control channel
-            // system->set_source(source);
-            // system_added = true;
+            system->set_source(source);
+            system_added = true;
 
             channel_added = true;
             if (source->get_squelch_db() == 0) {

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1386,7 +1386,7 @@ bool monitor_system() {
     if ((system->get_system_type() == "conventional") ||
         (system->get_system_type() == "conventionalP25")) {
       std::vector<double> channels = system->get_channels();
-      int talkgroup = 1;
+      int tg_iterate_index = 1;
 
       for (vector<double>::iterator chan_it = channels.begin();
            chan_it != channels.end(); chan_it++) {
@@ -1420,7 +1420,7 @@ bool monitor_system() {
                 << " Talkgroup: " << talkgroup;
             Call_conventional *call =
                 new Call_conventional(talkgroup, channel, system, config);
-            talkgroup++;
+            tg_iterate_index++;
             Talkgroup *talkgroup =
                 system->find_talkgroup(call->get_talkgroup());
 

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1392,7 +1392,7 @@ bool monitor_system() {
            chan_it != channels.end(); chan_it++) {
         double channel = *chan_it;
         ++tg_iterate_index;
-        int channel_added = false;
+        bool channel_added = false;
 
         for (vector<Source *>::iterator src_it = sources.begin();
              src_it != sources.end(); src_it++) {


### PR DESCRIPTION
My apologies for the mess clang-format has made to the PR overall change view.

Last night I set up a test trunk-recorder configuration with a bunch of conventional resources which used more than 1 SDR source. In my haste, I didn't give enough band edge spacing not just for roll off (keeping my sample rate and subsequent bandwidth tight is a personal preference), but also `rate/decim` (which ought to be documented, but I digress).

Cue my surprise when I get informed there seems to be weird off-by-one-or-more channel name/conventional TG# to frequency issue.

This is because of the way `main.cc` `monitor_system()` iterates through channels to be added in a conventional system. In particular, it only iterates talkgroups when a source has been found. If a source isn't found, then the system works the next channel to be added without incrementing talkgroup number.

This means if you have a channel(s) that doesn't have a source, your `frequency` array no longer lines up with your expectations like in your `alphatags` array (which by extension also applies to anywhere you're uploading as well).

Some additional infuriating bits:
1. reusing the `talkgroup` variable, not just for this incrementing integer, but also a Talkgroup object pointer.
2. having references to a CC when this is conventional (this is fine, I get that this is code reuse from the trunking portion of the setup)

These changes remove and clean up things that don't get used, and renames the for loop `talkgroup` increment variable to `tg_interate_index`. These also fix the primary issue by incrementing the talkgroup index whether or not a source has been found, as well as adding a `channel_added` variable with testing to provide user error warning on a channel that can't be recorded.

The reason this is an error and not a fatal is because there are trunk-recorder installations that don't completely cover all channels of a trunk(s), and run on best-possible recording ("Not Recording: no source covering Freq"). I figure systems that record conventional channels and wish to operate best-possible recording should receive similar warning (which is provided at startup).

Another problem: if a source squelch isn't set, then the program just segfaults. This should be made into an issue, and work on graceful exit. (The issue could also probably get rolled into the general issue of "make squelch and other configuration knobs system/channel-specific and not source-specific).

I'm groggy from being woken and earlier than typical, to report the testing environment, but it's the same host from my recent previous PRs, only changes made are to configuration files and the program. This PR is confirmed working with both:
- properly configured sources that have ample band edges and cover all channels
- and with improperly configured sources introducing uncoverable channels - error warning is properly provided.

Please let me know if there are any questions I can answer.