### PR TITLE
Type II encryption and emergency group call handling

### DIFF
--- a/trunk-recorder/systems/smartnet_parser.cc
+++ b/trunk-recorder/systems/smartnet_parser.cc
@@ -238,8 +238,15 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
       message.message_type = UPDATE;
       message.freq = getfreq(stack[3].cmd, system);
       message.talkgroup = stack[3].full_address;
-      // message.encrypted    = false;
-      // message.emergency    = false;
+      if (stack[3].status >= 8) {
+        message.encrypted = true;
+        if ((stack[3].status == 10) || (stack[3].status == 12) || (stack[3].status == 13)) {
+          message.emergency = true;
+        }
+      }
+      if ((stack[3].status == 2) || (stack[3].status == 4) || (stack[3].status == 5)) {
+        message.emergency = true;
+      }
       messages.push_back(message);
       return messages;
     } else {
@@ -338,8 +345,15 @@ std::vector<TrunkMessage> SmartnetParser::parse_message(std::string s,
         message.message_type = GRANT;
         message.freq = getfreq(stack[2].cmd, system);
         message.talkgroup = stack[2].full_address;
-        // message.encrypted    = false;
-        // message.emergency    = false;
+        if (stack[3].status >= 8) {
+          message.encrypted = true;
+          if ((stack[3].status == 10) || (stack[3].status == 12) || (stack[3].status == 13)) {
+            message.emergency = true;
+          }
+        }
+        if ((stack[3].status == 2) || (stack[3].status == 4) || (stack[3].status == 5)) {
+          message.emergency = true;
+        }
         message.source = stack[3].full_address;
         messages.push_back(message);
         return messages;


### PR DESCRIPTION
Not much to report here. This PR adds parsing of the status nibble for encrypted and emergency signaling.

Good thing here means if the talkgroup grant/continue is coming up as encrypted, `main.cc` doesn't bother recording it.

One thing to particularly note is we're still using `full_address` for the talkgroup. I'm not willing to switch that to just `talkgroup` right now, because that will be a breaking change and needs to have some discussion in an issue for coordination before making and merging that change.