### PR TITLE
Plugin Audio Streaming CPU/Memory Usage Reduction

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -124,6 +124,7 @@ Here is a map of the different sections of the *config.json* file:
 | debugRecorder           |          | true              | **true** / **false**                                        | Will attach a debug recorder to each Source. The debug recorder will allow you to examine the channel of a call be recorded. There is a single Recorder per Source. It will monitor a recording and when it is done, it will monitor the next recording started. The information is sent over a network connection and can be viewed using the `udp-debug.grc` graph in GnuRadio Companion |
 | debugRecorderPort       |          | 1234              | number                                                      | The network port that the Debug Recorders will start on. For each Source an additional Debug Recorder will be added and the port used will be one higher than the last one. For example the ports for a system with 3 Sources would be: 1234, 12345, 1236. |
 | debugRecorderAddress    |          | "127.0.0.1"       | string                                                      | The network address of the computer that will be monitoring the Debug Recorders. UDP packets will be sent from Trunk Recorder to this computer. The default is *"127.0.0.1"* which is the address used for monitoring on the same computer as Trunk Recorder. |
+| audioStreaming          |          |     false         | **true** / **false**                                        | whether or not to enable the audio streaming callbacks for plugins. |
 
 
 
@@ -150,7 +151,6 @@ Here is a map of the different sections of the *config.json* file:
 | vga2Gain         |          |               | number                                                       | [bladeRF only] sets the **VGA2** gain.                       |
 | antenna          |          |               | string, e.g.: **"TX/RX"**                                    | [usrp] selects which antenna jack to use                     |
 | debugRecorders   |          |               | number                                                       | the number of Debug Recorder to have attached to this source. Debug Recorders capture a raw sample that you can examine later using GNURadio Companion. This is helpful if you want to fine tune your the error and gain for this Source. |
-| audioStreaming   |          |     false     | **true** / **false**                                         | whether or not to enable the audio streaming callbacks for plugins. |
 
 
 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -150,6 +150,7 @@ Here is a map of the different sections of the *config.json* file:
 | vga2Gain         |          |               | number                                                       | [bladeRF only] sets the **VGA2** gain.                       |
 | antenna          |          |               | string, e.g.: **"TX/RX"**                                    | [usrp] selects which antenna jack to use                     |
 | debugRecorders   |          |               | number                                                       | the number of Debug Recorder to have attached to this source. Debug Recorders capture a raw sample that you can examine later using GNURadio Companion. This is helpful if you want to fine tune your the error and gain for this Source. |
