### PR TITLE
M/A-COM patch following enhancement

### DIFF
--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -977,6 +977,29 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg) {
     // self.trunked_systems[nac].decode_mbt_data(opcode, header << 16, mbt_data
     // << 32)
   }
+  else if (type == 18){
+    uint8_t opcode = (uint8_t)s[0];
+    uint8_t mfrid = (uint8_t)s[1];
+    BOOST_LOG_TRIVIAL(debug) <<"FOUND A TYPE 18 TDMA PDU MESSAGE WITH OPCODE " << opcode <<" AND MFRID "<< mfrid;
+    BOOST_LOG_TRIVIAL(debug) << s;
+    boost::dynamic_bitset<> b((s.length() + 2) * 8);
+    for (unsigned int i = 0; i < s.length(); ++i) {
+      unsigned char c = (unsigned char)s[i];
+      b <<= 8;
+
+      for (int j = 0; j < 8; j++) {
+        if (c & 0x1) {
+          b[j] = 1;
+        } else {
+          b[j] = 0;
+        }
+        c >>= 1;
+      }
+    }
+    b <<= 16; // for missing crc
+    BOOST_LOG_TRIVIAL(debug) << b;
+    //return decode_tdma(b, nac, sys_num);
+  }
   messages.push_back(message);
   return messages;
 }

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -632,6 +632,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
         unsigned long rta = bitset_shift_mask(tsbk, 16, 0xffffff);
         unsigned long algid = (rta >> 16) & 0xff; 
         unsigned long ga =  rta & 0xffff;  
+        BOOST_LOG_TRIVIAL(debug)<<"grg_t: " << grg_t << " grg_g: " << grg_g << " grg_a: " << grg_a << " sg: " << sg << " ga: " << ga;
         if (grg_a == 1){ // Activate
           if (grg_g == 1){ // Group request
             message.message_type = PATCH_ADD;

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -621,6 +621,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
     BOOST_LOG_TRIVIAL(debug) << "tsbk2f\tUnit Deregistration ACK\tSource ID: " << std::setw(7) << si;
   } else if (opcode == 0x30) {
       unsigned long mfrid = bitset_shift_mask(tsbk, 80, 0xff);
+      BOOST_LOG_TRIVIAL(debug) << "Opcode 0x30 with mfrid " << mfrid;
       if (mfrid == 0xA4) { // GRG_EXENC_CMD (M/A-COM patch)
         unsigned long grg_t = bitset_shift_mask(tsbk, 79, 0x1);
         unsigned long grg_g = bitset_shift_mask(tsbk, 28, 0x1);

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -994,29 +994,6 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg) {
     // self.trunked_systems[nac].decode_mbt_data(opcode, header << 16, mbt_data
     // << 32)
   }
-  else if (type == 18){
-    uint8_t opcode = (uint8_t)s[0];
-    uint8_t mfrid = (uint8_t)s[1];
-    BOOST_LOG_TRIVIAL(debug) <<"FOUND A TYPE 18 TDMA PDU MESSAGE WITH OPCODE " << opcode <<" AND MFRID "<< mfrid;
-    BOOST_LOG_TRIVIAL(debug) << s;
-    boost::dynamic_bitset<> b((s.length() + 2) * 8);
-    for (unsigned int i = 0; i < s.length(); ++i) {
-      unsigned char c = (unsigned char)s[i];
-      b <<= 8;
-
-      for (int j = 0; j < 8; j++) {
-        if (c & 0x1) {
-          b[j] = 1;
-        } else {
-          b[j] = 0;
-        }
-        c >>= 1;
-      }
-    }
-    b <<= 16; // for missing crc
-    BOOST_LOG_TRIVIAL(debug) << b;
-    //return decode_tdma(b, nac, sys_num);
-  }
   messages.push_back(message);
   return messages;
 }


### PR DESCRIPTION
User reported patch following wasn't working on a Phase 2 Harris system.  Found that patch data was in TSBK messages with opcode 0x30 and mfrid 0xA4 as expected.  However, grg_g value was 0 instead of 1.  OP25 code indicates that grg_g == 0 is a Unit Request instead of a Group Request (grg_g==1, which was already handled).  Added code to handle patching messages with grg_g == 0 and seems to be working with the reporting user's system.  