### PR TITLE
simplestream plugin segfault fix, update_active_talkgroup_patches() change

### DIFF
--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -9,8 +9,9 @@ using namespace boost::asio;
 
 typedef struct plugin_t plugin_t;
 typedef struct stream_t stream_t;
-std::map<long,std::vector<long>> TGID_map;
+std::map<long,std::vector<long>> TGID_map;  //recorder ID, list of TGIDs being recorded by that recorder
 std::vector<stream_t> streams;
+std::mutex TGID_map_mutex;
 
 struct plugin_t {
   Config* config;
@@ -26,63 +27,69 @@ struct stream_t {
 
 
 class Simple_Stream : public Plugin_Api {
-	typedef boost::asio::io_service io_service;
+  typedef boost::asio::io_service io_service;
+  
+  io_service my_io_service;
+  ip::udp::endpoint remote_endpoint;
+  ip::udp::socket my_socket{my_io_service};
+  public:
+  
+  Simple_Stream(){
+      
+  }
     
-	io_service my_io_service;
-	ip::udp::endpoint remote_endpoint;
-	ip::udp::socket my_socket{my_io_service};
-	public:
-	
-	Simple_Stream(){
-		
-	}
-	
-	int call_start(Call *call) {
-		//BOOST_LOG_TRIVIAL(debug) << "call_start called in simplestream plugin" ;
-		long talkgroup_num = call->get_talkgroup();
-		std::vector<long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
-		//BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin for TGID "<< talkgroup_num << " with patch size " << patched_talkgroups.size();
-		if (patched_talkgroups.size() == 0){
-			patched_talkgroups.push_back(talkgroup_num);
-		}
-		//BOOST_LOG_TRIVIAL(debug) << "TGID is "<<talkgroup_num ;
-		Recorder *recorder = call->get_recorder();
-		if (recorder != NULL) {
-			int recorder_id = recorder->get_num();
-			TGID_map[recorder_id] = patched_talkgroups;
-			//BOOST_LOG_TRIVIAL(debug) << "Recorder num is "<<recorder_id ;
-		}
-		else {
-			//BOOST_LOG_TRIVIAL(debug) << "No Recorder for this TGID...doing nothing! ";
-		}
-		//BOOST_LOG_TRIVIAL(debug) << "made it to the end of call_start()" ;
-		return 0;
-	}
-	
+  int call_start(Call *call) {
+    BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin" ;
+    long talkgroup_num = call->get_talkgroup();
+    std::vector<long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
+    BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin for TGID "<< talkgroup_num << " with patch size " << patched_talkgroups.size();
+    if (patched_talkgroups.size() == 0){
+      patched_talkgroups.push_back(talkgroup_num);
+    }
+    BOOST_LOG_TRIVIAL(info) << "TGID is "<<talkgroup_num ;
+    Recorder *recorder = call->get_recorder();
+    if (recorder != NULL) {
+      int recorder_id = recorder->get_num();
+      TGID_map_mutex.lock();
+      TGID_map[recorder_id] = patched_talkgroups;
+      TGID_map_mutex.unlock();
+      BOOST_LOG_TRIVIAL(info) << "Recorder num is "<<recorder_id ;
+    }
+    else {
+      BOOST_LOG_TRIVIAL(info) << "No Recorder for this TGID...doing nothing! ";
+    }
+    //BOOST_LOG_TRIVIAL(debug) << "made it to the end of call_start()" ;
+    return 0;
+  }
+    
   int call_end(Call_Data_t call_info) {
 
     long talkgroup_num = call_info.talkgroup;
     std::vector<long> patched_talkgroups = call_info.patched_talkgroups;
     std::vector<long> recorders_to_erase;
-    //BOOST_LOG_TRIVIAL(info) << "call_end called in simplestream plugin on TGID " << talkgroup_num << " with patch size " << patched_talkgroups.size() ;
+    BOOST_LOG_TRIVIAL(info) << "call_end called in simplestream plugin on TGID " << talkgroup_num << " with patch size " << patched_talkgroups.size() ;
+    TGID_map_mutex.lock();  //Need to lock during this entire loop to prevent another thread from modifying TGID_map while we are iterating
     BOOST_FOREACH(auto& element, TGID_map){
-      BOOST_FOREACH(auto& mapped_TGID, element.second) {
-        //BOOST_LOG_TRIVIAL(info) << "TGID_map[" << element.first << "] contains " << mapped_TGID;
+      BOOST_FOREACH(long mapped_TGID, element.second) {
+        BOOST_LOG_TRIVIAL(info) << "TGID_map[" << element.first << "] contains " << mapped_TGID;
         if (mapped_TGID == talkgroup_num){
           recorders_to_erase.push_back(element.first);
-          //BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";
+          BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";
         }
-        BOOST_FOREACH(auto& TGID, patched_talkgroups){
+        BOOST_FOREACH(long TGID, patched_talkgroups){
           if (mapped_TGID == TGID){
             recorders_to_erase.push_back(element.first);
-            //BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";
+            BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";
           }
         }
       }
     }
-    BOOST_FOREACH(auto& recorder_id, recorders_to_erase){
-      //BOOST_LOG_TRIVIAL(info) << "erasing recorder " << recorder_id << " from TGID_Map";
+    TGID_map_mutex.unlock();
+    BOOST_FOREACH(long recorder_id, recorders_to_erase){
+      BOOST_LOG_TRIVIAL(info) << "erasing recorder " << recorder_id << " from TGID_Map";
+      TGID_map_mutex.lock();
       TGID_map.erase(recorder_id);
+      TGID_map_mutex.unlock();
     }
     return 0;
   }

--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -40,8 +40,8 @@ class Simple_Stream : public Plugin_Api {
     
   int call_start(Call *call) {
     BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin" ;
-    long talkgroup_num = call->get_talkgroup();
-    std::vector<long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
+    unsigned long talkgroup_num = call->get_talkgroup();
+    std::vector<unsigned long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
     BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin for TGID "<< talkgroup_num << " with patch size " << patched_talkgroups.size();
     if (patched_talkgroups.size() == 0){
       patched_talkgroups.push_back(talkgroup_num);
@@ -50,10 +50,10 @@ class Simple_Stream : public Plugin_Api {
     Recorder *recorder = call->get_recorder();
     if (recorder != NULL) {
       int recorder_id = recorder->get_num();
+      BOOST_LOG_TRIVIAL(info) << "Recorder num is "<<recorder_id ;
       TGID_map_mutex.lock();
       TGID_map[recorder_id] = patched_talkgroups;
       TGID_map_mutex.unlock();
-      BOOST_LOG_TRIVIAL(info) << "Recorder num is "<<recorder_id ;
     }
     else {
       BOOST_LOG_TRIVIAL(info) << "No Recorder for this TGID...doing nothing! ";
@@ -62,38 +62,6 @@ class Simple_Stream : public Plugin_Api {
     return 0;
   }
     
-	io_service my_io_service;
-	ip::udp::endpoint remote_endpoint;
-	ip::udp::socket my_socket{my_io_service};
-	public:
-	
-	Simple_Stream(){
-		
-	}
-	
-	int call_start(Call *call) {
-		//BOOST_LOG_TRIVIAL(debug) << "call_start called in simplestream plugin" ;
-		unsigned long talkgroup_num = call->get_talkgroup();
-		std::vector<unsigned long> patched_talkgroups = call->get_system()->get_talkgroup_patch(talkgroup_num);
-		//BOOST_LOG_TRIVIAL(info) << "call_start called in simplestream plugin for TGID "<< talkgroup_num << " with patch size " << patched_talkgroups.size();
-		if (patched_talkgroups.size() == 0){
-			patched_talkgroups.push_back(talkgroup_num);
-		}
-		//BOOST_LOG_TRIVIAL(debug) << "TGID is "<<talkgroup_num ;
-		Recorder *recorder = call->get_recorder();
-		if (recorder != NULL) {
-			int recorder_id = recorder->get_num();
-			TGID_map[recorder_id] = patched_talkgroups;
-			//BOOST_LOG_TRIVIAL(debug) << "Recorder num is "<<recorder_id ;
-		}
-		else {
-			//BOOST_LOG_TRIVIAL(debug) << "No Recorder for this TGID...doing nothing! ";
-		}
-		//BOOST_LOG_TRIVIAL(debug) << "made it to the end of call_start()" ;
-		return 0;
-	}
-	
->>>>>>> 43fce531ff87419064dc657c1f1f5b37dc745b92
   int call_end(Call_Data_t call_info) {
 
     unsigned long talkgroup_num = call_info.talkgroup;
@@ -102,13 +70,13 @@ class Simple_Stream : public Plugin_Api {
     BOOST_LOG_TRIVIAL(info) << "call_end called in simplestream plugin on TGID " << talkgroup_num << " with patch size " << patched_talkgroups.size() ;
     TGID_map_mutex.lock();  //Need to lock during this entire loop to prevent another thread from modifying TGID_map while we are iterating
     BOOST_FOREACH(auto& element, TGID_map){
-      BOOST_FOREACH(long mapped_TGID, element.second) {
+      BOOST_FOREACH(unsigned long mapped_TGID, element.second) {
         BOOST_LOG_TRIVIAL(info) << "TGID_map[" << element.first << "] contains " << mapped_TGID;
         if (mapped_TGID == talkgroup_num){
           recorders_to_erase.push_back(element.first);
           BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";
         }
-        BOOST_FOREACH(long TGID, patched_talkgroups){
+        BOOST_FOREACH(unsigned long TGID, patched_talkgroups){
           if (mapped_TGID == TGID){
             recorders_to_erase.push_back(element.first);
             BOOST_LOG_TRIVIAL(info) << "adding recorder " << element.first << " to erase list";

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1007,7 +1007,7 @@ void handle_message(std::vector<TrunkMessage> messages, System *sys) {
 
     case MOTO_PATCH_ADD:
       //update_patches(message, sys);
-      sys->update_active_talkgroup_patches(message);
+      sys->update_active_talkgroup_patches(message.moto_patch_data);
       break;
     case UNKNOWN:
       break;

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -19,10 +19,10 @@ enum MessageType {
 };
 
 struct MotoPatchData {
-  unsigned long sg;
-  unsigned long ga1;
-  unsigned long ga2;
-  unsigned long ga3;
+  long sg;
+  long ga1;
+  long ga2;
+  long ga3;
 };
 
 struct TrunkMessage {

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -19,10 +19,10 @@ enum MessageType {
 };
 
 struct MotoPatchData {
-  long sg;
-  long ga1;
-  long ga2;
-  long ga3;
+  unsigned long sg;
+  unsigned long ga1;
+  unsigned long ga2;
+  unsigned long ga3;
 };
 
 struct TrunkMessage {

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -456,28 +456,28 @@ boost::property_tree::ptree System::get_stats_current(float timeDiff) {
 std::vector<long> System::get_talkgroup_patch(long talkgroup){
   //Given a single TGID, return a vector of TGIDs that are part of the same patch
   std::vector<long> patched_tgids;
-  BOOST_FOREACH (auto& patch, talkgroup_patches) {
+  BOOST_FOREACH (auto& patch, talkgroup_patches) {  //talkgroup_patches:  map<long sg,std::map<long tgid,std::time_t timestamp>>
     if (patch.second.find(talkgroup) != patch.second.end()) {
       //talkgroup passed in is part of this patch, so add all talkgroups from this patch to our output vector
-      BOOST_FOREACH(auto& patch_element, patch.second){
-        patched_tgids.push_back(patch_element.first);
+      BOOST_FOREACH(auto& patch_element, patch.second){  //patch.second:  std::map<long tgid,std::time_t timestamp>
+        patched_tgids.push_back(patch_element.first);    //patch_element.first: long tgid
       }
     }
   }
   return patched_tgids;
 }
 
-void System::update_active_talkgroup_patches(TrunkMessage message){
+void System::update_active_talkgroup_patches(MotoPatchData moto_patch_data){
   std::time_t update_time = std::time(nullptr);
   bool new_flag = true;
 
   BOOST_FOREACH (auto& patch, talkgroup_patches) {
-    if (patch.first == message.moto_patch_data.sg){
+    if (patch.first == moto_patch_data.sg){
       new_flag = false;
-      patch.second[message.moto_patch_data.sg] = update_time;
-      patch.second[message.moto_patch_data.ga1] = update_time;
-      patch.second[message.moto_patch_data.ga2] = update_time;
-      patch.second[message.moto_patch_data.ga3] = update_time;
+      patch.second[moto_patch_data.sg] = update_time;
+      patch.second[moto_patch_data.ga1] = update_time;
+      patch.second[moto_patch_data.ga2] = update_time;
+      patch.second[moto_patch_data.ga3] = update_time;
     }
     //Can add another IF statement here to handle Harris patch messages
   }
@@ -485,11 +485,11 @@ void System::update_active_talkgroup_patches(TrunkMessage message){
     //TGIDs from the Message were not found in an existing patch, so add them to a new one
     //BOOST_LOG_TRIVIAL(debug) << "Adding a new patch";
     std::map<long,std::time_t> new_patch;
-    new_patch[message.moto_patch_data.sg] = update_time;
-    new_patch[message.moto_patch_data.ga1] = update_time;
-    new_patch[message.moto_patch_data.ga2] = update_time;
-    new_patch[message.moto_patch_data.ga3] = update_time;
-    talkgroup_patches[message.moto_patch_data.sg] = new_patch;
+    new_patch[moto_patch_data.sg] = update_time;
+    new_patch[moto_patch_data.ga1] = update_time;
+    new_patch[moto_patch_data.ga2] = update_time;
+    new_patch[moto_patch_data.ga3] = update_time;
+    talkgroup_patches[moto_patch_data.sg] = new_patch;
   }
 }
 
@@ -506,7 +506,7 @@ void System::clear_stale_talkgroup_patches(){
       }
     }
     BOOST_FOREACH(auto& stale_talkgroup, stale_talkgroups){
-      BOOST_LOG_TRIVIAL(debug) << "Going to remove stale TGID " << stale_talkgroup << "from patch wigh sg id " << patch.first;
+      BOOST_LOG_TRIVIAL(info) << "Going to remove stale TGID " << stale_talkgroup << "from patch wigh sg id " << patch.first;
       patch.second.erase(stale_talkgroup);
     }
     if (patch.second.size() == 0){
@@ -514,18 +514,18 @@ void System::clear_stale_talkgroup_patches(){
     }
   }
   BOOST_FOREACH(auto& stale_patch, stale_patches){
-    BOOST_LOG_TRIVIAL(debug) << "Going to remove entire patch with sg id " << stale_patch;
+    BOOST_LOG_TRIVIAL(info) << "Going to remove entire patch with sg id " << stale_patch;
     talkgroup_patches.erase(stale_patch);
   }
   
   //Print out all active patches to the console
-  BOOST_LOG_TRIVIAL(debug) << "Found " << talkgroup_patches.size() << " active talkgroup patches:";
+  BOOST_LOG_TRIVIAL(info) << "Found " << talkgroup_patches.size() << " active talkgroup patches:";
   BOOST_FOREACH (auto& patch, talkgroup_patches) {
     std::string printstring;
     BOOST_FOREACH(auto& patch_element, patch.second){
       printstring+=" ";
       printstring+= std::to_string(patch_element.first);
     }
-    BOOST_LOG_TRIVIAL(debug) << "Active Patch of TGIDs" << printstring;
+    BOOST_LOG_TRIVIAL(info) << "Active Patch of TGIDs" << printstring;
   }
 }

--- a/trunk-recorder/systems/system.cc
+++ b/trunk-recorder/systems/system.cc
@@ -456,11 +456,11 @@ boost::property_tree::ptree System::get_stats_current(float timeDiff) {
 std::vector<unsigned long> System::get_talkgroup_patch(unsigned long talkgroup){
   //Given a single TGID, return a vector of TGIDs that are part of the same patch
   std::vector<unsigned long> patched_tgids;
-  BOOST_FOREACH (auto& patch, talkgroup_patches) {  //talkgroup_patches:  map<long sg,std::map<long tgid,std::time_t timestamp>>
+  BOOST_FOREACH (auto& patch, talkgroup_patches) {
     if (patch.second.find(talkgroup) != patch.second.end()) {
       //talkgroup passed in is part of this patch, so add all talkgroups from this patch to our output vector
-      BOOST_FOREACH(auto& patch_element, patch.second){  //patch.second:  std::map<long tgid,std::time_t timestamp>
-        patched_tgids.push_back(patch_element.first);    //patch_element.first: long tgid
+      BOOST_FOREACH(auto& patch_element, patch.second){
+        patched_tgids.push_back(patch_element.first);
       }
     }
   }
@@ -506,7 +506,7 @@ void System::clear_stale_talkgroup_patches(){
       }
     }
     BOOST_FOREACH(auto& stale_talkgroup, stale_talkgroups){
-      BOOST_LOG_TRIVIAL(info) << "Going to remove stale TGID " << stale_talkgroup << "from patch wigh sg id " << patch.first;
+      BOOST_LOG_TRIVIAL(debug) << "Going to remove stale TGID " << stale_talkgroup << "from patch wigh sg id " << patch.first;
       patch.second.erase(stale_talkgroup);
     }
     if (patch.second.size() == 0){
@@ -514,18 +514,18 @@ void System::clear_stale_talkgroup_patches(){
     }
   }
   BOOST_FOREACH(auto& stale_patch, stale_patches){
-    BOOST_LOG_TRIVIAL(info) << "Going to remove entire patch with sg id " << stale_patch;
+    BOOST_LOG_TRIVIAL(debug) << "Going to remove entire patch with sg id " << stale_patch;
     talkgroup_patches.erase(stale_patch);
   }
   
   //Print out all active patches to the console
-  BOOST_LOG_TRIVIAL(info) << "Found " << talkgroup_patches.size() << " active talkgroup patches:";
+  BOOST_LOG_TRIVIAL(debug) << "Found " << talkgroup_patches.size() << " active talkgroup patches:";
   BOOST_FOREACH (auto& patch, talkgroup_patches) {
     std::string printstring;
     BOOST_FOREACH(auto& patch_element, patch.second){
       printstring+=" ";
       printstring+= std::to_string(patch_element.first);
     }
-    BOOST_LOG_TRIVIAL(info) << "Active Patch of TGIDs" << printstring;
+    BOOST_LOG_TRIVIAL(debug) << "Active Patch of TGIDs" << printstring;
   }
 }

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -212,7 +212,7 @@ public:
   //std::vector<std::map<int,std::time_t>> get_active_talkgroup_patches();
   //void set_active_talkgroup_patches(std::vector<std::map<int,std::time_t>> updated_talkgroup_patches);
   std::vector<long> get_talkgroup_patch(long talkgroup);
-  void update_active_talkgroup_patches(TrunkMessage message);
+  void update_active_talkgroup_patches(MotoPatchData moto_patch_data);
   void clear_stale_talkgroup_patches();
 
 private:


### PR DESCRIPTION
Added mutex to fix segfaults in simplestream plugin.  Been running well for ~48 hours vs. segfault after several hours.

Reduced amount/type of data being passed into update_active_talkgroup_patches().