### PR TITLE
Add method in P25 Recorder to allow talkgroup ID to be retreived

### DIFF
--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -306,6 +306,10 @@ double p25_recorder::get_freq() {
   return chan_freq;
 }
 
+long p25_recorder::get_talkgroup(){
+  return this->call->get_talkgroup();
+}
+
 double p25_recorder::get_current_length() {
   if (qpsk_mod) {
     return qpsk_p25_decode->get_current_length();

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -91,6 +91,7 @@ public:
   void stop();
   void clear();
   double get_freq();
+  long get_talkgroup();
   int get_num();
   void set_tdma(bool phase2);
   void switch_tdma(bool phase2);


### PR DESCRIPTION
Allows audio_stream() in plugins to get talkgroup ID since Call info is protected and not available.  