### PR TITLE
fix compile issue

### DIFF
--- a/lib/gr_blocks/selector_impl.cc
+++ b/lib/gr_blocks/selector_impl.cc
@@ -53,7 +53,7 @@ selector_impl::selector_impl(size_t itemsize,
       d_num_outputs(0)
 {
     message_port_register_in(pmt::mp("en"));
-    set_msg_handler(pmt::mp("en"), boost::bind(&selector_impl::handle_enable, this, _1));
+    set_msg_handler(pmt::mp("en"), boost::bind(&selector_impl::handle_enable, this, boost::placeholders::_1));
 
     // TODO: add message ports for input_index and output_index
 }


### PR DESCRIPTION
fixes this issue when compiling:

trunk-recorder/lib/gr_blocks/selector_impl.cc: In constructor ‘gr::blocks::selector_impl::selector_impl(size_t, unsigned int, unsigned int)’:
trunk-recorder/lib/gr_blocks/selector_impl.cc:56:85: error: ‘_1’ was not declared in this scope
   56 |     set_msg_handler(pmt::mp("en"), boost::bind(&selector_impl::handle_enable, this, _1));
      |                                                                                     ^~