+| audioStreaming   |          |     false     | **true** / **false**                                         | whether or not to enable the audio streaming callbacks for plugins. |
 
 
 

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -32,6 +32,7 @@ struct Config {
   int control_message_warn_rate;
   int control_retune_limit;
   bool broadcast_signals;
+  bool enable_audio_streaming;
 };
 
 

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -383,6 +383,7 @@ bool load_config(string config_file) {
       int tia_gain = node.second.get<double>("tiaGain", 0);
       int vga1_gain = node.second.get<double>("vga1Gain", 0);
       int vga2_gain = node.second.get<double>("vga2Gain", 0);
+      bool audio_streaming = node.second.get<bool>("audioStreaming", false);
 
       std::string antenna = node.second.get<string>("antenna", "");
       int digital_recorders = node.second.get<int>("digitalRecorders", 0);
@@ -416,6 +417,7 @@ bool load_config(string config_file) {
       BOOST_LOG_TRIVIAL(info) << "Debug Recorder: " << node.second.get<bool>("debugRecorder", 0);
       BOOST_LOG_TRIVIAL(info) << "SigMF Recorders: " << node.second.get<int>("sigmfRecorders", 0);
       BOOST_LOG_TRIVIAL(info) << "Analog Recorders: " << node.second.get<int>("analogRecorders", 0);
+      BOOST_LOG_TRIVIAL(info) << "Enable Audio Streaming: " << node.second.get<bool>("audioStreaming", false);
 
       if ((ppm != 0) && (error != 0)) {
         BOOST_LOG_TRIVIAL(info) << "Both PPM and Error should not be set at the same time. Setting Error to 0.";
@@ -481,6 +483,8 @@ bool load_config(string config_file) {
         BOOST_LOG_TRIVIAL(error) << "! No Gain was specified! Things will probably not work";
       }
 
+      source->set_enable_audio_streaming(audio_streaming);
+
       source->set_gain_mode(agc);
       source->set_antenna(antenna);
       source->set_silence_frames(silence_frames);
@@ -494,6 +498,7 @@ bool load_config(string config_file) {
       if (config.debug_recorder) {
         source->create_debug_recorder(tb, source_count);
       }
+      
       sources.push_back(source);
       source_count++;
       BOOST_LOG_TRIVIAL(info) << "\n-------------------------------------\n\n";

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -383,7 +383,6 @@ bool load_config(string config_file) {
       int tia_gain = node.second.get<double>("tiaGain", 0);
       int vga1_gain = node.second.get<double>("vga1Gain", 0);
       int vga2_gain = node.second.get<double>("vga2Gain", 0);
-      bool audio_streaming = node.second.get<bool>("audioStreaming", false);
 
       std::string antenna = node.second.get<string>("antenna", "");
       int digital_recorders = node.second.get<int>("digitalRecorders", 0);
@@ -417,7 +416,6 @@ bool load_config(string config_file) {
       BOOST_LOG_TRIVIAL(info) << "Debug Recorder: " << node.second.get<bool>("debugRecorder", 0);
       BOOST_LOG_TRIVIAL(info) << "SigMF Recorders: " << node.second.get<int>("sigmfRecorders", 0);
       BOOST_LOG_TRIVIAL(info) << "Analog Recorders: " << node.second.get<int>("analogRecorders", 0);
-      BOOST_LOG_TRIVIAL(info) << "Enable Audio Streaming: " << node.second.get<bool>("audioStreaming", false);
 
       if ((ppm != 0) && (error != 0)) {
         BOOST_LOG_TRIVIAL(info) << "Both PPM and Error should not be set at the same time. Setting Error to 0.";
@@ -483,8 +481,6 @@ bool load_config(string config_file) {
         BOOST_LOG_TRIVIAL(error) << "! No Gain was specified! Things will probably not work";
       }
 
-      source->set_enable_audio_streaming(audio_streaming);
-
       source->set_gain_mode(agc);
       source->set_antenna(antenna);
       source->set_silence_frames(silence_frames);
@@ -537,6 +533,8 @@ bool load_config(string config_file) {
     BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
     config.control_retune_limit = pt.get<int>("controlRetuneLimit", 0);
     BOOST_LOG_TRIVIAL(info) << "Control channel retune limit: " << config.control_retune_limit;
+    config.enable_audio_streaming = pt.get<bool>("audioStreaming", false);
+    BOOST_LOG_TRIVIAL(info) << "Enable Audio Streaming: " << config.enable_audio_streaming;
 
     BOOST_LOG_TRIVIAL(info) << "Frequency format: " << get_frequency_format();
 

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -92,7 +92,12 @@ analog_recorder::analog_recorder(Source *src)
   starttime = time(NULL);
 
   float offset = 0;
-  bool use_streaming = source->get_enable_audio_streaming();
+  bool use_streaming = false; 
+  
+  if (config != NULL ) {
+    use_streaming = config->enable_audio_streaming;
+  }
+
 
   //int samp_per_sym        = 10;
   system_channel_rate = 96000; //4800 * samp_per_sym;

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -92,6 +92,7 @@ analog_recorder::analog_recorder(Source *src)
   starttime = time(NULL);
 
   float offset = 0;
+  bool use_streaming = source->get_enable_audio_streaming();
 
   //int samp_per_sym        = 10;
   system_channel_rate = 96000; //4800 * samp_per_sym;
@@ -197,7 +198,7 @@ analog_recorder::analog_recorder(Source *src)
 
   wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, wav_sample_rate, 16, true); //  Configurable
 
-  if(source->get_enable_audio_streaming()) {
+  if(use_streaming) {
     BOOST_LOG_TRIVIAL(info) << "Creating plugin sink..." << std::endl;
     plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&analog_recorder::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
     BOOST_LOG_TRIVIAL(info) << "Plugin sink created!" << std::endl;
@@ -239,7 +240,7 @@ analog_recorder::analog_recorder(Source *src)
   connect(decim_audio, 0, high_f, 0);
   connect(decim_audio, 0, decoder_sink, 0);
 
-  if(source->get_enable_audio_streaming()) {
+  if(use_streaming) {
     connect(decim_audio, 0, plugin_sink, 0);
   }
   

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -197,9 +197,11 @@ analog_recorder::analog_recorder(Source *src)
 
   wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, wav_sample_rate, 16, true); //  Configurable
 
-  BOOST_LOG_TRIVIAL(info) << "Creating plugin sink..." << std::endl;
-  plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&analog_recorder::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
-  BOOST_LOG_TRIVIAL(info) << "Plugin sink created!" << std::endl;
+  if(source->get_enable_audio_streaming()) {
+    BOOST_LOG_TRIVIAL(info) << "Creating plugin sink..." << std::endl;
+    plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&analog_recorder::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
+    BOOST_LOG_TRIVIAL(info) << "Plugin sink created!" << std::endl;
+  }
 
   BOOST_LOG_TRIVIAL(info) << "Creating decoder sink..." << std::endl;
   decoder_sink = gr::blocks::decoder_wrapper_impl::make(wav_sample_rate, src->get_num(), std::bind(&analog_recorder::decoder_callback_handler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
@@ -236,7 +238,11 @@ analog_recorder::analog_recorder(Source *src)
   connect(deemph, 0, decim_audio, 0);
   connect(decim_audio, 0, high_f, 0);
   connect(decim_audio, 0, decoder_sink, 0);
-  connect(decim_audio, 0, plugin_sink, 0);
+
+  if(source->get_enable_audio_streaming()) {
+    connect(decim_audio, 0, plugin_sink, 0);
+  }
+  
   connect(high_f, 0, low_f, 0);
   connect(low_f, 0, squelch_two, 0);
   connect(squelch_two, 0, levels, 0);

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -170,6 +170,12 @@ void p25_recorder::initialize(Source *src) {
   timestamp = time(NULL);
   starttime = time(NULL);
 
+  if (config == NULL ) {
+    this->set_enable_audio_streaming(false);
+  } else {
+    this->set_enable_audio_streaming(config->enable_audio_streaming);
+  }
+
   initialize_prefilter();
   //initialize_p25();
 

--- a/trunk-recorder/recorders/p25_recorder_decode.cc
+++ b/trunk-recorder/recorders/p25_recorder_decode.cc
@@ -77,6 +77,10 @@ void p25_recorder_decode::initialize(  int silence_frames) {
   slicer = gr::op25_repeater::fsk4_slicer_fb::make(slices);
   wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, 8000, 16, true);
   //recorder->initialize(src);
+
+  bool use_streaming = false;
+  if(_recorder->get_source() != NULL)
+    use_streaming = _recorder->get_source()->get_enable_audio_streaming();
   
   //OP25 Frame Assembler
   traffic_queue = gr::msg_queue::make(2);
@@ -96,7 +100,7 @@ void p25_recorder_decode::initialize(  int silence_frames) {
   converter = gr::blocks::short_to_float::make(1, 32768.0);
   levels = gr::blocks::multiply_const_ff::make(1);
 
-  if(source->get_enable_audio_streaming()) {
+  if(use_streaming) {
     plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&p25_recorder_decode::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
   }
 
@@ -105,10 +109,10 @@ void p25_recorder_decode::initialize(  int silence_frames) {
   connect(op25_frame_assembler, 0, converter, 0);
   connect(converter, 0, levels, 0);
 
-  if(source->get_enable_audio_streaming()) {
+  if(use_streaming) {
     connect(converter, 0, plugin_sink, 0);
   }
-  
+
   connect(levels, 0, wav_sink, 0);
 }
 

--- a/trunk-recorder/recorders/p25_recorder_decode.cc
+++ b/trunk-recorder/recorders/p25_recorder_decode.cc
@@ -13,7 +13,7 @@ p25_recorder_decode::p25_recorder_decode(Recorder* recorder)
     : gr::hier_block2("p25_recorder_decode",
                       gr::io_signature::make(1, 1, sizeof(float)),
                       gr::io_signature::make(0, 0, sizeof(float))) {
-  _recorder = recorder;
+  d_recorder = recorder;
 }
 
 p25_recorder_decode::~p25_recorder_decode(){
@@ -78,9 +78,7 @@ void p25_recorder_decode::initialize(  int silence_frames) {
   wav_sink = gr::blocks::nonstop_wavfile_sink_impl::make(1, 8000, 16, true);
   //recorder->initialize(src);
 
-  bool use_streaming = false;
-  if(_recorder->get_source() != NULL)
-    use_streaming = _recorder->get_source()->get_enable_audio_streaming();
+  bool use_streaming = d_recorder->get_enable_audio_streaming();
   
   //OP25 Frame Assembler
   traffic_queue = gr::msg_queue::make(2);
@@ -117,7 +115,7 @@ void p25_recorder_decode::initialize(  int silence_frames) {
 }
 
 void p25_recorder_decode::plugin_callback_handler(float *samples, int sampleCount) {
-  plugman_audio_callback(_recorder, samples, sampleCount);
+  plugman_audio_callback(d_recorder, samples, sampleCount);
 }
 
 double p25_recorder_decode::get_output_sample_rate() {

--- a/trunk-recorder/recorders/p25_recorder_decode.cc
+++ b/trunk-recorder/recorders/p25_recorder_decode.cc
@@ -95,13 +95,20 @@ void p25_recorder_decode::initialize(  int silence_frames) {
   op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(0, silence_frames, udp_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
   converter = gr::blocks::short_to_float::make(1, 32768.0);
   levels = gr::blocks::multiply_const_ff::make(1);
-  plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&p25_recorder_decode::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
+
+  if(source->get_enable_audio_streaming()) {
+    plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&p25_recorder_decode::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
+  }
 
   connect( self(),0, slicer,0);
   connect(slicer, 0, op25_frame_assembler, 0);
   connect(op25_frame_assembler, 0, converter, 0);
   connect(converter, 0, levels, 0);
-  connect(converter, 0, plugin_sink, 0);
+
+  if(source->get_enable_audio_streaming()) {
+    connect(converter, 0, plugin_sink, 0);
+  }
+  
   connect(levels, 0, wav_sink, 0);
 }
 

--- a/trunk-recorder/recorders/p25_recorder_decode.h
+++ b/trunk-recorder/recorders/p25_recorder_decode.h
@@ -44,7 +44,7 @@ class p25_recorder_decode : public gr::hier_block2 {
 protected:
 
   virtual void initialize(  int silence_frames);
-  Recorder* _recorder;
+  Recorder* d_recorder;
   gr::op25_repeater::p25_frame_assembler::sptr op25_frame_assembler;
   gr::msg_queue::sptr traffic_queue;
   gr::msg_queue::sptr rx_queue;

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -108,13 +108,15 @@ public:
   virtual boost::property_tree::ptree get_stats();
   virtual int get_recording_count() { return recording_count; }
   virtual double get_recording_duration() { return recording_duration; }
-
   virtual void process_message_queues(void){};
   virtual double get_output_sample_rate(){ return 0;}
   virtual int get_output_channels() { return 1; }
+  virtual bool get_enable_audio_streaming() {return d_enable_audio_streaming; };
+  virtual void set_enable_audio_streaming(bool enable_audio_streaming) { d_enable_audio_streaming = enable_audio_streaming; };
 
 protected:
   int recording_count;
+  bool d_enable_audio_streaming;
   double recording_duration;
   std::string type;
 };

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -61,6 +61,14 @@ double Source::get_error() {
   return error;
 }
 
+bool Source::get_enable_audio_streaming() {
+  return enable_audio_streaming;
+}
+
+void Source::set_enable_audio_streaming(bool b) {
+  enable_audio_streaming = b;
+}
+
 void Source::set_gain(int r) {
   if (driver == "osmosdr") {
     gain = r;

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -62,11 +62,10 @@ double Source::get_error() {
 }
 
 bool Source::get_enable_audio_streaming() {
-  return enable_audio_streaming;
-}
-
-void Source::set_enable_audio_streaming(bool b) {
-  enable_audio_streaming = b;
+  if(get_config() == NULL)
+    return false;
+  else
+    return get_config()->enable_audio_streaming;
 }
 
 void Source::set_gain(int r) {

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -61,13 +61,6 @@ double Source::get_error() {
   return error;
 }
 
-bool Source::get_enable_audio_streaming() {
-  if(get_config() == NULL)
-    return false;
-  else
-    return get_config()->enable_audio_streaming;
-}
-
 void Source::set_gain(int r) {
   if (driver == "osmosdr") {
     gain = r;

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -47,7 +47,6 @@ class Source {
   int max_sigmf_recorders;
   int max_analog_recorders;
   int debug_recorder_port;
-  bool enable_audio_streaming;
 
   int silence_frames;
   Config *config;
@@ -94,7 +93,6 @@ public:
   void set_silence_frames(int m);
   int get_silence_frames();
 
-  void set_enable_audio_streaming(bool b);
   bool get_enable_audio_streaming();
 
   int get_bb_gain();

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -92,9 +92,6 @@ public:
 
   void set_silence_frames(int m);
   int get_silence_frames();
-
-  bool get_enable_audio_streaming();
-
   int get_bb_gain();
   int get_mix_gain();
   int get_lna_gain();

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -47,6 +47,7 @@ class Source {
   int max_sigmf_recorders;
   int max_analog_recorders;
   int debug_recorder_port;
+  bool enable_audio_streaming;
 
   int silence_frames;
   Config *config;
@@ -93,6 +94,8 @@ public:
   void set_silence_frames(int m);
   int get_silence_frames();
 
+  void set_enable_audio_streaming(bool b);
+  bool get_enable_audio_streaming();
 
   int get_bb_gain();
   int get_mix_gain();


### PR DESCRIPTION
This change allows the audio streaming callbacks to be turned off if they are not being used. This reduces the memory and CPU usage. On RaspberryPi3 and other small devices, this can add significant overhead on a feature that is not commonly used.