### PR TITLE
Set set_is_analog(true) for conventional analog

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1278,6 +1278,7 @@ bool setup_systems() {
               analog_recorder_sptr rec;
               rec = source->create_conventional_recorder(tb);
               rec->start(call);
+	      call->set_is_analog(true);
               call->set_recorder((Recorder *)rec.get());
               call->set_state(RECORDING);
               system->add_conventional_recorder(rec);


### PR DESCRIPTION
Per https://github.com/robotastic/trunk-recorder/issues/615, conventional analog shows up as digital in json logs since `set_is_analog` never set and the call reports back the default value of false.
```
"audio_type": "digital",
```

Adding `call->set_is_analog(true)` to conventional system setup correctly identifies those calls as analog in the resulting json.
```
"audio_type": "analog",
```
