### PR TITLE
Correct the squelch key for squelch_eob

### DIFF
--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
@@ -317,7 +317,7 @@ int nonstop_wavfile_sink_impl::work(int noutput_items, gr_vector_const_void_star
   std::vector<gr::tag_t> tags;
   pmt::pmt_t this_key(pmt::intern("src_id"));
   pmt::pmt_t that_key(pmt::intern("terminate"));
-  pmt::pmt_t squelch_key(pmt::intern("squelch:eob"));
+  pmt::pmt_t squelch_key(pmt::intern("squelch_eob"));
   get_tags_in_range(tags, 0, nitems_read(0), nitems_read(0) + noutput_items);
 
   unsigned pos = 0;


### PR DESCRIPTION
Since I was investigating other squelch-related stuff for #318 and #570, this looks to be a typo and will not be found by the nonstop_wavfile_sink.

While the documentation for pwr_squelch does say:
> The block will emit a tag with the key pmt::intern("squelch_sob") with the value of pmt::PMT_NIL on the first item it passes, and with the key pmt::intern("squelch:eob") on the last item it passes.

It appears to be in error, as the underlying squelch_base passes `squelch_eob` upon closing, not `squelch:eob`.

https://github.com/gnuradio/gnuradio/blob/a2a682518fab2a91b5b4628586568f2e1cf1b65b/gr-analog/lib/squelch_base_ff_impl.cc#L27-L28