### PR TITLE
Set alpha tag for conventional talkgroup and restore startup console message

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -1347,16 +1347,16 @@ bool setup_convetional_channel(System *system, double frequency, long channel_in
             if (system->has_channel_file()) {
               Talkgroup *tg = system->find_talkgroup_by_freq(frequency);
               call = new Call_conventional(tg->number, tg->freq, system, config);
+              call->set_talkgroup_tag(tg->alpha_tag);
             } else {
               call = new Call_conventional(channel_index, frequency, system, config);
-              BOOST_LOG_TRIVIAL(info) << "[" << system->get_short_name() << "]\tMonitoring Conventional Channel: " << format_freq(frequency) << " Talkgroup: " << channel_index;
-            
             }
+            BOOST_LOG_TRIVIAL(info) << "[" << system->get_short_name() << "]\tMonitoring " << system->get_system_type() << " channel: " << format_freq(frequency) << " Talkgroup: " << channel_index;
             if (system->get_system_type() == "conventional") {
               analog_recorder_sptr rec;
               rec = source->create_conventional_recorder(tb);
               rec->start(call);
-	            call->set_is_analog(true);
+              call->set_is_analog(true);
               call->set_recorder((Recorder *)rec.get());
               call->set_state(RECORDING);
               system->add_conventional_recorder(rec);


### PR DESCRIPTION
Conventional channels using a .csv currently do not have their alpha tag displayed in the trunk-recorder console messages.  As in previous releases, the alpha tag should be when the conventional channel is started.

Also to be consistent with previous releases, the "Monitoring Conventional Channel" startup message should display whether or not a conventional csv is being used.