### PR TITLE
Rdio scanner auto-populate / Better TG info for plugins

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -225,6 +225,8 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
 
   call_info.talkgroup = call->get_talkgroup();
   call_info.talkgroup_tag = call->get_talkgroup_tag();
+  call_info.tg_info = sys->find_talkgroup(call_info.talkgroup);
+
   call_info.freq = call->get_freq();
   call_info.encrypted = call->get_encrypted();
   call_info.emergency = call->get_emergency();

--- a/trunk-recorder/call_concluder/call_concluder.h
+++ b/trunk-recorder/call_concluder/call_concluder.h
@@ -43,6 +43,8 @@ struct Call_Data_t {
   std::string upload_script;
   std::string audio_type;
 
+  Talkgroup *tg_info;
+
   int tdma_slot;
   double length;
   bool phase2_tdma;


### PR DESCRIPTION
The rdio scanner plugin has been attempting to auto-populate "Talkgroup Groups" using the variable `tg_group`.  The plugin currently is only provided the Tallkgroup ID# and Alpha Text, and cannot access other talkgroup information that may have been read in from the csv.

Complicating things, `tg_group` is presently creating downstream issues since it is a string variable assigned an integer without type conversion. This is resulting in non-printable characters and other garbage overwriting TG group assignments in Rdio-Scanner as seen below:
<img width="600" alt="Screen_Shot_2022-02-07_at_9 25 26_AM" src="https://user-images.githubusercontent.com/12748062/153117839-e0b6f267-427f-4267-b48d-802b8511faca.png">

While the simple fix is to correct the type error, or `tg_group = "";`, the optimum solution would be to let plugins have all the talkgroup data loaded from the CSV to pass on as needed.

The call .json and other plugins could benefit by retaining this data as well.

The inability for plugins to have all the TG data was noted in the following rdio-scanner issues:
https://github.com/chuot/rdio-scanner/issues/123
https://github.com/chuot/rdio-scanner/issues/115

This PR works independently of https://github.com/robotastic/trunk-recorder/pull/630.