### PR TITLE
Include boost/filesystem header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,9 @@ if(NOT Boost_FOUND)
 endif()
 
 ADD_DEFINITIONS(-DBOOST_ALL_DYN_LINK)
+if(NOT EXISTS /usr/include/spdlog/fmt/bundled)
+  ADD_DEFINITIONS(-DSPDLOG_FMT_EXTERNAL=ON)
+endif()
 add_definitions(-DGNURADIO_VERSION=${GNURADIO_VERSION})
 
 ########################################################################

--- a/trunk-recorder/gr_blocks/transmission_sink.cc
+++ b/trunk-recorder/gr_blocks/transmission_sink.cc
@@ -24,6 +24,7 @@
 #include "transmission_sink.h"
 #include "../../trunk-recorder/call.h"
 #include <boost/math/special_functions/round.hpp>
+#include <boost/filesystem.hpp>
 #include <climits>
 #include <cmath>
 #include <cstring>


### PR DESCRIPTION
Without this include I get an error that boost::filesystem::create_directories is not declared while compiling this file.