### PR TITLE
Per-day call log plugin, log P25 priority/mode/duplex

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Thank you to everyone who has contributed!
 ## Overview
 Need help? Got something working? Share it!
 
-[Discord Server](Https://discord.gg/trunk-recorder) - and don't forget the [Wiki](https://github.com/robotastic/trunk-recorder/wiki)
+[Discord Server](https://discord.gg/trunk-recorder) - and don't forget the [Wiki](https://github.com/robotastic/trunk-recorder/wiki)
 
 Trunk Recorder is able to record the calls on trunked and conventional radio systems. It uses 1 or more Software Defined Radios (SDRs) to do this. The SDRs capture large swathes of RF and then use software to process what was received. [GNU Radio](https://gnuradio.org/) is used to do this processing because it provides lots of convenient RF blocks that can be pieced together to allow for complex RF processing. The libraries from the amazing [OP25](http://op25.osmocom.org/trac/wiki) project are used for a lot of the P25 functionality. Multiple radio systems can be recorded at the same time.
 
@@ -58,18 +58,20 @@ RTL-SDR dongles; HackRF; Ettus USRP B200, B210, B205; BladeRF; Airspy
 
 ### Playback & Sharing
 By default, Trunk Recorder just dumps a lot of recorded files into a directory. Here are a couple of options to make it easier to browse through recordings and share them on the Internet.
-* [OpenMHz](https://github.com/robotastic/trunk-recorder/wiki/Uploading-to-OpenMHz) - This is my free hosted platform for sharing recordings
-* [Trunk Player](https://github.com/ScanOC/trunk-player) - A great Python based server, if you want to you want to run your own
-* [Rdio Scanner](https://github.com/chuot/rdio-scanner) - Provide a good looking, scanner style interface for listening to Trunk Recorder
+* [OpenMHz](https://github.com/robotastic/trunk-recorder/wiki/Uploading-to-OpenMHz): This is my free hosted platform for sharing recordings
+* [Trunk Player](https://github.com/ScanOC/trunk-player): A great Python based server, if you want to you want to run your own
+* [Rdio Scanner](https://github.com/chuot/rdio-scanner): Provide a good looking, scanner style interface for listening to Trunk Recorder
 * Broadcastify Calls (API): see Radio Reference [forum thread](https://forums.radioreference.com/threads/405236/) and [wiki page](https://wiki.radioreference.com/index.php/Broadcastify-Calls-Trunk-Recorder)
 * [Broadcastify via Liquidsoap](https://github.com/robotastic/trunk-recorder/wiki/Streaming-online-to-Broadcastify-with-Liquid-Soap)
 * [audioplayer.php](https://github.com/robotastic/trunk-recorder/wiki/Using-audioplayer.php)
+* [rosecitytransit's Live Web page](https://github/rosecitytransit/trunk-recorder-daily-log)
 
 ### Plugins
 
-* [MQTT Status](https://github.com/robotastic/trunk-recorder-mqtt-status) -  Publishes the current status of a Trunk Recorder instance over MQTT
-* [MQTT Statistics](https://github.com/robotastic/trunk-recorder-mqtt-statistics) - Publishes statistics about a Trunk Recorder instance over MQTT
-* [Decode rates logger](https://github/rosecitytransit/trunk-recorder-decode-rate) - Logs trunking control channel decode rates to a CSV file, and includes a PHP file that outputs an SVG graph
+* [MQTT Status](https://github.com/robotastic/trunk-recorder-mqtt-status): Publishes the current status of a Trunk Recorder instance over MQTT
+* [MQTT Statistics](https://github.com/robotastic/trunk-recorder-mqtt-statistics): Publishes statistics about a Trunk Recorder instance over MQTT
+* [Decode rates logger](https://github.com/rosecitytransit/trunk-recorder-decode-rate): Logs trunking control channel decode rates to a CSV file, and includes a PHP file that outputs an SVG graph
+* [Daily call log and live Web page]((https://github.com/rosecitytransit/trunk-recorder-daily-log): Creates a daily log of calls (instead of just individual JSON files) and includes an updating PHP Web page w/audio player
 
 ### Troubleshooting
 

--- a/trunk-recorder/call.h
+++ b/trunk-recorder/call.h
@@ -70,6 +70,9 @@ public:
   virtual bool get_encrypted() = 0;
   virtual void set_emergency(bool m) = 0;
   virtual bool get_emergency() = 0;
+  virtual int get_priority() = 0;
+  virtual bool get_mode() = 0;
+  virtual bool get_duplex() = 0;
   virtual std::string get_talkgroup_display() = 0;
   virtual void set_talkgroup_tag(std::string tag) = 0;
   virtual void clear_transmission_list() = 0;

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -58,6 +58,9 @@ int create_call_json(Call_Data_t call_info) {
     json_file << "\"start_time\": " << call_info.start_time << ",\n";
     json_file << "\"stop_time\": " << call_info.stop_time << ",\n";
     json_file << "\"emergency\": " << call_info.emergency << ",\n";
+    json_file << "\"priority\": " << call_info.priority << ",\n";
+    json_file << "\"mode\": " << call_info.mode << ",\n";
+    json_file << "\"duplex\": " << call_info.duplex << ",\n";
     json_file << "\"encrypted\": " << call_info.encrypted << ",\n";
     json_file << "\"call_length\": " << call_info.length << ",\n";
     json_file << "\"talkgroup\": " << call_info.talkgroup << ",\n";
@@ -229,6 +232,9 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
   call_info.freq = call->get_freq();
   call_info.encrypted = call->get_encrypted();
   call_info.emergency = call->get_emergency();
+  call_info.priority = call->get_priority();
+  call_info.mode = call->get_mode();
+  call_info.duplex = call->get_duplex();
   call_info.tdma_slot = call->get_tdma_slot();
   call_info.phase2_tdma = call->get_phase2_tdma();
   call_info.transmission_list = call->get_transmissions();

--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -266,6 +266,18 @@ bool Call_impl::get_emergency() {
   return emergency;
 }
 
+int Call_impl::get_priority() {
+  return priority;
+}
+
+bool Call_impl::get_mode() {
+  return mode;
+}
+
+bool Call_impl::get_duplex() {
+  return duplex;
+}
+
 void Call_impl::set_tdma_slot(int m) {
   tdma_slot = m;
   if (!phase2_tdma && tdma_slot) {
@@ -425,6 +437,9 @@ boost::property_tree::ptree Call_impl::get_stats() {
   call_node.put("conventional", this->is_conventional());
   call_node.put("encrypted", this->get_encrypted());
   call_node.put("emergency", this->get_emergency());
+  call_node.put("priority", this->get_priority());
+  call_node.put("mode", this->get_mode());
+  call_node.put("duplex", this->get_duplex());
   call_node.put("startTime", this->get_start_time());
   call_node.put("stopTime", this->get_stop_time());
   call_node.put("srcId", this->get_current_source_id());

--- a/trunk-recorder/call_impl.h
+++ b/trunk-recorder/call_impl.h
@@ -72,6 +72,9 @@ public:
   bool get_encrypted();
   void set_emergency(bool m);
   bool get_emergency();
+  int get_priority();
+  bool get_mode();
+  bool get_duplex();
   std::string get_talkgroup_display();
   void set_talkgroup_tag(std::string tag);
   void clear_transmission_list();
@@ -110,7 +113,7 @@ protected:
   bool mode;
   bool duplex;
   bool is_analog;
-  long priority;
+  int priority;
   char filename[255];
   char transmission_filename[255];
   char converted_filename[255];

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -95,6 +95,9 @@ struct Call_Data_t {
   long spike_count;
   bool encrypted;
   bool emergency;
+  int priority;
+  bool mode;
+  bool duplex;
   bool audio_archive;
   bool transmission_archive;
   bool call_log;

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -123,7 +123,7 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
     bool encrypted = (bool)bitset_shift_mask(header, 24, 0x40);
     bool duplex = (bool)bitset_shift_mask(header, 24, 0x20);
     bool mode = (bool)bitset_shift_mask(header, 24, 0x10);
-    unsigned long priority = bitset_shift_mask(header, 24, 0x07);
+    int priority = bitset_shift_mask(header, 24, 0x07);
 
 
     message.message_type = GRANT;
@@ -226,7 +226,7 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
     bool encrypted = (bool)bitset_shift_mask(header, 24, 0x40);
     bool dup = (bool)bitset_shift_mask(header, 24, 0x20);
     bool mod = (bool)bitset_shift_mask(header, 24, 0x10);
-    unsigned long pri = bitset_shift_mask(header, 24, 0x07);
+    int pri = bitset_shift_mask(header, 24, 0x07);
     unsigned long ch = bitset_shift_mask(header, 16, 0xffff); /// ????
     unsigned long f = channel_id_to_frequency(ch, sys_num);
     unsigned long sa = bitset_shift_mask(header, 48, 0xffffff);
@@ -275,6 +275,9 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
   message.sys_num = sys_num;
   message.talkgroup = 0;
   message.emergency = false;
+  message.duplex = false;
+  message.mode = false;
+  message.priority = 0;
   message.encrypted = false;
   message.phase2_tdma = false;
   message.tdma_slot = 0;
@@ -306,7 +309,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       bool encrypted = (bool)bitset_shift_mask(tsbk, 72, 0x40);
       bool duplex = (bool)bitset_shift_mask(tsbk, 72, 0x20);
       bool mode = (bool)bitset_shift_mask(tsbk, 72, 0x10);
-      unsigned long priority = bitset_shift_mask(tsbk, 72, 0x07);
+      int priority = bitset_shift_mask(tsbk, 72, 0x07);
       unsigned long ch = bitset_shift_mask(tsbk, 56, 0xffff);
       unsigned long ga = bitset_shift_mask(tsbk, 40, 0xffff);
       unsigned long sa = bitset_shift_mask(tsbk, 16, 0xffffff);
@@ -408,7 +411,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
     bool encrypted = (bool)bitset_shift_mask(tsbk, 72, 0x40);
     bool duplex = (bool)bitset_shift_mask(tsbk, 72, 0x20);
     bool mode = (bool)bitset_shift_mask(tsbk, 72, 0x10);
-    unsigned long priority = bitset_shift_mask(tsbk, 72, 0x07);
+    int priority = bitset_shift_mask(tsbk, 72, 0x07);
 
     if (mfrid == 0x90) { // MOT_GRG_CN_GRANT_UPDT
       unsigned long ch1 = bitset_shift_mask(tsbk, 64, 0xffff);
@@ -485,7 +488,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
     bool encrypted = (bool)bitset_shift_mask(tsbk, 72, 0x40);
     bool duplex = (bool)bitset_shift_mask(tsbk, 72, 0x20);
     bool mode = (bool)bitset_shift_mask(tsbk, 72, 0x10);
-    unsigned long priority = bitset_shift_mask(tsbk, 72, 0x07);
+    int priority = bitset_shift_mask(tsbk, 72, 0x07);
     unsigned long ch = bitset_shift_mask(tsbk, 64, 0xffff);
     unsigned long f = channel_id_to_frequency(ch, sys_num);
     unsigned long sa = bitset_shift_mask(tsbk, 16, 0xffffff);
@@ -514,7 +517,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
     bool encrypted = (bool)bitset_shift_mask(tsbk, 72, 0x40);
     bool duplex = (bool)bitset_shift_mask(tsbk, 72, 0x20);
     bool mode = (bool)bitset_shift_mask(tsbk, 72, 0x10);
-    unsigned long priority = bitset_shift_mask(tsbk, 72, 0x07);
+    int priority = bitset_shift_mask(tsbk, 72, 0x07);
     unsigned long sa = bitset_shift_mask(tsbk, 16, 0xffffff);
     unsigned long si = bitset_shift_mask(tsbk, 40, 0xffffff);
 

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -39,7 +39,7 @@ struct TrunkMessage {
   bool emergency;
   bool duplex;
   bool mode;
-  long priority;
+  int priority;
   int tdma_slot;
   bool phase2_tdma;
   long source;


### PR DESCRIPTION
Completes #153

https://github.com/robotastic/trunk-recorder/commit/9a115eba51594d5facf4edd3f1ec6fa66ff83c70 puts a link to my daily log plugin (and live Web page audio player) in README.md and makes a few minor changes, including correcting links

https://github.com/robotastic/trunk-recorder/commit/83bed1fc4a81ceb926b0300bdbb40522a49a6f9b adds logging of P25 call priority (can be 0-7), circuit/packet mode and duplex from the Service Options field in control channel packets. Was originally https://github.com/robotastic/trunk-recorder/commit/67a0d86428c3d625c3a607793c336c86169f69af