### PR TITLE
Fix recording encrypted transmissions

### DIFF
--- a/trunk-recorder/recorders/p25_recorder_decode.cc
+++ b/trunk-recorder/recorders/p25_recorder_decode.cc
@@ -90,9 +90,9 @@ void p25_recorder_decode::initialize(  int silence_frames) {
   bool do_msgq = 0;
   bool do_audio_output = 1;
   bool do_tdma = 0;
-  bool do_crypt = 0;
+  bool do_nocrypt = 1;
 
-  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(0, silence_frames, wireshark_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_crypt);
+  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(0, silence_frames, wireshark_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
   converter = gr::blocks::short_to_float::make(1, 32768.0);
   levels = gr::blocks::multiply_const_ff::make(1);
   plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&p25_recorder_decode::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));

--- a/trunk-recorder/systems/p25_trunking.cc
+++ b/trunk-recorder/systems/p25_trunking.cc
@@ -228,8 +228,8 @@ void p25_trunking::initialize_p25() {
   bool do_msgq = 1;
   bool do_audio_output = 0;
   bool do_tdma = 0;
-  bool do_crypt = 0;
-  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(sys_num, silence_frames, wireshark_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_crypt);
+  bool do_nocrypt = 1;
+  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(sys_num, silence_frames, wireshark_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
 
   connect(slicer, 0, op25_frame_assembler, 0);
 }


### PR DESCRIPTION
Based on the code, I believe you intended to ignore encrypted transmissions, but the bool is set backwards based on what p25_frame_assembler::make() expects.