### PR TITLE
Add low pass filter to analog recorder audio flow

### DIFF
--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -135,7 +135,7 @@ analog_recorder::analog_recorder(Source *src)
   squelch_two = gr::analog::pwr_squelch_ff::make(-200, 0.01, 0, true);
 
   // k = quad_rate/(2*math.pi*max_dev) = 48k / (6.283185*5000) = 1.527
-  
+
   int d_max_dev = 5000;
   /* demodulator gain */
   quad_gain = system_channel_rate / (2.0 * M_PI * d_max_dev);
@@ -164,9 +164,14 @@ analog_recorder::analog_recorder(Source *src)
   decoder_sink = gr::blocks::decoder_wrapper_impl::make(wave_sample_rate, src->get_num(), std::bind(&analog_recorder::decoder_callback_handler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
   BOOST_LOG_TRIVIAL(info) << "Decoder sink created!" << std::endl;
 
-  // Try and get rid of the FSK wobble
+  // Analog audio band pass from 300 to 3000 Hz
+  // can't use gnuradio.filter.firdes.band_pass since we have different transition widths
+  // 300 Hz high pass (275-325 Hz): removes CTCSS/DCS and Type II 150 bps Low Speed Data (LSD), or "FSK wobble"
   high_f_taps = gr::filter::firdes::high_pass(1, wave_sample_rate, 300, 50, gr::filter::firdes::WIN_HANN); // Configurable
   high_f = gr::filter::fir_filter_fff::make(1, high_f_taps);
+  // 3000 Hz low pass (3000-3500 Hz)
+  low_f_taps = gr::filter::firdes::low_pass(1, wave_sample_rate, 3250, 500, gr::filter::firdes::WIN_HANN);
+  low_f = gr::filter::fir_filter_fff::make(1, low_f_taps);
 
   // using squelch
   connect(self(), 0, valve, 0);
@@ -183,7 +188,8 @@ analog_recorder::analog_recorder(Source *src)
   connect(deemph, 0, decim_audio, 0);
   connect(decim_audio, 0, high_f, 0);
   connect(decim_audio, 0, decoder_sink, 0);
-  connect(high_f, 0, squelch_two, 0);
+  connect(high_f, 0, low_f, 0);
+  connect(low_f, 0, squelch_two, 0);
   connect(squelch_two, 0, levels, 0);
   connect(levels, 0, wav_sink, 0);
 }

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -107,6 +107,7 @@ private:
   std::vector<float> audio_resampler_taps;
   std::vector<float> sym_taps;
   std::vector<float> high_f_taps;
+  std::vector<float> low_f_taps;
   std::vector<float> arb_taps;
   /* De-emph IIR filter taps */
   std::vector<double> d_fftaps; /*! Feed forward taps. */
@@ -128,6 +129,7 @@ private:
   gr::filter::pfb_arb_resampler_ccf::sptr arb_resampler;
   gr::filter::fir_filter_fff::sptr decim_audio;
   gr::filter::fir_filter_fff::sptr high_f;
+  gr::filter::fir_filter_fff::sptr low_f;
   gr::analog::pwr_squelch_cc::sptr squelch;
   gr::analog::pwr_squelch_ff::sptr squelch_two;
   gr::analog::quadrature_demod_cf::sptr demod;


### PR DESCRIPTION
Analog FM land mobile radio has an audio frequency response range of 300 to 3000 Hz [0]. In this change, we add a low pass filter to make our analog recorder consistent with that fact.

We characterize the new low pass filter with the "cutoff" (center) at 3250 Hz, and a transition band of 500 Hz. This produces a final audio signal with a pass band of 300 to 3000 Hz (including the already included `high_f` filter), a transition band of 3000 to 3500 Hz, and a stop band beyond that. We could use a band pass filter targeting 300 to 3000 Hz, but desire a more gradual rolloff for our low pass instead of an aggressive brick wall at both ends.

Tested working on top of `robotastic/master@b0e96e4` overnight.

Some before/afters below. Transmissions from systems that already sounded good at this site sound even better without the hiss and the harsh harmonics in alert tone 1:

![](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/fdnyems-1-1619342789.png) | ![](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/fdnyems-1-1619342788.png)
:-:|:-:
*fig. 0. FFT of [this audio](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/fdnyems-1-1619342789.m4a) on `robotastic/master@b0e96e4`.* | *fig. 1. FFT of [this audio](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/fdnyems-1-1619342788.m4a) with the proposed change.*

And an example of higher sample rate audio not helping at all. What's the use when it's all noise, coming from equipment and systems designed for audio below 4 kHz?

![](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/nypd-1-1619324653.png) | ![](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/nypd-1-1619324654.png)
:-:|:-:
*fig. 2. FFT of [this audio](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/nypd-1-1619324653.m4a), exhibiting some annoying noise, not as bad as the one we were originally investigating!* | *fig. 3. FFT of [this audio](https://gist.githubusercontent.com/leee/1807c39b3afd5f70a709b5711ba7be05/raw/bdb607cbfab68f2c8c6f418cea1ca34637031911/nypd-1-1619324654.m4a) simultaneously recorded [1]. We don't need any of that noise beyond 3-4 kHz!*

[0] - an artifact of copper telephony, this is well displayed in the specification and use of usable voice frequency band for radio remote control (e.g. tone remote signaling).
[1] - different test server, but at the same receive site, off of the same receive multicoupler, and identical SDR parameters.