### PR TITLE
Set d_call to null to prevent potential use after free

### DIFF
--- a/trunk-recorder/recorders/p25_recorder_decode.cc
+++ b/trunk-recorder/recorders/p25_recorder_decode.cc
@@ -21,6 +21,7 @@ p25_recorder_decode::~p25_recorder_decode() {
 
 void p25_recorder_decode::stop() {
   wav_sink->stop_recording();
+  d_call = NULL;
 }
 
 void p25_recorder_decode::start(Call *call) {
@@ -112,7 +113,9 @@ void p25_recorder_decode::initialize(int silence_frames) {
 }
 
 void p25_recorder_decode::plugin_callback_handler(int16_t *samples, int sampleCount) {
-  plugman_audio_callback(d_call, d_recorder, samples, sampleCount);
+  if (d_call) {
+    plugman_audio_callback(d_call, d_recorder, samples, sampleCount);
+  }
 }
 
 double p25_recorder_decode::get_output_sample_rate() {


### PR DESCRIPTION
plugman_audio_callback in p25_recorder_decode is sometimes call when d_call is an invalid pointer. This seems to be some form of race condition where d_call has been freed immediately before the audio callback is called, causing a segmentation fault in the simplestream plugin on line 63 (`call->get_system()`). By setting d_call to null when `p25_recorder_decode::stop()` is called,  we can check for it being invalid before a plugin ever sees it, preventing a use-after-free segmentation fault.