### PR TITLE
Update rdioscanner_uploader.cc

### DIFF
--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -87,7 +87,7 @@ public:
     patch_list << std::fixed << std::setprecision(2);
     patch_list << "[";
 
-    boost::filesystem::path audioPath(call_info.filename);
+    boost::filesystem::path audioPath(compress_wav ? call_info.converted : call_info.filename);
     boost::filesystem::path audioName = audioPath.filename();
 
     char formattedTalkgroup[62];


### PR DESCRIPTION
As discussed in https://github.com/chuot/rdio-scanner/issues/78, the rdio-scanner plugin does not currently check if it is using compressed audio when it reports a call filename to the server.  Audio sent via the plugin is logged, stored, and downloaded with a .wav extension, even when the actual content inside may be m4a compressed.

Uploading the with the correct filename should help with those issues, and potentially resolve other problems such as file corruption when rdio-scanner attempts to compress the incoming audio a second time due to the .wav extension.