### PR TITLE
Use Dockerfile CMD in shell form to avoid leaking unitScript processes (Closes #538)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /app
 # GNURadio requires a place to store some files, can only be set via $HOME env var.
 ENV HOME=/tmp
 
-CMD ["trunk-recorder", "--config=/app/config.json"]
+CMD trunk-recorder --config=/app/config.json


### PR DESCRIPTION
Migrate from JSON-style CMD in the Dockerfile to shell-form. This ensures that there is a parent shell running to reap unitScript processes when they exit

See https://github.com/robotastic/trunk-recorder/issues/538 for more details