### PR TITLE
Enforce MODE flag for Encrypted in `talksgroups.csv`.

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -620,7 +620,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
     call->set_talkgroup_tag("-");
   }
 
-  if (call->get_encrypted() == true) {
+  if (call->get_encrypted() == true || talkgroup->mode == 'E') {
     if (sys->get_hideEncrypted() == false) {
       BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\tTG: " << call->get_talkgroup_display() << "\tFreq: " << FormatFreq(call->get_freq()) << "\t\u001b[31mNot Recording: ENCRYPTED\u001b[0m ";
     }


### PR DESCRIPTION
Fixes #343 by enforcing the `MODE` flag in the `Talkgroups.csv` file. If you set the `MODE` flag to `E` it will _always_ ignore that talk-group as encrypted.

Keep in mind that `Talkgroup::Talkgroup` mode is a single char, as such you can only set to `E` and not `DE`. The only other place this is checked is for `A` as in analog, so it shouldn't break anything else. Also fine with me as encrypted also implies that it must be digital.