### PR TITLE
Build Docker images on release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
     branches: master
     tags:
       - v*
+  release:
 
 jobs:
   buildx:


### PR DESCRIPTION
Fixes issue found in #410 where the `latest` tag wasn't ever being built. It was because the workflow wasn't being triggered by a release.

@robotastic after you merge this can you please release 3.3.1 to cause the `latest` tag to be built and published? Thanks!