### PR TITLE
Fixes issue mentioned in #691

### DIFF
--- a/docs/INSTALL-PI.md
+++ b/docs/INSTALL-PI.md
@@ -71,7 +71,7 @@ sudo apt upgrade
 ```
 - Add all of the libraries needed:
 ```bash
-sudo apt -y install libssl-dev openssl curl git fdkaac sox libcurl3-gnutls libcurl4 libcurl4-openssl-dev gnuradio gnuradio-dev gr-osmosdr libhackrf-dev libuhd-dev cmake make build-essential libboost-all-dev libusb-1.0-0-dev
+sudo apt -y install libssl-dev openssl curl git fdkaac sox libcurl3-gnutls libcurl4 libcurl4-openssl-dev gnuradio gnuradio-dev gr-osmosdr libhackrf-dev libuhd-dev cmake make build-essential libboost-all-dev libusb-1.0-0-dev libsndfile1-dev
 ```
 
 Configure RTL-SDRs to load correctly:


### PR DESCRIPTION
Adds `libsndfile1-dev` as soft dependency for ubuntu / debian systems. (In my case Pop_OS.)