### PR TITLE
allow specifying log file directory

### DIFF
--- a/trunk-recorder/config.h
+++ b/trunk-recorder/config.h
@@ -21,6 +21,7 @@ struct Config {
   std::string instance_id;
   std::string capture_dir;
   std::string debug_recorder_address;
+  std::string log_dir;
   bool debug_recorder;
   int debug_recorder_port;
   int call_timeout;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -536,6 +536,8 @@ bool load_config(string config_file) {
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;
     config.log_file = pt.get<bool>("logFile", false);
     BOOST_LOG_TRIVIAL(info) << "Log to File: " << config.log_file;
+    config.log_dir = pt.get<std::string>("logDir", "logs");
+    BOOST_LOG_TRIVIAL(info) << "Log Directory: " << config.log_dir;
     config.control_message_warn_rate = pt.get<int>("controlWarnRate", 10);
     BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
     config.control_retune_limit = pt.get<int>("controlRetuneLimit", 0);
@@ -1462,7 +1464,7 @@ int main(int argc, char **argv) {
 
   if (config.log_file) {
     logging::add_file_log(
-        keywords::file_name = "logs/%m-%d-%Y_%H%M_%2N.log",
+        keywords::file_name = config.log_dir + "/%m-%d-%Y_%H%M_%2N.log",
         keywords::format = "[%TimeStamp%] (%Severity%)   %Message%",
         keywords::rotation_size = 10 * 1024 * 1024,
         keywords::time_based_rotation = sinks::file::rotation_at_time_point(0, 0, 0),


### PR DESCRIPTION
This can be done with the config key "logDir". It does what you think for both relative and absolute paths. No trailing slash needed, but it won't hurt if you include one. Same behavior of a relative-path "logs" directory if none is specified.

Fixes #443, hopefully.

Tested by running it.

Tangent/newb question: Is there a dummy source/config.json available? I'm a newb and spent more time struggling to start up an RTL-SDR dongle than I did coding this up.