### PR TITLE
Add info to Recorder object for stream_audio()

### DIFF
--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -84,6 +84,7 @@ analog_recorder::analog_recorder(Source *src)
   talkgroup = 0;
   recording_count = 0;
   recording_duration = 0;
+  short_name = "";
 
   rec_num = rec_counter++;
   state = INACTIVE;
@@ -334,6 +335,11 @@ long analog_recorder::get_talkgroup() {
   return talkgroup;
 }
 
+std::string analog_recorder::get_short_name(){
+  return short_name;
+}
+
+
 double analog_recorder::get_freq() {
   return chan_freq;
 }
@@ -398,6 +404,7 @@ bool analog_recorder::start(Call *call) {
 
   talkgroup = call->get_talkgroup();
   chan_freq = call->get_freq();
+  short_name = call->get_short_name();
 
   squelch_db = system->get_squelch_db();
   squelch->set_threshold(squelch_db);

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -80,6 +80,7 @@ public:
   void set_source(long src);
   Source *get_source();
   long get_talkgroup();
+  std::string get_short_name();
   time_t get_start_time();
   double get_current_length();
   long get_wav_hz(); 
@@ -104,7 +105,7 @@ private:
   double center_freq, chan_freq;
   long talkgroup;
   long samp_rate;
-
+  std::string short_name;
   double system_channel_rate;
   double initial_rate;
   float quad_gain;

--- a/trunk-recorder/recorders/dmr_recorder.cc
+++ b/trunk-recorder/recorders/dmr_recorder.cc
@@ -160,6 +160,7 @@ void dmr_recorder::initialize(Source *src) {
   squelch_db = 0;
 
   talkgroup = 0;
+  short_name = "";
   d_phase2_tdma = true;
   rec_num = rec_counter++;
   recording_count = 0;
@@ -333,6 +334,14 @@ bool dmr_recorder::is_idle() {
 
 double dmr_recorder::get_freq() {
   return chan_freq;
+}
+
+long dmr_recorder::get_talkgroup() {
+  return talkgroup;
+}
+
+std::string dmr_recorder::get_short_name(){
+  return short_name;
 }
 
 double dmr_recorder::get_current_length() {

--- a/trunk-recorder/recorders/dmr_recorder.h
+++ b/trunk-recorder/recorders/dmr_recorder.h
@@ -112,6 +112,8 @@ public:
   bool start(Call *call);
   void stop();
   double get_freq();
+  long get_talkgroup();
+  std::string get_short_name();
   int get_num();
   void set_tdma(bool phase2);
   void switch_tdma(bool phase2);

--- a/trunk-recorder/recorders/p25_recorder.cc
+++ b/trunk-recorder/recorders/p25_recorder.cc
@@ -160,6 +160,7 @@ void p25_recorder::initialize(Source *src) {
   squelch_db = 0;
 
   talkgroup = 0;
+  short_name = "";
   d_phase2_tdma = false;
   rec_num = rec_counter++;
   recording_count = 0;
@@ -310,6 +311,14 @@ bool p25_recorder::is_idle() {
 
 double p25_recorder::get_freq() {
   return chan_freq;
+}
+
+long p25_recorder::get_talkgroup() {
+  return talkgroup;
+}
+
+std::string p25_recorder::get_short_name(){
+  return short_name;
 }
 
 double p25_recorder::get_current_length() {

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -91,6 +91,8 @@ public:
   void stop();
   void clear();
   double get_freq();
+  long get_talkgroup();
+  std::string get_short_name();
   int get_num();
   void set_tdma(bool phase2);
   void switch_tdma(bool phase2);

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -89,6 +89,7 @@ public:
   virtual long get_source_count() { return 0; };
   virtual long get_wav_hz() { return 8000; };
   virtual long get_talkgroup() { return 0; };
+  std::string get_short_name() { return ""; };
   virtual void set_record_more_transmissions(bool more){};
   virtual State get_state() { return INACTIVE; };
   virtual Rx_Status get_rx_status() {

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -89,7 +89,7 @@ public:
   virtual long get_source_count() { return 0; };
   virtual long get_wav_hz() { return 8000; };
   virtual long get_talkgroup() { return 0; };
-  std::string get_short_name() { return ""; };
+  virtual std::string get_short_name() { return ""; };
   virtual void set_record_more_transmissions(bool more){};
   virtual State get_state() { return INACTIVE; };
   virtual Rx_Status get_rx_status() {


### PR DESCRIPTION
- Add missing function calls to populate talkgroup in all recorder types (already existed in analog but missing in P25 and DMR)
- Add System short_name to info in Recorder object

Both of these items can be useful in the stream_audio() function in plugins to provide relevant metadata that matches the audio samples being passed in.  