### PR TITLE
Update talk group patches to use unsigned long throughout the app.

### DIFF
--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -9,7 +9,7 @@ using namespace boost::asio;
 
 typedef struct plugin_t plugin_t;
 typedef struct stream_t stream_t;
-std::map<unsigned long,std::vector<long>> TGID_map;
+std::map<unsigned long,std::vector<unsigned long>> TGID_map;
 std::vector<stream_t> streams;
 
 struct plugin_t {

--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -9,7 +9,7 @@ using namespace boost::asio;
 
 typedef struct plugin_t plugin_t;
 typedef struct stream_t stream_t;
-std::map<long,std::vector<long>> TGID_map;
+std::map<unsigned long,std::vector<long>> TGID_map;
 std::vector<stream_t> streams;
 
 struct plugin_t {
@@ -17,7 +17,7 @@ struct plugin_t {
 };
 
 struct stream_t {
-  long TGID;
+  unsigned long TGID;
   std::string address;
   long port;
   ip::udp::endpoint remote_endpoint;
@@ -39,8 +39,8 @@ class Simple_Stream : public Plugin_Api {
 	
 	int call_start(Call *call) {
 		//BOOST_LOG_TRIVIAL(debug) << "call_start called in simplestream plugin" ;
-		long talkgroup_num = call->get_talkgroup();
-		std::vector<long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
+		unsigned long talkgroup_num = call->get_talkgroup();
+		std::vector<unsigned long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
 		//BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin for TGID "<< talkgroup_num << " with patch size " << patched_talkgroups.size();
 		if (patched_talkgroups.size() == 0){
 			patched_talkgroups.push_back(talkgroup_num);
@@ -61,8 +61,8 @@ class Simple_Stream : public Plugin_Api {
 	
   int call_end(Call_Data_t call_info) {
 
-    long talkgroup_num = call_info.talkgroup;
-    std::vector<long> patched_talkgroups = call_info.patched_talkgroups;
+    unsigned long talkgroup_num = call_info.talkgroup;
+    std::vector<unsigned long> patched_talkgroups = call_info.patched_talkgroups;
     std::vector<long> recorders_to_erase;
     //BOOST_LOG_TRIVIAL(info) << "call_end called in simplestream plugin on TGID " << talkgroup_num << " with patch size " << patched_talkgroups.size() ;
     BOOST_FOREACH(auto& element, TGID_map){
@@ -90,7 +90,7 @@ class Simple_Stream : public Plugin_Api {
   int parse_config(boost::property_tree::ptree &cfg) {
     BOOST_FOREACH (boost::property_tree::ptree::value_type &node, cfg.get_child("streams")) {
       stream_t stream;
-      stream.TGID = node.second.get<long>("TGID");
+      stream.TGID = node.second.get<unsigned long>("TGID");
       stream.address = node.second.get<std::string>("address");
       stream.port = node.second.get<long>("port");
       stream.remote_endpoint = ip::udp::endpoint(ip::address::from_string(stream.address), stream.port);

--- a/plugins/unit_script/unit_script.cc
+++ b/plugins/unit_script/unit_script.cc
@@ -63,7 +63,7 @@ int unit_group_affiliation(System *sys, long source_id, long talkgroup_num) {
     std::string system_script = get_system_script(sys->get_short_name());
   if ((system_script != "") && (source_id != 0)) {
     char shell_command[200];
-    std::vector<long> talkgroup_patches = sys->get_talkgroup_patch(talkgroup_num);
+    std::vector<unsigned long> talkgroup_patches = sys->get_talkgroup_patch(talkgroup_num);
     std::string patch_string;
     bool first = true;
     BOOST_FOREACH (auto& TGID, talkgroup_patches) {
@@ -85,7 +85,7 @@ int call_start(Call *call) {
     std::string system_script = get_system_script(short_name);
   if ((system_script != "") && (source_id != 0)) {
     char shell_command[200];
-    std::vector<long> talkgroup_patches = call->get_system()->get_talkgroup_patch(talkgroup_num);
+    std::vector<unsigned long> talkgroup_patches = call->get_system()->get_talkgroup_patch(talkgroup_num);
     std::string patch_string;
     bool first = true;
     BOOST_FOREACH (auto& TGID, talkgroup_patches) {

--- a/trunk-recorder/call_concluder/call_concluder.h
+++ b/trunk-recorder/call_concluder/call_concluder.h
@@ -23,7 +23,7 @@ class Uploader;
 enum Call_Data_Status { INITIAL, SUCCESS, RETRY, FAILED };
 struct Call_Data_t {
   long talkgroup;
-  std::vector<long> patched_talkgroups;
+  std::vector<unsigned long> patched_talkgroups;
   long call_num;
   double freq;
   long start_time;

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -484,7 +484,7 @@ void System::update_active_talkgroup_patches(TrunkMessage message){
   if (new_flag == true){
     //TGIDs from the Message were not found in an existing patch, so add them to a new one
     //BOOST_LOG_TRIVIAL(debug) << "Adding a new patch";
-    std::map<long,std::time_t> new_patch;
+    std::map<unsigned long,std::time_t> new_patch;
     new_patch[message.moto_patch_data.sg] = update_time;
     new_patch[message.moto_patch_data.ga1] = update_time;
     new_patch[message.moto_patch_data.ga2] = update_time;

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -453,9 +453,9 @@ boost::property_tree::ptree System::get_stats_current(float timeDiff) {
   return system_node;
 }
 
-std::vector<long> System::get_talkgroup_patch(long talkgroup){
+std::vector<unsigned long> System::get_talkgroup_patch(unsigned long talkgroup){
   //Given a single TGID, return a vector of TGIDs that are part of the same patch
-  std::vector<long> patched_tgids;
+  std::vector<unsigned long> patched_tgids;
   BOOST_FOREACH (auto& patch, talkgroup_patches) {
     if (patch.second.find(talkgroup) != patch.second.end()) {
       //talkgroup passed in is part of this patch, so add all talkgroups from this patch to our output vector
@@ -494,11 +494,11 @@ void System::update_active_talkgroup_patches(TrunkMessage message){
 }
 
 void System::clear_stale_talkgroup_patches(){
-  std::vector<long> stale_patches;
+  std::vector<unsigned long> stale_patches;
 
   BOOST_FOREACH (auto& patch, talkgroup_patches) {
     //patch.first (map key) is supergroup TGID, patch.second (map value) is the map of all TGIDs in this patch and associated timestamps
-    std::vector<long> stale_talkgroups;
+    std::vector<unsigned long> stale_talkgroups;
     BOOST_FOREACH(auto& patch_element, patch.second){
       //patch_element.first (map key) is TGID, patch.second (map value) is the timestamp
       if (std::time(nullptr) - patch_element.second >= 10){  //10 second hard coded timeout for now

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -101,7 +101,7 @@ public:
   smartnet_trunking_sptr smartnet_trunking;
   p25_trunking_sptr p25_trunking;
   
-  std::map<long,std::map<long,std::time_t>> talkgroup_patches;
+  std::map<unsigned long,std::map<unsigned long,std::time_t>> talkgroup_patches;
 
   std::string get_short_name();
   void set_short_name(std::string short_name);
@@ -211,7 +211,7 @@ public:
   
   //std::vector<std::map<int,std::time_t>> get_active_talkgroup_patches();
   //void set_active_talkgroup_patches(std::vector<std::map<int,std::time_t>> updated_talkgroup_patches);
-  std::vector<long> get_talkgroup_patch(long talkgroup);
+  std::vector<unsigned long> get_talkgroup_patch(unsigned long talkgroup);
   void update_active_talkgroup_patches(TrunkMessage message);
   void clear_stale_talkgroup_patches();
 


### PR DESCRIPTION
P25_parser.cc was writing talk goups using unsigned long data types, and most of the patch tracking was using signed long data types. This could lead to unexpected results.