### PR TITLE
Fix short transmission deletes.

### DIFF
--- a/lib/op25_repeater/lib/p25p1_fdma.cc
+++ b/lib/op25_repeater/lib/p25p1_fdma.cc
@@ -688,7 +688,7 @@ namespace gr {
                             std::string encr = "{\"encrypted\": " + std::to_string(0) + ", \"algid\": " + std::to_string(ess_algid) + ", \"keyid\": " + std::to_string(ess_keyid) + "}";
                             send_msg(encr, M_P25_JSON_DATA);
                             // This is the Vocoder that OP25 currently uses.
-                            /*software_decoder.decode_fullrate(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7], E0, ET);
+                            software_decoder.decode_fullrate(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7], E0, ET);
                             audio_samples *samples = software_decoder.audio();
                             for (int i=0; i < SND_FRAME; i++) {
                            	    if (samples->size() > 0) {
@@ -697,10 +697,11 @@ namespace gr {
                                 } else {
                                     snd[i] = 0;
                                 }
-                            }*/
+                            }
 
                             // This is the older, fullrate vocoder
                             // it was copied from p25p1_voice_decode.cc
+                            /*
                             int16_t frame_vector[8];
 
                             for (int i=0; i < 8; i++) { // Ugh. For compatibility convert imbe params from uint32_t to int16_t
@@ -708,7 +709,7 @@ namespace gr {
                             }
                             frame_vector[7] >>= 1;
                             vocoder.imbe_decode(frame_vector, snd);
-
+                            */
 
 
 

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -282,12 +282,15 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
           
           snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, 35, call_info.talkgroup, 0x1B);
           std::string talkgroup_display = boost::lexical_cast<std::string>(formattedTalkgroup);
-          BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num<< "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tRemoving transmission less than " << sys->get_min_tx_duration() <<" seconds. Actual length: " << t.length << "." << std::endl;
+          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num<< "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tRemoving transmission less than " << sys->get_min_tx_duration() <<" seconds. Actual length: " << t.length << "." << std::endl;
       
           if (checkIfFile(t.filename)) {
             remove(t.filename);
           }
         }
+
+        it = call_info.transmission_list.erase(it);
+
         continue;
       } 
       snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, 35, call_info.talkgroup, 0x1B);

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -289,7 +289,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
           }
         }
 
-        it = call_info.transmission_list.erase(it--);
+        call_info.transmission_list.erase(it--);
 
         continue;
       } 

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -289,7 +289,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
           }
         }
 
-        it = call_info.transmission_list.erase(it);
+        it = call_info.transmission_list.erase(it--);
 
         continue;
       } 

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -282,7 +282,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
           
           snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, 35, call_info.talkgroup, 0x1B);
           std::string talkgroup_display = boost::lexical_cast<std::string>(formattedTalkgroup);
-          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num<< "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tRemoving transmission less than " << sys->get_min_tx_duration() <<" seconds. Actual length: " << t.length << "." << std::endl;
+          BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num<< "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tRemoving transmission less than " << sys->get_min_tx_duration() <<" seconds. Actual length: " << t.length << "." << std::endl;
       
           if (checkIfFile(t.filename)) {
             remove(t.filename);


### PR DESCRIPTION
Simply continuing in the **create_call_data** function is causing later functions (**upload_call_worker**, **combine_wav**) to have issues when they try to iterate the transmissions_list and the files have been removed. This should remove the entry from the transmission list and correct the issue.