### PR TITLE
Add maximum call duration to split long calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Here are the different arguments:
  - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile**. The options are *digital* or *analog*. The default is *digital*. This argument is global and not system-specific, and only affects Type II `smartnet` trunking systems which can have both analog and digital talkpaths whereas `p25` trunking systems don't have analog talkpaths.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
+ - **maxDuration** - If a call is being recorded and the duration exceeds this value in seconds, the call will stop recording and a new call will pick up where the previous on left off. The default is *0* or "no timeout".
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.
  - **frequencyFormat** - the display format for frequencies to display in the console and log file. The options are *exp*, *mhz* & *hz*. The default is *exp*.
  - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This file is used to configure how Trunk Recorder is setup. It defines the SDRs 
 }
 ```
 Here are the different arguments:
- - **ver** - the version of formatting for the config file. **This should be set to 2**. Trunk Recorder will not start without this set. 
+ - **ver** - the version of formatting for the config file. **This should be set to 2**. Trunk Recorder will not start without this set.
  - **sources** - an array of JSON objects that define the different SDRs available. The following options are used to configure each Source:
    - **center** - the center frequency in Hz to tune the SDR to
    - **rate** - the sampling rate to set the SDR to, in samples / second
@@ -112,7 +112,7 @@ Here are the different arguments:
    - **analogLevels** - the amount of amplification that will be applied to the analog audio. The value should be between 1-32. The default value is 8.
    - **digitalLevels** - the amount of amplification that will be applied to the digital audio. The value should be between 1-16. The default value is 1.
    - **modulation** - the type of modulation that the system uses. The options are *qpsk* & *fsk4*. It is possible to have a mix of sources using fsk4 and qpsk demodulation.
-   - **squelch** - Squelch in DB, this needs to be set for all convetional systems. The squelch setting is also used for analog talkgroups in a SmartNet system. I generally use -60 for my rtl-sdr. Defaults to 0, which is disabled. 
+   - **squelch** - Squelch in DB, this needs to be set for all convetional systems. The squelch setting is also used for analog talkgroups in a SmartNet system. I generally use -60 for my rtl-sdr. Defaults to 0, which is disabled.
    - **maxDev** - Allows you to set the maximum deviation for analog channels. The default is 4000. If you analog recordings sound good or if you have a completely digital system, then there is no need to tough this.
    - **channels** - *(For conventional systems)* an array of the channel frequencies, in Hz, used for the system. The channels get assigned a virtual talkgroup number based upon their position in the array. Squelch levels need to be specified for the Source(s) being used.
    - **alphatags** - *(Optional, For conventional systems)* an array of the alpha tags, these will be outputed to the logfiles *talkgroupDisplayFormat* is set to include tags. Alpha tags will be applied to the *channels* in the order the values appear in the array.
@@ -129,6 +129,7 @@ Here are the different arguments:
    - **audioArchive** - should the recorded audio files be kept after successfully uploading them. The options are *true* and *false* (without quotes). The default is *true*.
    - **callLog** - should a json file with the call details be kept after successful uploads. The options are *true* and *false* (without quotes). The default is *true*.
    - **minDuration** - the minimum call (transmission) duration in seconds (decimals allowed), calls below this number will have recordings deleted and will not be uploaded. The default is *0* (no minimum duration).
+   - **maxDuration** - If a call is being recorded and the duration exceeds this value in seconds, the call will stop recording and a new call will pick up where the previous on left off. The default is *0* or "no timeout".
    - **bandplan** - [SmartNet only] this is the SmartNet bandplan that will be used. The options are *800_standard*, *800_reband*, *800_splinter*, and *400_custom*. *800_standard* is the default.
    - **bandplanBase** - [SmartNet, 400_custom only] this is for the *400_custom* bandplan only. This is the base frequency, specified in Hz.
    - **bandplanHigh** - [SmartNet, 400_custom only] this is the highest channel in the system, specified in Hz.
@@ -144,7 +145,6 @@ Here are the different arguments:
  - **defaultMode** - Default mode to use when a talkgroups is not listed in the **talkgroupsFile**. The options are *digital* or *analog*. The default is *digital*. This argument is global and not system-specific, and only affects Type II `smartnet` trunking systems which can have both analog and digital talkpaths whereas `p25` trunking systems don't have analog talkpaths.
  - **captureDir** - the complete path to the directory where recordings should be saved.
  - **callTimeout** - a Call will stop recording and save if it has not received anything on the control channel, after this many seconds. The default is 3.
- - **maxDuration** - If a call is being recorded and the duration exceeds this value in seconds, the call will stop recording and a new call will pick up where the previous on left off. The default is *0* or "no timeout".
  - **logFile** - save the console output to a file. The options are *true* or *false*, without quotes. The default is *false*.
  - **frequencyFormat** - the display format for frequencies to display in the console and log file. The options are *exp*, *mhz* & *hz*. The default is *exp*.
  - **controlWarnRate** - Log the control channel decode rate when it falls bellow this threshold. The default is *10*. The value of *-1* will always log the decode rate.

--- a/trunk-recorder/config.h
+++ b/trunk-recorder/config.h
@@ -27,6 +27,7 @@ struct Config {
   int call_timeout;
   bool log_file;
   int control_message_warn_rate;
+  int max_duration;
   int control_retune_limit;
   bool broadcast_signals;
 };

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -542,6 +542,8 @@ bool load_config(string config_file) {
     BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
     config.control_retune_limit = pt.get<int>("controlRetuneLimit", 0);
     BOOST_LOG_TRIVIAL(info) << "Control channel retune limit: " << config.control_retune_limit;
+    config.max_duration = pt.get<int>("maxDuration", 0);
+    BOOST_LOG_TRIVIAL(info) << "Maximum Call Duration (seconds): " << config.max_duration;
 
     BOOST_LOG_TRIVIAL(info) << "Frequency format: " << frequencyFormat;
 
@@ -744,9 +746,9 @@ void stop_inactive_recorders() {
           call->reset_idle_count();
         }
 
-        // if no additional recording has happened in the past X periods, stop and open new file
-        if (call->get_idle_count() > 5) {
-          Recorder *recorder = call->get_recorder();
+        // if no additional recording has happened in the past X periods, or the call has gone on for longer than max_duration, stop and open new file
+        if (call->get_idle_count() > 5 || ( call->get_current_length() > config.max_duration && config.max_duration > 0 )) {
+          Recorder * recorder = call->get_recorder();
           call->end_call();
           stats.send_call_end(call);
           call->restart_call();
@@ -755,7 +757,7 @@ void stop_inactive_recorders() {
           }
         }
       } else if (!call->get_recorder()->is_active()) {
-              // P25 Conventional Recorders need a have the graph unlocked before they can start recording.  
+              // P25 Conventional Recorders need a have the graph unlocked before they can start recording.
               Recorder *recorder = call->get_recorder();
               recorder->start(call);
               call->set_state(recording);
@@ -1320,7 +1322,7 @@ bool monitor_system() {
               rec = source->create_digital_conventional_recorder(tb);
               call->set_recorder((Recorder *)rec.get());
               calls.push_back(call);
-              
+
             }
 
             // break out of the for loop
@@ -1411,7 +1413,7 @@ int main(int argc, char **argv) {
       logging::trivial::severity >= logging::trivial::info
 
   );
-  
+
   boost::log::register_simple_formatter_factory< boost::log::trivial::severity_level, char >("Severity");
 
   boost::log::add_common_attributes();

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -48,6 +48,14 @@ void System::set_min_duration(double duration) {
   this->min_call_duration = duration;
 }
 
+double System::get_max_duration() {
+  return this->max_call_duration;
+}
+
+void System::set_max_duration(double duration) {
+  this->max_call_duration = duration;
+}
+
 System::System(int sys_num) {
   this->sys_num = sys_num;
   sys_id = 0;

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -66,6 +66,7 @@ public:
   int max_dev;
   double filter_width;
   double min_call_duration;
+  double max_call_duration;
 
   bool qpsk_mod;
   double squelch_db;
@@ -99,6 +100,8 @@ public:
   void set_bcfy_system_id(int bcfy_system_id);
   double get_min_duration();
   void set_min_duration(double duration);
+  double get_max_duration();
+  void set_max_duration(double duration);
   bool get_audio_archive();
   void set_audio_archive(bool);
   bool get_record_unknown();


### PR DESCRIPTION
Resolves #197, resolves #357.

Co-authored-by: jarek <jarek@citizen.com>
Co-authored-by: jareklupinski <jareklupinski@users.noreply.github.com>
Co-authored-by: Eric Tendian <erictendian@gmail.com>

---

I'd like to reopen for consideration #357, which @EricTendian submitted on behalf of @jareklupinski. #357 directly resolves #197, although more work can be done surrounding the topic.

There are many cases where a conventional or trunked resource stays in use for extremely long periods of times, making the receipt of that one transmission delayed for the duration of that period.

#197 is an example of dispatch consoles being able to mark a trunked resource in emergency, reserving and holding voice talkpaths for it for the duration of the emergency.

Some conventional channels can experience lengthy recordings due to emergencies or high acuity incidents, and never gets a chance to meet `callTimeout` (default 3s). Some conventional systems can also be configured to have extremely long drop out delay, or stay keyed until released by console.

Ideally, calls would be terminated by transmission immediately instead of waiting for a timeout - so by carrier/power squelch, PL/DPL tone squelch, voice termination data, or control channel data. There is already some discussion on this underway in #451 which covers P25 TDU/TDULCs, and I think that issue could be generalized to also cover call termination from control channel data and conventional channels.

There's also another matter of audio files being shortened because squelched periods are not written to files, and therefore not real-time. If trunk-recorder changed its transmission strategy to individual transmissions this wouldn't be a problem, and could make transmission dedupe from multiple site recorders easier to handle, as touched on in #326.

---

I tried to merge #357 but there's been a lot of work since then. I did cherry pick and edit the pull request commit, but basically had to reorganize and rewrite it.

With all that said, this PR implements #197 - if the length of call audio exceeds a user-specified duration, it will end the call and start a new one where it left off. If no duration is specified it will default to 0 (the current behavior). To clear up the confusion from #197, the duration is measured by the length of active transmission/audio, not real-time.