### PR TITLE
Unified Dockerfile that gets builds working on armv7 and optimizes deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,49 @@
-FROM robotastic/gnuradio:nightly
+FROM ubuntu:20.04 AS base
+
+# Install everything except cmake
+RUN apt-get update && \
+  apt-get -y upgrade &&\
+  export DEBIAN_FRONTEND=noninteractive && \
+  apt-get install -y \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    fdkaac \
+    git \
+    gnupg \
+    gnuradio \
+    gnuradio-dev \
+    gr-osmosdr \
+    libboost-all-dev \
+    libcurl4-openssl-dev \
+    libgmp-dev \
+    libhackrf-dev \
+    liborc-0.4-dev \
+    libpthread-stubs0-dev \
+    libssl-dev \
+    libuhd-dev \
+    libusb-dev \
+    pkg-config \
+    software-properties-common \
+    sox && \
+  rm -rf /var/lib/apt/lists/*
+
+# Need to install newer cmake than what's in Ubuntu repo to build armv7 due to this:
+# https://gitlab.kitware.com/cmake/cmake/-/issues/20568
+RUN curl https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
+    apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
 
 COPY . .
 
-RUN cmake . && make && cp recorder /recorder
+RUN cmake . && make -j`nproc` && cp recorder /recorder
 
 USER nobody
+
+# GNURadio requires a place to store some files, can only be set via $HOME env var.
+ENV HOME=/tmp
 
 CMD ["/recorder", "--config=/app/config.json"]


### PR DESCRIPTION
Fixes armv7 builds which were broken due to [this bug in CMake](https://gitlab.kitware.com/cmake/cmake/-/issues/20568) when building inside of QEMU like our GitHub Workflow does.

Also installs all deps in this file instead of docker-gnuradio as a stepping stone to work in #446.