### PR TITLE
Remove nested BOOST_LOG_TRIVIAL to fix erroneous log level display

### DIFF
--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -335,7 +335,6 @@ bool Call_impl::update(TrunkMessage message) {
 }
 
 int Call_impl::since_last_update() {
-    BOOST_LOG_TRIVIAL(trace) << "last_update: " << last_update << " diff: " << time(NULL) - last_update;
     return time(NULL) - last_update;
 }
 


### PR DESCRIPTION
In trunk-recorder, some `BOOST_LOG_TRIVIAL(info)` entries are showing as trace even when the log level is set at info.

As noted [here](https://github.com/boostorg/log/issues/137), nested BOOST_LOG_TRIVIAL calls override the severity display of the parent call.  

This is commonly seen in "Concluding Recorded Call" messages and other things displaying "Last Update:  X s" because `Call_impl::since_last_update()` has a `BOOST_LOG_TRIVIAL(trace)` while passing back the integer result.

```
[2022-05-19 14:56:17.766432] (info)   [clmrn]	67064C	TG:       4011 (           CTT NH Bus 1)	Freq: 769.656250 MHz	Starting P25 Recorder Num [0]	TDMA: true	Slot: 1	QPSK: true
[2022-05-19 14:56:25.008572] (trace)   [clmrn]	67061C	TG:       4012 (           CTT NH Bus 2)	Freq: 773.281250 MHz	Concluding Recorded Call - Last Update: 4s	Call Elapsed: 21
[2022-05-19 14:56:25.008882] (info)   [clmrn]	67061C	TG:       4012	Freq: 773.281250 MHz	- Transmission src: 45139 tag: CT Transit pos: 0 length: 11.24
[2022-05-19 14:56:30.121810] (info)   [clmrn]	67065C	TG:        301 (       CSP Trp G Disp 1)	Freq: 769.656250 MHz	Starting P25 Recorder Num [1]	TDMA: true	Slot: 0	QPSK: true
[2022-05-19 14:56:32.001151] (trace)   [clmrn]	67062C	TG:        301 (       CSP Trp G Disp 1)	Freq: 773.281250 MHz	Concluding Recorded Call - Last Update: 4s	Call Elapsed: 20
[2022-05-19 14:56:32.001406] (info)   [clmrn]	67062C	TG:        301	Freq: 773.281250 MHz	- Transmission src: 1819332 tag: CSP Dispatch pos: 0 length: 2.32
[2022-05-19 14:56:32.001651] (info)   [clmrn]	67062C	TG:        301	Freq: 773.281250 MHz	- Transmission src: -1 tag:  pos: 2.32 length: 8.88
[2022-05-19 14:56:33.010151] (trace)   [clmrn]	67064C	TG:       4011 (           CTT NH Bus 1)	Freq: 769.656250 MHz	Concluding Recorded Call - Last Update: 4s	Call Elapsed: 16
```
There may be other nested boosts to uncover, but this one was fairly prevalent since it occurs at least once with each call.