### PR TITLE
Dockerfile build/install AUR package

### DIFF
--- a/utils/Dockerfile.arch-latest-aur.dev
+++ b/utils/Dockerfile.arch-latest-aur.dev
@@ -1,0 +1,21 @@
+FROM archlinux:latest AS base
+
+# Install enought to run makepkg 
+# PKGBUILD from the repo will pull all dependencies for build and install
+RUN pacman -Suy --noconfirm base-devel git
+
+ARG AUR_PACKAGE=trunk-recorder-git
+
+RUN useradd builduser -m \
+  && passwd -d builduser \
+  && cd /home/builduser \
+  && git clone "https://aur.archlinux.org/$AUR_PACKAGE.git" target \
+  && chown builduser -R target \
+  && (printf 'builduser ALL=(ALL) ALL\n' | tee -a /etc/sudoers) \
+  && sudo -u builduser bash -c 'cd ~/target && makepkg -si --noconfirm' \
+  && pacman -Rns --noconfirm $(pacman -Qtdq)
+
+# GNURadio requires a place to store some files, can only be set via $HOME env var.
+ENV HOME=/tmp
+
+CMD ["/usr/bin/recorder", "--config=/app/config.json"]


### PR DESCRIPTION
This provides a Dockerfile that will build/install the AUR package: https://aur.archlinux.org/packages/trunk-recorder-git

This could easily be changed by VAR to also build: https://aur.archlinux.org/packages/trunk-recorder

I hope this can help troubleshooting the segfault I've been experiencing. Perhaps be a first step to packaging. 