### PR TITLE
Adds docker-client To Dockerfile for DID Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04 AS base
 
 # Install everything except cmake
+# Install docker for passing the socket to allow for intercontainer exec
 RUN apt-get update && \
   apt-get -y upgrade &&\
   export DEBIAN_FRONTEND=noninteractive && \
@@ -10,6 +11,7 @@ RUN apt-get update && \
     ca-certificates \
     fdkaac \
     git \
+    docker \
     gnupg \
     gnuradio \
     gnuradio-dev \


### PR DESCRIPTION
Adds the docker client so those who run trunk-player/other webUI's in docker can call the host docker daemon with  in the upload script 

Example:
```bash
docker -v /var/run/docker.sock:/var/run/docker.sock trunkplayer_app_1 'python ./mange.py add_transmission $1'
```