### PR TITLE
Revert 572 squelch eob typo

### DIFF
--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
@@ -328,7 +328,7 @@ int nonstop_wavfile_sink_impl::work(int noutput_items, gr_vector_const_void_star
   std::vector<gr::tag_t> tags;
   pmt::pmt_t this_key(pmt::intern("src_id"));
   pmt::pmt_t that_key(pmt::intern("terminate"));
-  pmt::pmt_t squelch_key(pmt::intern("squelch_eob"));
+  pmt::pmt_t squelch_key(pmt::intern("squelch:eob"));
   get_tags_in_range(tags, 0, nitems_read(0), nitems_read(0) + noutput_items);
 
   unsigned pos = 0;

--- a/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
+++ b/lib/gr_blocks/nonstop_wavfile_sink_impl.cc
@@ -328,7 +328,7 @@ int nonstop_wavfile_sink_impl::work(int noutput_items, gr_vector_const_void_star
   std::vector<gr::tag_t> tags;
   pmt::pmt_t this_key(pmt::intern("src_id"));
   pmt::pmt_t that_key(pmt::intern("terminate"));
-  pmt::pmt_t squelch_key(pmt::intern("squelch:eob"));
+  //pmt::pmt_t squelch_key(pmt::intern("squelch_eob"));
   get_tags_in_range(tags, 0, nitems_read(0), nitems_read(0) + noutput_items);
 
   unsigned pos = 0;
@@ -364,7 +364,7 @@ int nonstop_wavfile_sink_impl::work(int noutput_items, gr_vector_const_void_star
       }
 
     }
-    if (pmt::eq(that_key, tags[i].key) || pmt::eq(squelch_key, tags[i].key)) {
+    if (pmt::eq(that_key, tags[i].key)) {
       d_termination_flag = true;
     }
   }


### PR DESCRIPTION
Reverts robotastic/trunk-recorder#572

Ultimately, things were better when squelch_eob _wasn't_ working.

Terminating a transmission based on squelch_eob leads to dropped audio samples for conventional P25 (and presumably conventional DMR) when a unit's transmission ends up spread across multiple .wav files.  I'm not sure if this change even had an effect on trunked systems, as they don't rely on squelch as heavily as conventional digital modes.