### PR TITLE
Conventional P25 demod checks after analog transmissions

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -725,11 +725,9 @@ void process_message_queues() {
   }
 }
 
-void manage_conventional_call(Call *call) {
-  if (call->get_recorder()) {
-    // if any recording has happened
 
-    if (call->get_current_length() > 0) {
+
+void handle_conventional_call_recording(Call *call) {
       BOOST_LOG_TRIVIAL(trace) << "[" << call->get_short_name() << "]\t\033[0;34m" << call->get_call_num() << "C\033[0m Call Length: " << call->get_current_length() << "s\t Idle: " << call->get_recorder()->is_idle() << "\t Idle Count: " << call->get_idle_count();
 
       // means that the squelch is on and it has stopped recording
@@ -762,6 +760,16 @@ void manage_conventional_call(Call *call) {
           plugman_setup_recorder(recorder);
         }
       }
+}
+
+void manage_conventional_call(Call *call) {
+
+  // make sure there is an associated recorder... there better be, since it is conventional
+  if (call->get_recorder()) {
+
+    // if any recording has happened
+    if (call->get_current_length() > 0) {
+      handle_conventional_call_recording(call);
     } else if (!call->get_recorder()->is_active()) {
       // P25 Conventional Recorders need a have the graph unlocked before they can start recording.
       Recorder *recorder = call->get_recorder();

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -170,6 +170,8 @@ void p25_recorder::initialize(Source *src) {
   timestamp = time(NULL);
   starttime = time(NULL);
 
+  costas_error_count = 0;
+
   if (config == NULL ) {
     this->set_enable_audio_streaming(false);
   } else {
@@ -287,6 +289,24 @@ bool p25_recorder::is_active() {
   } else {
     return false;
   }
+}
+
+void p25_recorder::costas_reset() {
+  if (qpsk_mod) {
+    qpsk_demod->reset();
+  }
+}
+
+int p25_recorder::get_costas_error_count() {
+  return costas_error_count;
+}
+
+void p25_recorder::reset_costas_error_count() {
+  costas_error_count = 0;
+}
+
+void p25_recorder::increase_costas_error_count() {
+  costas_error_count++;
 }
 
 bool p25_recorder::is_squelched() {

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -110,6 +110,10 @@ public:
   Source *get_source();
   void autotune();
   void reset();
+  void costas_reset();
+  int get_costas_error_count();
+  void reset_costas_error_count();
+  void increase_costas_error_count();
 
 protected:
   State state;
@@ -125,6 +129,7 @@ protected:
   bool qpsk_mod;
   bool conventional;
   double squelch_db;
+  int costas_error_count;
   gr::analog::pwr_squelch_cc::sptr squelch;
   gr::blocks::selector::sptr modulation_selector;
   gr::blocks::copy::sptr valve;

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -113,6 +113,10 @@ public:
   virtual int get_output_channels() { return 1; }
   virtual bool get_enable_audio_streaming() {return d_enable_audio_streaming; };
   virtual void set_enable_audio_streaming(bool enable_audio_streaming) { d_enable_audio_streaming = enable_audio_streaming; };
+  virtual void costas_reset(){};
+  virtual int get_costas_error_count(){ return 0;}
+  virtual void reset_costas_error_count(){};
+  virtual void increase_costas_error_count(){};
 
 protected:
   int recording_count;


### PR DESCRIPTION
As discussed in #318 and #322, a Conventional P25 recorder often locks up when an analog transmission such as a morse ID occurs on that frequency.

Currently, the costas clock is reset at the beginning of each call.  But when analog transmissions occur *anywhere afterward* to knock the costas clock off, no further audio is decoded, so `get_current_length()` in `main.cc:void manage_conventional_call()` will not be > 0, and the call will not time out or conclude.  The recorder remains stuck until it either catches a lucky fragment of garbled P25 audio (`get_current_length() > 0`), or until trunk-recorder is restarted.

My local systems aren't very active, but I used to restart trunk-recorder via a cron job twice an hour because of CW IDs.  After this, it's been handling station IDs and other spurious analog transmissions over the past couple weeks and resetting the costas timer as required.

There may be other ways to address this, but looking for instances where the squelch opens and closes without producing audio seems to be a simple indicator that the Conventional P25 demod should probably be reset, and doesn't interfere with trunked systems I can't test against.