### PR TITLE
Talkgroup patching priority fix

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -602,10 +602,11 @@ void process_signal(long unitId, const char *signaling_type, gr::blocks::SignalT
 
 bool start_recorder(Call *call, TrunkMessage message, System *sys) {
   Talkgroup *talkgroup = sys->find_talkgroup(call->get_talkgroup());
+  int priority = 100;
   BOOST_FOREACH (auto& TGID, sys->get_talkgroup_patch(call->get_talkgroup())) {
     if (sys->find_talkgroup(TGID)->get_priority() < talkgroup->get_priority()){
-      talkgroup->set_priority(sys->find_talkgroup(TGID)->get_priority());
-      BOOST_LOG_TRIVIAL(info) << "Increased priority of talkgroup " << call->get_talkgroup() << " to " << sys->find_talkgroup(TGID)->get_priority() << " due to active patch with talkgroup " << TGID;
+      priority = sys->find_talkgroup(TGID)->get_priority();
+      BOOST_LOG_TRIVIAL(info) << "Temporarily increased priority of talkgroup " << call->get_talkgroup() << " to " << sys->find_talkgroup(TGID)->get_priority() << " due to active patch with talkgroup " << TGID;
     }
   }
   bool source_found = false;
@@ -645,7 +646,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
         if (talkgroup->mode.compare("A") == 0) {
           recorder = source->get_analog_recorder(talkgroup);
         } else {
-          recorder = source->get_digital_recorder(talkgroup);
+          recorder = source->get_digital_recorder(talkgroup, priority);
         }
       } else {
         BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\t\033[0;34m" << call->get_call_num() << "C\033[0m\tTG: " << call->get_talkgroup_display() << "\tFreq: " << format_freq(call->get_freq()) << "\tTG not in Talkgroup File ";

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -602,9 +602,9 @@ void process_signal(long unitId, const char *signaling_type, gr::blocks::SignalT
 
 bool start_recorder(Call *call, TrunkMessage message, System *sys) {
   Talkgroup *talkgroup = sys->find_talkgroup(call->get_talkgroup());
-  int priority = 100;
+  int priority = talkgroup->get_priority();
   BOOST_FOREACH (auto& TGID, sys->get_talkgroup_patch(call->get_talkgroup())) {
-    if (sys->find_talkgroup(TGID)->get_priority() < talkgroup->get_priority()){
+    if (sys->find_talkgroup(TGID)->get_priority() < priority){
       priority = sys->find_talkgroup(TGID)->get_priority();
       BOOST_LOG_TRIVIAL(info) << "Temporarily increased priority of talkgroup " << call->get_talkgroup() << " to " << sys->find_talkgroup(TGID)->get_priority() << " due to active patch with talkgroup " << TGID;
     }

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -325,12 +325,12 @@ int Source::get_num_available_analog_recorders() {
   return num_available_recorders;
 }
 
-Recorder *Source::get_digital_recorder(Talkgroup *talkgroup) {
+Recorder *Source::get_digital_recorder(Talkgroup *talkgroup, int priority) {
   int num_available_recorders = get_num_available_digital_recorders();
 
-  if (talkgroup && talkgroup->get_priority() > num_available_recorders) { // a low priority is bad. You need atleast the number of availalbe recorders to your priority
+  if (talkgroup && priority > num_available_recorders) { // a low priority is bad. You need atleast the number of availalbe recorders to your priority
     BOOST_LOG_TRIVIAL(info) << "\t\tNot recording talkgroup " << talkgroup->number << " (" << talkgroup->alpha_tag << ")" << ", priority is " <<
-      talkgroup->get_priority() << " but only " << num_available_recorders << " recorders available";
+      priority << " but only " << num_available_recorders << " recorders available";
     return NULL;
   }
 

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -115,7 +115,7 @@ public:
   void create_digital_recorders(gr::top_block_sptr tb, int r);
   p25_recorder_sptr create_digital_conventional_recorder(gr::top_block_sptr tb);
   Recorder *get_digital_recorder();
-  Recorder *get_digital_recorder(Talkgroup *talkgroup);
+  Recorder *get_digital_recorder(Talkgroup *talkgroup, int priority);
   void create_debug_recorder(gr::top_block_sptr tb, int source_num);
   Recorder *get_debug_recorder();
   void create_sigmf_recorders(gr::top_block_sptr tb, int r);


### PR DESCRIPTION
Prevent priority increases from talkgroup patching from being permanently stored in the System->Talkgroup objects