### PR TITLE
add armv7 builds, switch to official buildx action and stop building nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: buildx
 
 on:
-  schedule:
-    - cron: '0 10 * * *' # everyday at 10am
   pull_request:
     branches: master
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,6 @@ jobs:
       # https://github.com/docker/setup-buildx-action
       - 
         name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
         uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker layers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,15 @@ jobs:
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             ${TAGS} --file ./Dockerfile .
-      -
+      # https://github.com/docker/setup-qemu-action
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/setup-buildx-action
+      - 
         name: Set up Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v3
+        uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         id: prepare
         run: |
           DOCKER_IMAGE=robotastic/trunk-recorder
-          DOCKER_PLATFORMS=linux/amd64,linux/arm64
+          DOCKER_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7
           VERSION=edge
 
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM robotastic/gnuradio:latest
+FROM robotastic/gnuradio:nightly
 
 WORKDIR /src
 


### PR DESCRIPTION
- Start building for `linux/arm/v7`
- Switch to official buildx action
- Stop building nightly

Cleaner version of #444. Related PR for GR (this doesn't depend on it): https://github.com/robotastic/docker-gnuradio/pull/6.