### PR TITLE
Update Arch Linux Instructions

### DIFF
--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -68,36 +68,44 @@ sudo apt install git cmake make build-essential libboost-all-dev libusb-1.0-0.de
 ### Arch Linux
 
 #### Install from AUR
-1. Update and dependencies
+Update and dependencies
 ```bash
 sudo pacman -Suy
 sudo pacman -S --needed base-devel git
 ```
-3. Clone the package
+
+Clone the package
 ```bash
 git clone https://aur.archlinux.org/trunk-recorder.git
 ```
-2. Install trunk-recorder
+
+Install trunk-recorder
 ```bash
 cd trunk-recorder
 makepkg -si
 ```
+
+Configure `/etc/trunk-recorder/config.json` and start with `systemctl start trunk-recorder.service`. The service runs as trunk-recorder so ensure needed devices(SDR) and files(Media/Talkgroups) are usable(Read or Read/Write) by the trunk-recorder user. 
+
 #### Install with AUR helper
 ```bash
 yay -S trunk-recorder
 ```
+Configure `/etc/trunk-recorder/config.json` and start with `systemctl start trunk-recorder.service`. The service runs as trunk-recorder so ensure needed devices(SDR) and files(Media/Talkgroups) are usable(Read or Read/Write) by the trunk-recorder user. 
 
 #### Install from source
 
-1. It is suggested to make sure your installed packages are up to date and to review the [Arch Linux documentation regarding upgrades](https://wiki.archlinux.org/index.php/System_maintenance#Upgrading_the_system):
+It is suggested to make sure your installed packages are up to date and to review the [Arch Linux documentation regarding upgrades](https://wiki.archlinux.org/index.php/System_maintenance#Upgrading_the_system):
 ```bash
 sudo pacman -Syyu
 ```
-2. Install the packages required to build Trunk Recorder:
+
+Install the packages required to build Trunk Recorder:
 ```bash
 sudo pacman -S --needed base-devel git cmake boost gnuradio gnuradio-osmosdr libuhd fdkaac sox
 ```
-3. Continue with Building Trunk Recorder below
+
+Continue with Building Trunk Recorder below
 
 ## Building Trunk Recorder
 


### PR DESCRIPTION
This updates the Arch Linux install instructions to include installing from AUR while still including updated build prereq. The `--needed` is awesome and won't reinstall what is already there. 

I welcome testers of these instructions. I need to test them in the AM when I'm more alert. This gets the ball rolling however. 

I make some assumptions as part of my package by including a systemd unit and stashing the config in /etc/trunk-recorder/config.json for that unit and running the unit as a non-root user(trunk-recorder). We can change if you have another preference? 