### PR TITLE
Add a trailing / to the cp command

### DIFF
--- a/examples/SETUP_SERVICE.md
+++ b/examples/SETUP_SERVICE.md
@@ -7,7 +7,7 @@ Modify the example serivce: [trunk-recorder.service](trunk-recorder.service)
 Install it by copying it to the **/etc/systemd/system** folder:
 
 ```bash
-sudo cp trunk-recorder.service /etc/systemd/service
+sudo cp trunk-recorder.service /etc/systemd/service/
 ```
 
 And now start it up!


### PR DESCRIPTION
I accidently just overwrote my /etc/systemd/service folder by doing sudo cp trunk-recorder.service /etc/systemd/service without a trailing /