### PR TITLE
Update main.cc - fix for segfault on conventional systems

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1196,7 +1196,9 @@ void monitor_messages() {
     if (timeDiff >= 3.0) {
       check_message_count(timeDiff);
       lastMsgCountTime = current_time;
-      sys->clear_stale_talkgroup_patches();
+      if (sys->get_system_type()=="p25"){
+        sys->clear_stale_talkgroup_patches();
+      }
     }
 
     float statusTimeDiff = current_time - lastStatusTime;


### PR DESCRIPTION
In a conventional system the sys object isn't initialized since a control channel message is never received, leading to a segfault when the clear_stale_talkgroup_patches() function gets called and gets passed an empty System object.  This check prevents calling the function unless the system type is known as p25, which means by definition that it's not empty.