### PR TITLE
simplestream Plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,8 @@ add_subdirectory(plugins/unit_script)
 
 add_subdirectory(plugins/rdioscanner_uploader)
 
+add_subdirectory(plugins/simplestream)
+
 add_executable(trunk-recorder trunk-recorder/main.cc ${trunk_recorder_sources})
 
 target_link_libraries(trunk-recorder trunk_recorder_library gnuradio-op25_repeater   ${CMAKE_DL_LIBS} ssl crypto ${CURL_LIBRARIES} ${Boost_LIBRARIES} ${GNURADIO_PMT_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_FILTER_LIBRARIES} ${GNURADIO_DIGITAL_LIBRARIES} ${GNURADIO_ANALOG_LIBRARIES} ${GNURADIO_AUDIO_LIBRARIES} ${GNURADIO_UHD_LIBRARIES} ${UHD_LIBRARIES} ${GNURADIO_BLOCKS_LIBRARIES} ${GNURADIO_OSMOSDR_LIBRARIES}  ) # gRPC::grpc++_reflection protobuf::libprotobuf)

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -246,7 +246,7 @@ This plugin makes it easy to connect Trunk Recorder with [Rdio Scanner](https://
 **Name:** simplestream
 **Library:** libsimplestream.so
 
-This plugin streams uncompressed audio (32 bit float, 8 kHz, mono) to UDP ports in real time as it is being recorded by trunk-recorder.  It can be configured to stream audio from all talkgroups being recorded or only specified talkgroups.  TGID information can be prepended to the audio data to allow the receiving program to take action based on the TGID.
+This plugin streams uncompressed audio (16 bit Int, 8 kHz, mono) to UDP ports in real time as it is being recorded by trunk-recorder.  It can be configured to stream audio from all talkgroups being recorded or only specified talkgroups.  TGID information can be prepended to the audio data to allow the receiving program to take action based on the TGID.
 
 This plugin does not, by itself, stream audio to any online services.  Because it sends uncompressed PCM audio, it is not bandwidth efficient and is intended mostly to send audio to other programs running on the same computer as trunk-recorder or to other computers on the LAN.  The programs receiving PCM audio from this plugin may play it on speakers, compress it and stream it to an online service, etc.  
 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -241,8 +241,92 @@ This plugin makes it easy to connect Trunk Recorder with [Rdio Scanner](https://
           }
 ```
 
+##### simplestream Plugin
 
+**Name:** simplestream
+**Library:** libsimplestream.so
 
+This plugin streams uncompressed audio (32 bit float, 8 kHz, mono) to UDP ports in real time as it is being recorded by trunk-recorder.  It can be configured to stream audio from all talkgroups being recorded or only specified talkgroups.  TGID information can be prepended to the audio data to allow the receiving program to take action based on the TGID.
+
+This plugin does not, by itself, stream audio to any online services.  Because it sends uncompressed PCM audio, it is not bandwidth efficient and is intended mostly to send audio to other programs running on the same computer as trunk-recorder or to other computers on the LAN.  The programs receiving PCM audio from this plugin may play it on speakers, compress it and stream it to an online service, etc.  
+
+| Key     | Required | Default Value | Type   | Description                                                  |
+| ------- | :------: | ------------- | ------ | ------------------------------------------------------------ |
+| streams |    ✓     |               | array  | This is an array of objects, where each is an audio stream that will be sent to a specific IP address and UDP port. More information about what should be in each object is in the following table. |
+
+*Audio Stream Object:*
+
+| Key       | Required | Default Value | Type   | Description                                                  |
+| --------- | :------: | ------------- | ------ | ------------------------------------------------------------ |
+| address   |    ✓     |               | string | IP address to send this audio stream to.  Use "127.0.0.1" to send to the same computer that trunk-recorder is running on. |
+| port      |    ✓     |               | number | UDP port that this stream will send audio to. |
+| TGID      |    ✓     |               | number | Audio from this Talkgroup ID will be sent on this stream.  Set to 0 to stream all recorded talkgroups. |
+| sendTGID  |           |    false     | boolean | When set to true, the TGID will be prepended in long integer format (4 bytes, little endian) to the audio data each time a UDP packet is sent. |
+
+###### Plugin Object Example #1:
+This example will stream audio from talkgroup 58914 and 58916 to the local machine on UDP port 9123.  
+```yaml
+        {
+          "name":"simplestream",
+          "library":"libsimplestream.so",
+          "streams":[{
+            "TGID":58914,
+            "address":"127.0.0.1",
+            "port":9123,
+            "sendTGID":false}
+        }
+```
+
+###### Plugin Object Example #2:
+This example will stream audio from talkgroup 58914 to the local machine on UDP port 9123 and stream audio from talkgroup 58916 to the local machine on UDP port 9124.
+```yaml
+        {
+          "name":"simplestream",
+          "library":"libsimplestream.so",
+          "streams":[{
+            "TGID":58914,
+            "address":"127.0.0.1",
+            "port":9123,
+            "sendTGID":false},
+           {"TGID":58916,
+            "address":"127.0.0.1",
+            "port":9124,
+            "sendTGID":false}
+          ]}
+        }
+```
+
+###### Plugin Object Example #3:
+This example will stream audio from talkgroups 58914 and 58916 to the local machine on the same UDP port 9123.  It will prepend the TGID to the audio data in each UDP packet so that the receiving program can differentiate the two audio streams (the receiver may decide to only play one depending on priority, mix the two streams, play one left and one right, etc.)
+```yaml
+        {
+          "name":"simplestream",
+          "library":"libsimplestream.so",
+          "streams":[{
+            "TGID":58914,
+            "address":"127.0.0.1",
+            "port":9123,
+            "sendTGID":true},
+           {"TGID":58916,
+            "address":"127.0.0.1",
+            "port":9123,
+            "sendTGID":true}
+          ]}
+        }
+```
+###### Plugin Object Example #4:
+This example will stream audio from all talkgroups being recorded to the local machine on UDP port 9123.  It will prepend the TGID to the audio data in each UDP packet so that the receiving program can decide which ones to play or otherwise handle)
+```yaml
+        {
+          "name":"simplestream",
+          "library":"libsimplestream.so",
+          "streams":[{
+            "TGID":0,
+            "address":"127.0.0.1",
+            "port":9123,
+            "sendTGID":true}
+        }
+```
 
 
 ## talkgroupsFile

--- a/plugins/simplestream/CMakeLists.txt
+++ b/plugins/simplestream/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(simplestream
+MODULE
+  simplestream.cc
+)
+
+target_link_libraries(simplestream trunk_recorder_library ssl crypto ${CURL_LIBRARIES} ${Boost_LIBRARIES} ${GNURADIO_PMT_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_FILTER_LIBRARIES} ${GNURADIO_DIGITAL_LIBRARIES} ${GNURADIO_ANALOG_LIBRARIES} ${GNURADIO_AUDIO_LIBRARIES} ${GNURADIO_UHD_LIBRARIES} ${UHD_LIBRARIES} ${GNURADIO_BLOCKS_LIBRARIES} ${GNURADIO_OSMOSDR_LIBRARIES}  ${LIBOP25_REPEATER_LIBRARIES} gnuradio-op25_repeater) # gRPC::grpc++_reflection protobuf::libprotobuf)
+
+if(NOT Gnuradio_VERSION VERSION_LESS "3.8")
+
+    target_link_libraries(simplestream
+    gnuradio::gnuradio-analog
+    gnuradio::gnuradio-blocks
+    gnuradio::gnuradio-digital
+    gnuradio::gnuradio-filter
+    gnuradio::gnuradio-pmt
+    )  
+    
+endif()
+
+install(TARGETS simplestream LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/trunk-recorder)

--- a/plugins/simplestream/example_audio_player.py
+++ b/plugins/simplestream/example_audio_player.py
@@ -3,10 +3,10 @@ import struct
 import pyaudio
 import time
 
-TGID_in_stream = False
-TGID_to_play = 58916
-UDP_PORT = 9123
-AUDIO_OUTPUT_DEVICE_INDEX = 2
+TGID_in_stream = False         #When set to True, we expect a 4 byte long int with the TGID prior to the audio in each packet
+TGID_to_play = 58917           #When TGID_in_stream is set to True, we'll only play audio if the received TGID matches this value
+UDP_PORT = 9123                #UDP port to listen on
+AUDIO_OUTPUT_DEVICE_INDEX = 2  #Audio device to play received audio on
 
 # Set up a UDP server
 UDPSock = socket.socket(socket.AF_INET,socket.SOCK_DGRAM)
@@ -16,8 +16,8 @@ listen_addr = ("",UDP_PORT)
 UDPSock.bind(listen_addr)
 
 p = pyaudio.PyAudio()
-chunk = int(3456/4)
-FORMAT = pyaudio.paFloat32
+chunk = int(3456/2)
+FORMAT = pyaudio.paInt16
 CHANNELS = 1
 RATE = 8000
 stream = p.open(format = FORMAT,
@@ -30,7 +30,7 @@ stream = p.open(format = FORMAT,
 
 while True:
 		try:
-			data,addr = UDPSock.recvfrom(2048*4)
+			data,addr = UDPSock.recvfrom(2048*2)
 			if TGID_in_stream:
 				tgid = int.from_bytes(data[0:4],"little")
 				print(tgid," ",len(data))
@@ -38,6 +38,6 @@ while True:
 					stream.write(data[4:])
 			else:
 				stream.write(data)
-				print(len(data))
+				print(data)
 		except socket.timeout:
 			pass

--- a/plugins/simplestream/example_audio_player.py
+++ b/plugins/simplestream/example_audio_player.py
@@ -1,0 +1,43 @@
+import socket
+import struct
+import pyaudio
+import time
+
+TGID_in_stream = False
+TGID_to_play = 58916
+UDP_PORT = 9123
+AUDIO_OUTPUT_DEVICE_INDEX = 2
+
+# Set up a UDP server
+UDPSock = socket.socket(socket.AF_INET,socket.SOCK_DGRAM)
+UDPSock.settimeout(.2)
+
+listen_addr = ("",UDP_PORT)
+UDPSock.bind(listen_addr)
+
+p = pyaudio.PyAudio()
+chunk = int(3456/4)
+FORMAT = pyaudio.paFloat32
+CHANNELS = 1
+RATE = 8000
+stream = p.open(format = FORMAT,
+				channels = CHANNELS,
+				rate = RATE,
+				input = False,
+				output = True,
+				frames_per_buffer = chunk,
+				output_device_index = AUDIO_OUTPUT_DEVICE_INDEX,)
+
+while True:
+		try:
+			data,addr = UDPSock.recvfrom(2048*4)
+			if TGID_in_stream:
+				tgid = int.from_bytes(data[0:4],"little")
+				print(tgid," ",len(data))
+				if (tgid == TGID_to_play or TGID_to_play == 0):
+					stream.write(data[4:])
+			else:
+				stream.write(data)
+				print(len(data))
+		except socket.timeout:
+			pass

--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -1,0 +1,155 @@
+#include "../../trunk-recorder/plugin_manager/plugin_api.h"
+#include "../../trunk-recorder/recorders/recorder.h"
+#include <boost/dll/alias.hpp> // for BOOST_DLL_ALIAS
+#include <boost/foreach.hpp>
+#include <boost/asio.hpp>
+#include <map>
+
+
+/* TO DO
+- *add patch following support
+- *add option to prepend 2 byte TGID to audio data when sending
+- test sending multiple talkgroups to different ports
+- *test sending multiple talkgroups to the same port with prepended TGID info
+*/
+using namespace boost::asio;
+
+typedef struct plugin_t plugin_t;
+typedef struct stream_t stream_t;
+std::map<long,std::vector<long>> TGID_map;
+std::vector<stream_t> streams;
+
+struct plugin_t {
+  Config* config;
+};
+
+struct stream_t {
+  long TGID;
+  std::string address;
+  long port;
+  ip::udp::endpoint remote_endpoint;
+  bool sendTGID = false;
+};
+
+
+class Simple_Stream : public Plugin_Api {
+	typedef boost::asio::io_service io_service;
+    
+	io_service my_io_service;
+	ip::udp::endpoint remote_endpoint;
+	ip::udp::socket my_socket{my_io_service};
+	public:
+	
+	Simple_Stream(){
+		
+	}
+	
+	int call_start(Call *call) {
+		//BOOST_LOG_TRIVIAL(debug) << "call_start called in simplestream plugin" ;
+		long talkgroup_num = call->get_talkgroup();
+		std::vector<long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
+		//BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin for TGID "<< talkgroup_num << " with patch size " << patched_talkgroups.size();
+		if (patched_talkgroups.size() == 0){
+			patched_talkgroups.push_back(talkgroup_num);
+		}
+		//BOOST_LOG_TRIVIAL(debug) << "TGID is "<<talkgroup_num ;
+		Recorder *recorder = call->get_recorder();
+		if (recorder != NULL) {
+			int recorder_id = recorder->get_num();
+			TGID_map[recorder_id] = patched_talkgroups;
+			//BOOST_LOG_TRIVIAL(debug) << "Recorder num is "<<recorder_id ;
+		}
+		else {
+			//BOOST_LOG_TRIVIAL(debug) << "No Recorder for this TGID...doing nothing! ";
+		}
+		//BOOST_LOG_TRIVIAL(debug) << "made it to the end of call_start()" ;
+		return 0;
+	}
+	
+  int call_end(Call_Data_t call_info) {
+
+    long talkgroup_num = call_info.talkgroup;
+    std::vector<long> patched_talkgroups = call_info.patched_talkgroups;
+    std::vector<long> recorders_to_erase;
+    //BOOST_LOG_TRIVIAL(info) << "call_end called in simplestream plugin on TGID " << talkgroup_num << " with patch size " << patched_talkgroups.size() ;
+    BOOST_FOREACH(auto& element, TGID_map){
+      BOOST_FOREACH(auto& mapped_TGID, element.second) {
+        //BOOST_LOG_TRIVIAL(info) << "TGID_map[" << element.first << "] contains " << mapped_TGID;
+        if (mapped_TGID == talkgroup_num){
+          recorders_to_erase.push_back(element.first);
+          //BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";
+        }
+        BOOST_FOREACH(auto& TGID, patched_talkgroups){
+          if (mapped_TGID == TGID){
+            recorders_to_erase.push_back(element.first);
+            //BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";
+          }
+        }
+      }
+    }
+    BOOST_FOREACH(auto& recorder_id, recorders_to_erase){
+      //BOOST_LOG_TRIVIAL(info) << "erasing recorder " << recorder_id << " from TGID_Map";
+      TGID_map.erase(recorder_id);
+    }
+    return 0;
+  }
+
+  int parse_config(boost::property_tree::ptree &cfg) {
+    BOOST_FOREACH (boost::property_tree::ptree::value_type &node, cfg.get_child("streams")) {
+      stream_t stream;
+      stream.TGID = node.second.get<long>("TGID");
+      stream.address = node.second.get<std::string>("address");
+      stream.port = node.second.get<long>("port");
+      stream.remote_endpoint = ip::udp::endpoint(ip::address::from_string(stream.address), stream.port);
+      stream.sendTGID = node.second.get<bool>("sendTGID");
+      BOOST_LOG_TRIVIAL(info) << "simplestreamer will stream audio from TGID " <<stream.TGID << " to " << stream.address <<" on port " << stream.port;
+      streams.push_back(stream);
+    }
+    return 0;
+  }
+  
+  int audio_stream(Recorder *recorder, float *samples, int sampleCount){
+    int recorder_id = recorder->get_num();
+    BOOST_FOREACH (auto& stream, streams){
+      BOOST_FOREACH (auto& TGID, TGID_map[recorder_id]){
+        if (TGID==stream.TGID || stream.TGID==0){  //setting TGID to 0 in the config file will stream everything
+          boost::system::error_code err;
+          BOOST_LOG_TRIVIAL(debug) << "got " <<sampleCount <<" samples - " <<sampleCount*4<<" bytes";
+          if (stream.sendTGID==true){
+            //prepend 4 byte long tgid to the audio data
+            boost::array<mutable_buffer, 2> buf1 = {
+              buffer(&TGID,4),
+              buffer(samples, sampleCount*4)
+            };
+            my_socket.send_to(buf1, stream.remote_endpoint, 0, err);
+          }
+          else{
+            //just send the audio data
+            my_socket.send_to(buffer(samples, sampleCount*4), stream.remote_endpoint, 0, err);
+          }
+        }
+      }
+    }
+    return 0;
+  }
+  
+  int start(){
+	my_socket.open(ip::udp::v4());
+	return 0;
+  }
+  
+  int stop(){
+	  my_socket.close();
+	  return 0;
+  }
+
+  static boost::shared_ptr<Simple_Stream> create() {
+    return boost::shared_ptr<Simple_Stream>(
+        new Simple_Stream());
+  }
+};
+
+BOOST_DLL_ALIAS(
+    Simple_Stream::create, // <-- this function is exported with...
+    create_plugin             // <-- ...this alias name
+)

--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -101,24 +101,24 @@ class Simple_Stream : public Plugin_Api {
     return 0;
   }
   
-  int audio_stream(Recorder *recorder, float *samples, int sampleCount){
+  int audio_stream(Recorder *recorder, int16_t *samples, int sampleCount){
     int recorder_id = recorder->get_num();
     BOOST_FOREACH (auto& stream, streams){
       BOOST_FOREACH (auto& TGID, TGID_map[recorder_id]){
         if (TGID==stream.TGID || stream.TGID==0){  //setting TGID to 0 in the config file will stream everything
           boost::system::error_code err;
-          BOOST_LOG_TRIVIAL(debug) << "got " <<sampleCount <<" samples - " <<sampleCount*4<<" bytes";
+          BOOST_LOG_TRIVIAL(debug) << "got " <<sampleCount <<" samples - " <<sampleCount*2<<" bytes";
           if (stream.sendTGID==true){
             //prepend 4 byte long tgid to the audio data
             boost::array<mutable_buffer, 2> buf1 = {
               buffer(&TGID,4),
-              buffer(samples, sampleCount*4)
+              buffer(samples, sampleCount*2)
             };
             my_socket.send_to(buf1, stream.remote_endpoint, 0, err);
           }
           else{
             //just send the audio data
-            my_socket.send_to(buffer(samples, sampleCount*4), stream.remote_endpoint, 0, err);
+            my_socket.send_to(buffer(samples, sampleCount*2), stream.remote_endpoint, 0, err);
           }
         }
       }

--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -5,13 +5,6 @@
 #include <boost/asio.hpp>
 #include <map>
 
-
-/* TO DO
-- *add patch following support
-- *add option to prepend 2 byte TGID to audio data when sending
-- test sending multiple talkgroups to different ports
-- *test sending multiple talkgroups to the same port with prepended TGID info
-*/
 using namespace boost::asio;
 
 typedef struct plugin_t plugin_t;


### PR DESCRIPTION
Plugin to stream raw uncompressed audio from all or specified talkgroups being recorded via one or more UDP ports.  Allows other downstream programs to play audio in real time or to compress and send to streaming services.