### PR TITLE
Adjust analog_recorder deemphasis filter

### DIFF
--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -145,7 +145,7 @@ analog_recorder::analog_recorder(Source *src)
   valve->set_enabled(false);
 
   /* de-emphasis */
-  d_tau = 0.000075; // 75us
+  d_tau = 0.00075; // 750us
   d_fftaps.resize(2);
   d_fbtaps.resize(2);
   calculate_iir_taps(d_tau);


### PR DESCRIPTION
Use a time constant of 750µs instead of 75µs.

Resolves #478.