### PR TITLE
Fix openmhz_uploader segfault in curl, use after free

### DIFF
--- a/plugins/openmhz_uploader/openmhz_uploader.cc
+++ b/plugins/openmhz_uploader/openmhz_uploader.cc
@@ -246,6 +246,9 @@ public:
         }
       }
 
+      long response_code;
+      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+
       res = curl_multi_cleanup(multi_handle);
 
       /* always cleanup */
@@ -256,9 +259,6 @@ public:
 
       /* free slist */
       curl_slist_free_all(headerlist);
-
-      long response_code;
-      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
 
       if (res == CURLM_OK && response_code == 200) {
         struct stat file_info;


### PR DESCRIPTION
A friend helped me debug this and the following patch seems to fix the issue.

curl_easy_cleanup(3)[1] cleans up the curl handle, and all usage
of it after calling this is illegal. The handle is used in the call
to curl_easy_getinfo(3)[2] which then segfaults as it access the now
null pointer.

[1]: https://curl.se/libcurl/c/curl_easy_cleanup.html
[2]: https://curl.se/libcurl/c/curl_easy_getinfo.html

Fixes #598 
