### PR TITLE
Build gr-osmosdr in Docker with multiple Airspy source patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,28 +8,52 @@ RUN apt-get update && \
     apt-transport-https \
     build-essential \
     ca-certificates \
+    cmake \
+    docker.io \
     fdkaac \
     git \
-    docker.io \
     gnupg \
     gnuradio \
     gnuradio-dev \
-    gr-osmosdr \
+    gr-funcube \
+    gr-iqbal \
+    libairspy-dev \
+    libairspyhf-dev \
+    libbladerf-dev \
     libboost-all-dev \
     libcurl4-openssl-dev \
+    libfreesrp-dev \
     libgmp-dev \
     libhackrf-dev \
     liborc-0.4-dev \
     libpthread-stubs0-dev \
+    librtlsdr-dev \
+    libsndfile1-dev \
+    libsoapysdr-dev \
     libssl-dev \
     libuhd-dev \
     libusb-dev \
-    libsndfile1-dev \
+    libxtrx-dev \
     pkg-config \
     software-properties-common \
-    cmake \
     sox && \
   rm -rf /var/lib/apt/lists/*
+
+COPY lib/gr-osmosdr/airspy_source_c.cc.patch /tmp/airspy_source_c.cc.patch
+
+# Compile gr-osmosdr ourselves so we can install the Airspy serial number patch
+RUN cd /tmp && \
+  git clone https://git.osmocom.org/gr-osmosdr && \
+  cd gr-osmosdr && \
+  git apply ../airspy_source_c.cc.patch && \
+  mkdir build && \
+  cd build && \
+  cmake .. && \
+  make -j$(nproc) && \
+  make install && \
+  ldconfig && \
+  cd /tmp && \
+  rm -rf gr-osmosdr airspy_source_c.cc.patch
 
 WORKDIR /src
 

--- a/lib/gr-osmosdr/airspy_source_c.cc.patch
+++ b/lib/gr-osmosdr/airspy_source_c.cc.patch
@@ -1,0 +1,51 @@
+diff --git a/lib/airspy/airspy_source_c.cc b/lib/airspy/airspy_source_c.cc
+index 25f73d4..52b1d81 100644
+--- a/lib/airspy/airspy_source_c.cc
++++ b/lib/airspy/airspy_source_c.cc
+@@ -90,12 +90,25 @@ airspy_source_c::airspy_source_c (const std::string &args)
+     _vga_gain(0),
+     _bandwidth(0)
+ {
+-  int ret;
+ 
++  int ret;
++  _dev = NULL;
+   dict_t dict = params_to_dict(args);
+ 
+-  _dev = NULL;
+-  ret = airspy_open( &_dev );
++  // the block below allows one to open airspy by serial number
++  // 2016-Apr-5 - by Lawrence Glaister VE7IT  ve7it@shaw.ca
++  // (allowing multiple airspy source blocks to be used) Note: each airspy should be
++  // plugged into its own USB bus controller to support the high data rates involved.
++  // osmocom Source block usage: Device arguments:  airspy=0x644064DC317C1FCD
++  // if no device arguments are given or s/n=0, the first found airspy device will be used
++  // use airspy_info utility to identify device serial number strings
++  uint64_t sn;
++  std::stringstream ss;
++  ss << std::hex << dict["airspy"];
++  ss >> sn;
++  std::cerr << "Attempting to open airspy by s/n= "
++            <<  boost::format("0x%016X") % (sn) << std::endl;
++  ret = airspy_open_sn( &_dev, sn );
+   AIRSPY_THROW_ON_ERROR(ret, "Failed to open AirSpy device")
+ 
+   uint8_t board_id;
+@@ -106,11 +119,15 @@ airspy_source_c::airspy_source_c (const std::string &args)
+   memset(version, 0, sizeof(version));
+   ret = airspy_version_string_read( _dev, version, sizeof(version));
+   AIRSPY_THROW_ON_ERROR(ret, "Failed to read version string")
+-#if 0
++
+   airspy_read_partid_serialno_t part_serial;
+   ret = airspy_board_partid_serialno_read( _dev, &part_serial );
+   AIRSPY_THROW_ON_ERROR(ret, "Failed to read serial number")
+-#endif
++  std::cerr << "Opened Device Serial Number=    "
++    << boost::format("0x%08X") % (part_serial.serial_no[2])
++    << boost::format("%08X")   % (part_serial.serial_no[3])
++    << std::endl;
++
+   uint32_t num_rates;
+   airspy_get_samplerates(_dev, &num_rates, 0);
+   uint32_t *samplerates = (uint32_t *) malloc(num_rates * sizeof(uint32_t));


### PR DESCRIPTION
This PR updates how gr-osmosdr is installed in the Docker image for trunk-recorder, to compile gr-osmosdr with a patch mentioned in https://github.com/robotastic/trunk-recorder/issues/403 for allowing multiple Airspys to be selected via serial number. By having this as part of the Docker image, it makes it a lot easier to use multiple Airspy devices without needing to follow a complicated process. As a bonus, gr-osmosdr will now support all the different SDRs it's capable of using (including the newish XTRX), since some extra dev packages were installed that are used in the build process.