### PR TITLE
Plugin system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ list(APPEND trunk_recorder_sources
   trunk-recorder/talkgroups.cc
   trunk-recorder/unit_tag.cc
   trunk-recorder/unit_tags.cc
+  trunk-recorder/plugins/plugin-common.cc
+  trunk-recorder/plugins/plugin-manager.cc
   lib/gr_blocks/freq_xlating_fft_filter.cc
   lib/lfsr/lfsr.cxx
   lib/gr_blocks/decoders/fsync_decode.cc
@@ -223,6 +225,7 @@ list(APPEND trunk_recorder_sources
   lib/gr_blocks/decoders/signal_decoder_sink_impl.cc
   lib/gr_blocks/decoders/tps_decoder_sink_impl.cc
   lib/gr_blocks/decoder_wrapper_impl.cc
+  lib/gr_blocks/plugin_wrapper_impl.cc
   lib/gr_blocks/selector_impl.cc
   )
 

--- a/PLUGIN-SYSTEM.md
+++ b/PLUGIN-SYSTEM.md
@@ -1,0 +1,52 @@
+Plugin System
+=============
+
+The plugin system is designed to allow third parties to integrate their own features without changing the core code of trunk-recorder, and allow for features to be updated independently of the trunk-recorder code base. The current methods supported by the plugin system is loosely based on the Status uploader.
+
+*Unless otherwise noted, all fuctions need to return an int result (0 for successful, -1 for failure)*
+
+Plugins need to implement the following methods:
+* `<name>_plugin_new`
+  * Returns a new pointer to a plugin_t instance, along with the used callback method references.
+
+* `init(plugin_t * const plugin)`
+  * The plugin_t instance needs to have a reference to an init(plugin_t) call.
+  * The init(plugin_t) method gets called after the parse_config method.
+
+Plugins can *optionally* implement the following methods, based on usage, or set to NULL:
+* `parse_config(plugin_t * const plugin, boost::property_tree::ptree::value_type &cfg)`
+  * Called before init(plugin_t), and passed the Configuration information in the settings file for that plugin.
+  
+* `start(plugin_t * const plugin)`
+  * Called after trunk-recorder has been setup and all configuraiton is loaded.
+
+* `stop(plugin_t * const plugin)`
+  * Called after trunk-recorder has started shutting down, but the top-block is still running.
+
+* `poll_one(plugin_t * const plugin)`
+  * Called during each pass thru the main loop of trunk-recorder.
+
+* `call_start(plugin_t * const plugin, Call *call)`
+  * Called when a new call is starting.
+
+* `call_end(plugin_t * const plugin, Call *call)`
+  * Called when a call has ended.
+
+* `setup_recorder(plugin_t * const plugin, Recorder *recorder)`
+  * Called when a new recorder has been created.
+
+* `setup_system(plugin_t * const plugin, System * system)`
+  * Called when a new system has been created.
+
+* `setup_systems(plugin_t * const plugin, std::vector<System *> systems)`
+  * Called during startup when the initial systems have been created.
+
+* `**`setup_sources(plugin_t * const plugin, std::vector<Source *> sources)`
+  * Called during startup when the initial sources have been created.
+    
+* `signal(plugin_t * const plugin, long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder)`
+  * Called when a decoded signal (i.e. MDC-1200) has been detected.
+
+* `audio_stream(plugin_t * const plugin, Recorder *recorder, float *samples, int sampleCount)`
+  * Called when a set of audio samples that would be written out to the wav file writer is available.
+  * Useful to implement live audio streaming.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ Here are the different arguments:
  - **debugRecorder** - Will attach a debug recorder to each Source. The debug recorder will allow you to examine the channel of a call be recorded. There is a single Recorder per Source. It will monitor a recording and when it is done, it will monitor the next recording started. The information is sent over a network connection and can be viewed using the `udp-debug.grc` graph in GnuRadio Companion. The setting is either *true* or *false* and the default is *false*.
  - **debugRecorderPort** - The network port that the Debug Recorders will start on. For each Source an additional Debug Recorder will be added and the port used will be one higher than the last one. For example the ports for a system with 3 Sources would be: 1234, 12345, 1236. The default value is *1234*.
  - **debugRecorderAddress** - The network address of the computer that will be monitoring the Debug Recorders. UDP packets will be sent from Trunk Recorder to this computer. The default is *"127.0.0.1"* which is the address used for monitoring on the same computer as Trunk Recorder.
-
+ - **plugins** - an array of JSON objects that define the different plugins to use. Refer to the [Plugin System](PLUGIN-SYSTEM.md) documentation for more details. The following options are used to configure each Plugin:
+   - **library** - the name of the library that contains the plugin. This can be left blank if the plugin is in the main trunk-recorder codebase.
+   - **name** - the name of the plugin. This name is used to find the `<name>_plugin_new` method that creates a new instance of the plugin.
+   - *Additional elements can be added, they will be passed into the `parse_config` method of the plugin.*
 
 **talkgroupsFile**
 

--- a/lib/gr_blocks/plugin_wrapper.h
+++ b/lib/gr_blocks/plugin_wrapper.h
@@ -1,0 +1,54 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GR_PLUGIN_WRAPPER_H
+#define INCLUDED_GR_PLUGIN_WRAPPER_H
+
+#include <boost/log/trivial.hpp>
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+#include <functional>
+
+namespace gr {
+    namespace blocks {
+
+        typedef std::function<void(float *samples, int sampleCount)> plugin_callback;
+
+        /*!
+         * \brief Wrapps the plugin functions into a single block.
+         * \ingroup audio_blk
+         *
+         * \details
+         * Values must be floats within [-1;1].
+         * Check gr_make_plugin_wrapper() for extra info.
+         */
+        class BLOCKS_API plugin_wrapper : virtual public sync_block
+        {
+        public:
+            // gr::blocks::plugin_wrapper::sptr
+            typedef boost::shared_ptr<plugin_wrapper> sptr;
+        };
+
+    } /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_PLUGIN_WRAPPER_H */

--- a/lib/gr_blocks/plugin_wrapper_impl.cc
+++ b/lib/gr_blocks/plugin_wrapper_impl.cc
@@ -1,0 +1,76 @@
+/* -*- c++ -*- */
+
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif // ifdef HAVE_CONFIG_H
+
+#include "plugin_wrapper.h"
+#include "plugin_wrapper_impl.h"
+#include <gnuradio/io_signature.h>
+#include <stdexcept>
+#include <climits>
+#include <cstring>
+#include <cmath>
+#include <fcntl.h>
+#include <gnuradio/thread/thread.h>
+#include <boost/math/special_functions/round.hpp>
+#include <stdio.h>
+
+namespace gr {
+    namespace blocks {
+
+        plugin_wrapper_impl::sptr
+            plugin_wrapper_impl::make(plugin_callback callback)
+        {
+            return gnuradio::get_initial_sptr
+            (new plugin_wrapper_impl(callback));
+        }
+
+        plugin_wrapper_impl::plugin_wrapper_impl(plugin_callback callback)
+            : sync_block("plugin_wrapper_impl",
+                io_signature::make(1, 1, sizeof(float)),
+                io_signature::make(0, 0, 0)),
+            d_callback(callback){}
+
+        int plugin_wrapper_impl::work(int noutput_items, gr_vector_const_void_star& input_items, gr_vector_void_star& output_items) {
+
+            gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this
+
+            return dowork(noutput_items, input_items, output_items);
+        }
+
+        int plugin_wrapper_impl::dowork(int noutput_items, gr_vector_const_void_star& input_items, gr_vector_void_star& output_items) {
+
+            if(d_callback != NULL) {
+                d_callback((float *)input_items[0], noutput_items);
+            }
+            else {
+                BOOST_LOG_TRIVIAL(warning) << "plugin_wrapper_impl dropped, no callback setup!";
+            }
+
+            return noutput_items;
+        }
+
+    } /* namespace blocks */
+} /* namespace gr */

--- a/lib/gr_blocks/plugin_wrapper_impl.h
+++ b/lib/gr_blocks/plugin_wrapper_impl.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GR_PLUGIN_WRAPPER_IMPL_H
+#define INCLUDED_GR_PLUGIN_WRAPPER_IMPL_H
+
+#include "plugin_wrapper.h"
+#include <boost/log/trivial.hpp>
+
+namespace gr {
+	namespace blocks {
+
+		class plugin_wrapper_impl : public plugin_wrapper
+		{
+		private:
+			plugin_callback d_callback;
+
+        protected:
+
+			boost::mutex d_mutex;
+			virtual int dowork(int noutput_items, gr_vector_const_void_star& input_items, gr_vector_void_star& output_items);
+
+		public:
+
+			typedef boost::shared_ptr <plugin_wrapper_impl> sptr;
+
+			static sptr make(plugin_callback callback);
+
+			plugin_wrapper_impl(plugin_callback callback);
+			
+            virtual int work(int noutput_items,
+				gr_vector_const_void_star& input_items,
+				gr_vector_void_star& output_items);
+		};
+
+	} /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_PLUGIN_WRAPPER_IMPL_H */

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -61,6 +61,8 @@
 #include <gnuradio/top_block.h>
 #include <gnuradio/uhd/usrp_source.h>
 
+#include "plugins/plugin-manager.h"
+
 using namespace std;
 namespace logging = boost::log;
 namespace keywords = boost::log::keywords;
@@ -546,6 +548,9 @@ bool load_config(string config_file) {
     std::string log_level = pt.get<std::string>("logLevel", "info");
     BOOST_LOG_TRIVIAL(info) << "Log Level: " << log_level;
     set_logging_level(log_level);
+
+    BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\nPLUGINS\n-------------------------------------\n";
+    initialize_plugins(pt);
   } catch (std::exception const &e) {
     BOOST_LOG_TRIVIAL(error) << "Failed parsing Config: " << e.what();
     return false;
@@ -560,6 +565,7 @@ bool load_config(string config_file) {
     }
     BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\n";
   }
+
   return true;
 }
 
@@ -592,6 +598,7 @@ bool replace(std::string &str, const std::string &from, const std::string &to) {
 }
 
 void process_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder) {
+  plugman_signal(unitId, signaling_type, sig_type, call, system, recorder);
   stats.send_signal(unitId, signaling_type, sig_type, call, system, recorder);
 }
 
@@ -662,6 +669,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
         recorder->start(call);
         call->set_recorder(recorder);
         call->set_state(recording);
+        plugman_setup_recorder(recorder);
         stats.send_recorder(recorder);
         recorder_found = true;
       } else {
@@ -676,6 +684,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
         debug_recorder->start(call);
         call->set_debug_recorder(debug_recorder);
         call->set_debug_recording(true);
+        plugman_setup_recorder(debug_recorder);
         stats.send_recorder(debug_recorder);
         recorder_found = true;
       } else {
@@ -688,6 +697,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
         sigmf_recorder->start(call);
         call->set_sigmf_recorder(sigmf_recorder);
         call->set_sigmf_recording(true);
+        plugman_setup_recorder(sigmf_recorder);
         stats.send_recorder(sigmf_recorder);
         recorder_found = true;
       } else {
@@ -696,6 +706,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
 
       if (recorder_found) {
         // recording successfully started.
+        plugman_call_start(call);
         stats.send_call_start(call);
         return true;
       }
@@ -747,6 +758,7 @@ void stop_inactive_recorders() {
           stats.send_call_end(call);
           call->restart_call();
           if (recorder != NULL) {
+            plugman_setup_recorder(recorder);
             stats.send_recorder(recorder);
           }
         }
@@ -765,8 +777,10 @@ void stop_inactive_recorders() {
         }
         Recorder *recorder = call->get_recorder();
         call->end_call();
+        plugman_call_end(call);
         stats.send_call_end(call);
         if (recorder != NULL) {
+          plugman_setup_recorder(recorder);
           stats.send_recorder(recorder);
         }
         it = calls.erase(it);
@@ -851,6 +865,7 @@ bool retune_recorder(TrunkMessage message, Call *call) {
 
 void current_system_status(TrunkMessage message, System *sys) {
   if (sys->update_status(message)) {
+    plugman_setup_system(sys);
     stats.send_system(sys);
   }
 }
@@ -1163,6 +1178,8 @@ void monitor_messages() {
       stats.poll_one();
     }
 
+    plugman_poll_one();
+
     // BOOST_LOG_TRIVIAL(info) << "Messages waiting: "  << msg_queue->count();
     msg = msg_queue->delete_head_nowait();
 
@@ -1267,6 +1284,7 @@ bool monitor_system() {
               call->set_state(recording);
               system->add_conventional_recorder(rec);
               calls.push_back(call);
+              plugman_setup_recorder((Recorder *)rec.get());
               stats.send_recorder((Recorder *)rec.get());
             } else { // has to be "conventional P25"
               // Because of dynamic mod assignment we can not start the recorder until the graph has been unlocked.
@@ -1415,6 +1433,7 @@ int main(int argc, char **argv) {
 
   stats.initialize(&config, &socket_connected);
   stats.open_stat();
+  start_plugins(sources, systems);
 
   if (config.log_file) {
     logging::add_file_log(
@@ -1434,9 +1453,12 @@ int main(int argc, char **argv) {
     // ------------------------------------------------------------------
     // -- stop flow graph execution
     // ------------------------------------------------------------------
-    BOOST_LOG_TRIVIAL(info) << "stopping flow graph";
+    BOOST_LOG_TRIVIAL(info) << "stopping flow graph" << std::endl;
     tb->stop();
     tb->wait();
+
+    BOOST_LOG_TRIVIAL(info) << "stopping plugins" << std::endl;
+    stop_plugins();
   } else {
     BOOST_LOG_TRIVIAL(error) << "Unable to setup a System to record, exiting..." << std::endl;
   }

--- a/trunk-recorder/plugins/plugin-common.cc
+++ b/trunk-recorder/plugins/plugin-common.cc
@@ -1,0 +1,213 @@
+#include "plugin-common.h"
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+
+#if defined(_WIN32)
+    #include <windows.h>
+#else
+    #include <dlfcn.h>
+    #include <sys/types.h>
+#endif
+
+using namespace std;
+
+typedef plugin_t * (*plugin_new_func_t)(void);
+
+plugin_t *plugin_new(const char * const plugin_file, char const * const plugin_name) {
+    assert(plugin_name != NULL);
+    char *fname = NULL;
+    assert(asprintf(&fname, "%s_plugin_new", plugin_name) > 0);
+    plugin_new_func_t fptr = NULL;
+
+#if defined(_WIN32)
+    HINSTANCE hplugin = LoadLibrary(plugin_file);
+    assert(hplugin != NULL);
+    fptr = (plugin_new_func_t)GetProcAddress(hplugin, fname);
+#else
+    void *dlhandle = dlopen(plugin_file, RTLD_NOW);
+    assert(dlhandle != NULL);
+    fptr = (plugin_new_func_t)dlsym(dlhandle, fname);
+#endif
+
+    free(fname);
+    if(fptr == NULL) {
+        return NULL;
+    }
+
+    plugin_t *plugin = (*fptr)();
+    assert(plugin->init != NULL);
+    return plugin;
+}
+
+int plugin_init(plugin_t * const plugin) {
+    assert(plugin != NULL);
+    plugin_state_t new_state = PLUGIN_FAILED;
+    errno = 0;
+    int ret = plugin->init(plugin);
+    if(ret < 0) {
+        ret = -1;
+    } else {
+        new_state = PLUGIN_INITIALIZED;
+        ret = 0;
+    }
+    plugin->state = new_state;
+    return ret;
+}
+
+int plugin_parse_config(plugin_t * const plugin, boost::property_tree::ptree::value_type &cfg) {
+    assert(plugin != NULL);
+    if(plugin->parse_config != NULL) {
+        return plugin->parse_config(plugin, cfg);
+    } else {
+        return 0;
+    }
+}
+
+int plugin_start(plugin_t * const plugin) {
+    assert(plugin != NULL);
+    assert(plugin->dev_data != NULL);
+    int err = 0;
+    errno = 0;
+    if(plugin->state == PLUGIN_INITIALIZED && plugin->start != NULL) {
+        err = plugin->start(plugin);
+        if(err != 0) {
+            plugin->state = PLUGIN_FAILED;
+            return -1;
+        }
+    }
+    plugin->state = PLUGIN_RUNNING;
+    return 0;
+}
+
+int plugin_stop(plugin_t * const plugin) {
+    assert(plugin != NULL);
+    assert(plugin->dev_data != NULL);
+    int err = 0;
+    errno = 0;
+    if(plugin->state == PLUGIN_RUNNING && plugin->stop != NULL) {
+        err = plugin->stop(plugin);
+        if(err != 0) {
+            plugin->state = PLUGIN_FAILED;
+            return -1;
+        }
+    }
+    plugin->state = PLUGIN_STOPPED;
+    return 0;
+}
+
+int plugin_poll_one(plugin_t * const plugin) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->poll_one != NULL) {
+        err = plugin->poll_one(plugin);
+    }
+
+    return err;
+}
+
+int plugin_signal(plugin_t * const plugin, long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->signal != NULL) {
+        err = plugin->signal(plugin, unitId, signaling_type, sig_type, call, system, recorder);
+    }
+
+    return err;
+}
+
+int plugin_audio_stream(plugin_t * const plugin, Recorder* recorder, float *samples, int sampleCount) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->audio_stream != NULL) {
+        err = plugin->audio_stream(plugin, recorder, samples, sampleCount);
+    }
+    return err;
+}
+
+int plugin_call_start(plugin_t * const plugin, Call *call) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->call_start != NULL) {
+        err = plugin->call_start(plugin, call);
+    }
+
+    return err;
+}
+
+int plugin_call_end(plugin_t * const plugin, Call *call) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->call_end != NULL) {
+        err = plugin->call_end(plugin, call);
+    }
+
+    return err;
+}
+
+int plugin_setup_recorder(plugin_t * const plugin, Recorder *recorder) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->setup_recorder != NULL) {
+        err = plugin->setup_recorder(plugin, recorder);
+    }
+
+    return err;
+}
+
+int plugin_setup_system(plugin_t * const plugin, System * system) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->setup_system != NULL) {
+        err = plugin->setup_system(plugin, system);
+    }
+
+    return err;
+}
+
+int plugin_setup_systems(plugin_t * const plugin, std::vector<System *> systems) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->setup_systems != NULL) {
+        err = plugin->setup_systems(plugin, systems);
+    }
+
+    return err;
+}
+
+int plugin_setup_sources(plugin_t * const plugin, std::vector<Source *> sources) {
+    assert(plugin != NULL);
+
+    int err = 0;
+    errno = 0;
+
+    if(plugin->state == PLUGIN_RUNNING && plugin->setup_sources != NULL) {
+        err = plugin->setup_sources(plugin, sources);
+    }
+
+    return err;
+}

--- a/trunk-recorder/plugins/plugin-common.h
+++ b/trunk-recorder/plugins/plugin-common.h
@@ -1,0 +1,55 @@
+#ifndef PLUGIN_COMMON_H
+#define PLUGIN_COMMON_H
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <vector>
+#include <boost/property_tree/ptree.hpp>
+#include "../recorders/recorder.h"
+#include "../systems/system.h"
+#include "../source.h"
+
+typedef enum {
+    PLUGIN_UNKNOWN = 0,
+    PLUGIN_INITIALIZED,
+    PLUGIN_RUNNING,
+    PLUGIN_FAILED,
+    PLUGIN_STOPPED,
+    PLUGIN_DISABLED
+} plugin_state_t;
+#define PLUGIN_STATE_CNT 6
+
+struct plugin_t {
+    void *plugin_data; // This is internal data for use by the plugin.
+    plugin_state_t state;
+    int (*init)(plugin_t * const plugin);
+    int (*parse_config)(plugin_t * const plugin, boost::property_tree::ptree::value_type &cfg);
+    int (*start)(plugin_t * const plugin);
+    int (*stop)(plugin_t * const plugin);
+    int (*poll_one)(plugin_t * const plugin);
+    int (*signal)(plugin_t * const plugin, long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
+    int (*audio_stream)(plugin_t * const plugin, Recorder *recorder, float *samples, int sampleCount);
+    int (*call_start)(plugin_t * const plugin, Call *call);
+    int (*call_end)(plugin_t * const plugin, Call *call);
+    int (*setup_recorder)(plugin_t * const plugin, Recorder *recorder);
+    int (*setup_system)(plugin_t * const plugin, System * system);
+    int (*setup_systems)(plugin_t * const plugin, std::vector<System *> systems);
+    int (*setup_sources)(plugin_t * const plugin, std::vector<Source *> sources);
+};
+
+plugin_t *plugin_new(const char * const plugin_file, char const * const plugin_name);
+int plugin_init(plugin_t * const plugin);
+int plugin_parse_config(plugin_t * const plugin, boost::property_tree::ptree::value_type &cfg);
+int plugin_start(plugin_t * const plugin);
+int plugin_stop(plugin_t * const plugin);
+int plugin_poll_one(plugin_t * const plugin);
+int plugin_signal(plugin_t * const plugin, long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
+int plugin_audio_stream(plugin_t * const plugin, Recorder *recorder, float *samples, int sampleCount);
+int plugin_call_start(plugin_t * const plugin, Call *call);
+int plugin_call_end(plugin_t * const plugin, Call *call);
+int plugin_setup_recorder(plugin_t * const plugin, Recorder *recorder);
+int plugin_setup_system(plugin_t * const plugin, System * system);
+int plugin_setup_systems(plugin_t * const plugin, std::vector<System *> systems);
+int plugin_setup_sources(plugin_t * const plugin, std::vector<Source *> sources);
+
+#endif // PLUGIN_COMMON_H

--- a/trunk-recorder/plugins/plugin-manager.cc
+++ b/trunk-recorder/plugins/plugin-manager.cc
@@ -1,0 +1,113 @@
+#include "plugin-manager.h"
+#include "plugin-common.h"
+#include <stdlib.h>
+#include <vector>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/foreach.hpp>
+#include <boost/log/trivial.hpp>
+
+std::vector<plugin_t *> plugins;
+
+void setup_plugin(std::string plugin_lib, std::string plugin_name, boost::property_tree::ptree::value_type &node) {
+  plugin_t *plugin = plugin_new(plugin_lib == "" ? NULL : plugin_lib.c_str(), plugin_name.c_str());
+  if(plugin != NULL && plugin_parse_config(plugin, node) == 0) {
+    plugins.push_back(plugin);
+  }
+}
+
+void initialize_plugins(boost::property_tree::ptree &cfg) {
+    BOOST_FOREACH (boost::property_tree::ptree::value_type &node, cfg.get_child("plugins")) {
+        std::string plugin_lib = node.second.get<std::string>("library", "");
+        std::string plugin_name = node.second.get<std::string>("name", "");
+
+        setup_plugin(plugin_lib, plugin_name, node);
+    }
+
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_init(plugin);
+    }
+}
+
+void initialize_internal_plugin(std::string name, boost::property_tree::ptree::value_type &node) {
+  setup_plugin("", name, node);
+}
+
+void start_plugins(std::vector<Source *> sources, std::vector<System *> systems) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_start(plugin);
+      plugin_setup_sources(plugin, sources);
+      plugin_setup_systems(plugin, systems);
+    }
+}
+
+void stop_plugins() {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_stop(plugin);
+    }
+}
+
+void plugman_poll_one() {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_poll_one(plugin);
+    }
+}
+
+void plugman_audio_callback(Recorder *recorder, float *samples, int sampleCount) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_audio_stream(plugin, recorder, samples, sampleCount);
+    }
+}
+
+void plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_signal(plugin, unitId, signaling_type, sig_type, call, system, recorder);
+    }
+}
+void plugman_call_start(Call *call) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_call_start(plugin, call);
+    }
+}
+void plugman_call_end(Call *call) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_call_end(plugin, call);
+    }
+}
+
+void plugman_setup_recorder(Recorder *recorder) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_setup_recorder(plugin, recorder);
+    }
+}
+
+void plugman_setup_system(System * system) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_setup_system(plugin, system);
+    }
+}
+
+void plugman_setup_systems(std::vector<System *> systems) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_setup_systems(plugin, systems);
+    }
+}
+
+void plugman_setup_sources(std::vector<Source *> sources) {
+    for (std::vector<plugin_t *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      plugin_t *plugin = *it;
+      plugin_setup_sources(plugin, sources);
+    }
+}

--- a/trunk-recorder/plugins/plugin-manager.h
+++ b/trunk-recorder/plugins/plugin-manager.h
@@ -1,0 +1,26 @@
+#ifndef PLUGIN_MANAGER_H
+#define PLUGIN_MANAGER_H
+
+#include "../recorders/recorder.h"
+#include "../systems/system.h"
+#include "../source.h"
+#include <boost/property_tree/ptree.hpp>
+#include <vector>
+#include <stdlib.h>
+
+void initialize_plugins(boost::property_tree::ptree &cfg);
+void initialize_internal_plugin(std::string name, boost::property_tree::ptree::value_type &node); // For use by internal plugins, like the uploaders. Should be called before initialize_plugins
+void start_plugins(std::vector<Source *> sources, std::vector<System *> systems);
+void stop_plugins();
+
+void plugman_poll_one();
+void plugman_audio_callback(Recorder *recorder, float *samples, int sampleCount);
+void plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
+void plugman_call_start(Call *call);
+void plugman_call_end(Call *call);
+void plugman_setup_recorder(Recorder *recorder);
+void plugman_setup_system(System * system);
+void plugman_setup_systems(std::vector<System *> systems);
+void plugman_setup_sources(std::vector<Source *> sources);
+
+#endif // PLUGIN_MANAGER_H

--- a/trunk-recorder/recorder_globals.h
+++ b/trunk-recorder/recorder_globals.h
@@ -1,7 +1,7 @@
 #ifndef RECORDER_GLOBALS_H
 #define RECORDER_GLOBALS_H
 
-#include "../lib/gr_blocks/decoder_wrapper.h"
+#include <gr_blocks/decoder_wrapper.h>
 #include "call.h"
 #include "recorders/recorder.h"
 #include "systems/system.h"

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -1,9 +1,11 @@
 
 #include "analog_recorder.h"
-#include "../../lib/gr_blocks/decoder_wrapper_impl.h"
-#include "../../lib/gr_blocks/nonstop_wavfile_sink_impl.h"
+#include <gr_blocks/decoder_wrapper_impl.h>
+#include <gr_blocks/plugin_wrapper_impl.h>
+#include <gr_blocks/nonstop_wavfile_sink_impl.h>
 #include "../formatter.h"
 #include "../recorder_globals.h"
+#include "../plugins/plugin-manager.h"
 
 using namespace std;
 
@@ -160,6 +162,10 @@ analog_recorder::analog_recorder(Source *src)
 
   wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, wave_sample_rate, 16, true); //  Configurable
 
+  BOOST_LOG_TRIVIAL(info) << "Creating plugin sink..." << std::endl;
+  plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&analog_recorder::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
+  BOOST_LOG_TRIVIAL(info) << "Plugin sink created!" << std::endl;
+
   BOOST_LOG_TRIVIAL(info) << "Creating decoder sink..." << std::endl;
   decoder_sink = gr::blocks::decoder_wrapper_impl::make(wave_sample_rate, src->get_num(), std::bind(&analog_recorder::decoder_callback_handler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
   BOOST_LOG_TRIVIAL(info) << "Decoder sink created!" << std::endl;
@@ -183,6 +189,7 @@ analog_recorder::analog_recorder(Source *src)
   connect(deemph, 0, decim_audio, 0);
   connect(decim_audio, 0, high_f, 0);
   connect(decim_audio, 0, decoder_sink, 0);
+  connect(decim_audio, 0, plugin_sink, 0);
   connect(high_f, 0, squelch_two, 0);
   connect(squelch_two, 0, levels, 0);
   connect(levels, 0, wav_sink, 0);
@@ -283,6 +290,10 @@ void analog_recorder::decoder_callback_handler(long unitId, const char *signalin
   } else {
     process_signal(unitId, signaling_type, signal, NULL, NULL, this);
   }
+}
+
+void analog_recorder::plugin_callback_handler(float *samples, int sampleCount) {
+  plugman_audio_callback(this, samples, sampleCount);
 }
 
 void analog_recorder::setup_decoders_for_system(System *system) {

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -161,7 +161,7 @@ analog_recorder::analog_recorder(Source *src)
   wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, wave_sample_rate, 16, true); //  Configurable
 
   BOOST_LOG_TRIVIAL(info) << "Creating decoder sink..." << std::endl;
-  decoder_sink = gr::blocks::decoder_wrapper_impl::make(8000, src->get_num(), std::bind(&analog_recorder::decoder_callback_handler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  decoder_sink = gr::blocks::decoder_wrapper_impl::make(wave_sample_rate, src->get_num(), std::bind(&analog_recorder::decoder_callback_handler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
   BOOST_LOG_TRIVIAL(info) << "Decoder sink created!" << std::endl;
 
   // Try and get rid of the FSK wobble

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -43,10 +43,10 @@ class Source;
 class analog_recorder;
 
 #include "../config.h"
-#include "../lib/gr_blocks/decoder_wrapper.h"
 #include "../systems/system.h"
 #include "recorder.h"
 #include <gr_blocks/decoder_wrapper.h>
+#include <gr_blocks/plugin_wrapper.h>
 #include <gr_blocks/freq_xlating_fft_filter.h>
 #include <gr_blocks/nonstop_wavfile_sink.h>
 
@@ -84,6 +84,7 @@ public:
 
   void process_message_queues(void);
   void decoder_callback_handler(long unitId, const char *signaling_type, gr::blocks::SignalType signal);
+  void plugin_callback_handler(float *samples, int sampleCount);
 
 private:
   double center_freq, chan_freq;
@@ -137,6 +138,7 @@ private:
   gr::blocks::copy::sptr valve;
 
   gr::blocks::decoder_wrapper::sptr decoder_sink;
+  gr::blocks::plugin_wrapper::sptr plugin_sink;
 
   void setup_decoders_for_system(System *system);
 };

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -183,9 +183,9 @@ void p25_recorder::initialize(Source *src) {
 
   modulation_selector = gr::blocks::selector::make(sizeof(gr_complex), 0 , 0);
   qpsk_demod = make_p25_recorder_qpsk_demod();
-  qpsk_p25_decode = make_p25_recorder_decode(silence_frames );
+  qpsk_p25_decode = make_p25_recorder_decode( this, silence_frames );
   fsk4_demod = make_p25_recorder_fsk4_demod();
-  fsk4_p25_decode = make_p25_recorder_decode(silence_frames );
+  fsk4_p25_decode = make_p25_recorder_decode( this, silence_frames );
 
   // Squelch DB
   // on a trunked network where you know you will have good signal, a carrier

--- a/trunk-recorder/recorders/p25_recorder_decode.h
+++ b/trunk-recorder/recorders/p25_recorder_decode.h
@@ -24,26 +24,30 @@
 
 #include <gr_blocks/nonstop_wavfile_sink.h>
 #include <gr_blocks/nonstop_wavfile_sink_impl.h>
+#include <gr_blocks/plugin_wrapper.h>
+#include "recorder.h"
 
 class p25_recorder_decode;
 typedef boost::shared_ptr<p25_recorder_decode> p25_recorder_decode_sptr;
-p25_recorder_decode_sptr make_p25_recorder_decode(  int silence_frames);
+p25_recorder_decode_sptr make_p25_recorder_decode( Recorder* recorder, int silence_frames);
 
 class p25_recorder_decode : public gr::hier_block2 {
-  friend p25_recorder_decode_sptr make_p25_recorder_decode( int silence_frames);
+  friend p25_recorder_decode_sptr make_p25_recorder_decode( Recorder* recorder, int silence_frames);
 
 protected:
 
   virtual void initialize(  int silence_frames);
+  Recorder* _recorder;
   gr::op25_repeater::p25_frame_assembler::sptr op25_frame_assembler;
-    gr::msg_queue::sptr traffic_queue;
+  gr::msg_queue::sptr traffic_queue;
   gr::msg_queue::sptr rx_queue;
   gr::op25_repeater::fsk4_slicer_fb::sptr slicer;
-    gr::blocks::short_to_float::sptr converter;
-      gr::blocks::multiply_const_ff::sptr levels;
-   gr::blocks::nonstop_wavfile_sink::sptr wav_sink;
+  gr::blocks::short_to_float::sptr converter;
+  gr::blocks::multiply_const_ff::sptr levels;
+  gr::blocks::nonstop_wavfile_sink::sptr wav_sink;
+  gr::blocks::plugin_wrapper::sptr plugin_sink;
 public:
-  p25_recorder_decode();
+  p25_recorder_decode(Recorder* recorder);
   void set_tdma_slot(int slot);
   void set_xor_mask(const char *mask);
   void switch_tdma(bool phase2_tdma); 
@@ -55,5 +59,6 @@ public:
   bool delay_open;
   virtual ~p25_recorder_decode();
   double get_current_length();
+  void plugin_callback_handler(float *samples, int sampleCount);
 };
 #endif

--- a/trunk-recorder/uploaders/stat_socket.h
+++ b/trunk-recorder/uploaders/stat_socket.h
@@ -5,7 +5,7 @@
 #include <websocketpp/client.hpp>
 #include <websocketpp/config/asio_no_tls_client.hpp>
 
-#include "../../lib/gr_blocks/decoder_wrapper.h"
+#include <gr_blocks/decoder_wrapper.h>
 #include "../config.h"
 #include "../source.h"
 #include "../systems/system.h"


### PR DESCRIPTION
As more and more features are added, such as uploaders and decoders, there has been a lot of code specific for each one. In order to organize this a little better, I have added a plugin system. This has the added benefit of allowing people to write their own uploaders, or custom handlers, without bloating the core trunk-recorder code. Included in this change is a basic plugin system, along with documentation to support it. Once merged in, I plan on cleaning up the uploaders to move them into this system and clean up a lot of the cross references.

Side note, this plugin system was designed to also support things like live audio streaming, and allow the plugins to only hook into things that they actually use.