### PR TITLE
Improve CSV parsing to allow quoted and escaped fields

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY . .
 
 WORKDIR /src/build
 
-RUN cmake .. && make && make install
+RUN cmake .. && make -j$(nproc) && make install
 
 #USER nobody
 

--- a/trunk-recorder/talkgroups.cc
+++ b/trunk-recorder/talkgroups.cc
@@ -26,8 +26,8 @@ void Talkgroups::load_talkgroups(std::string filename) {
     return;
   }
 
-  boost::char_separator<char> sep(",\t");
-  typedef boost::tokenizer<boost::char_separator<char>> t_tokenizer;
+  boost::escaped_list_separator<char> sep("\\", ",\t", "\"");
+  typedef boost::tokenizer<boost::escaped_list_separator<char>> t_tokenizer;
 
   std::vector<std::string> vec;
   std::string line;
@@ -123,8 +123,8 @@ void Talkgroups::load_channels(std::string filename) {
     return;
   }
 
-  boost::char_separator<char> sep(",", "\t", boost::keep_empty_tokens);
-  typedef boost::tokenizer<boost::char_separator<char>> t_tokenizer;
+  boost::escaped_list_separator<char> sep("\\", ",\t", "\"");
+  typedef boost::tokenizer<boost::escaped_list_separator<char>> t_tokenizer;
 
   std::vector<std::string> vec;
   std::string line;

--- a/trunk-recorder/unit_tags.cc
+++ b/trunk-recorder/unit_tags.cc
@@ -26,8 +26,8 @@ void UnitTags::load_unit_tags(std::string filename) {
     return;
   }
 
-  boost::char_separator<char> sep(",\t");
-  typedef boost::tokenizer<boost::char_separator<char>> t_tokenizer;
+  boost::escaped_list_separator<char> sep("\\", ",\t", "\"");
+  typedef boost::tokenizer<boost::escaped_list_separator<char>> t_tokenizer;
 
   std::vector<std::string> vec;
   std::string line;


### PR DESCRIPTION
The RadioReference talkgroup CSV output looks like the following:

```csv
Decimal,Hex,Alpha Tag,Mode,Description,Tag,Category
1,001,",T,"Installation / Techs / Evaluation",Business,"Motorola Installation / Testing"
2,002,"Motorola Tech 2",D,"Installation / Techs / Evaluation",Business,"Motorola Installation / Testing"
3,003,"Motorola Tech 3",DE,"Installation / Techs / Evaluation",Business,"Motorola Installation / Testing"
```

However, when trunk-recorder parses the CSV, it does not strip out the quotes, which leads to some malformed entry errors, as well as the call JSON to have syntax errors like the following:
```json
{
    "talkgroup_tag": ""DC Tac 2"",
    "talkgroup_description": ""Tac 2"",
    "talkgroup_group_tag": "Law Dispatch",
    "talkgroup_group": ""ISP District Chicago""
}
```

This PR fixes that error by switching to the Boost [`escaped_list_separator`](https://www.boost.org/doc/libs/1_31_0/libs/tokenizer/escaped_list_separator.htm) class, which is able to handle text being quoted and escaped. The previous class [`char_separator`](https://www.boost.org/doc/libs/1_42_0/libs/tokenizer/char_separator.htm) did not handle this.

Both comma-separated values and tab-separated values are still supported by this parser. I've done some testing to make sure everything still works.

Besides this, I made a tiny change to the Dockerfile to make compiling trunk-recorder use all available CPU cores for faster compilation.