### PR TITLE
Conventional recorder info for MQTT and status-server plugins

### DIFF
--- a/plugins/streamer/streamer_proto_helper.cc
+++ b/plugins/streamer/streamer_proto_helper.cc
@@ -98,7 +98,7 @@ streamer::RecorderInfo* ToRecorderInfo(Recorder *recorder) {
 
     streamer::RecorderInfo* ri;
     ri->set_recorder_num(recorder->get_num());
-    ri->set_recorder_type(recorder->get_type());
+    ri->set_recorder_type(recorder->get_type_string());
     ri->set_source_num(recorder->get_source()->get_num());
     ri->set_id(boost::lexical_cast<std::string>(recorder->get_source()->get_num()) + "_" + boost::lexical_cast<std::string>(recorder->get_num()));
     ri->set_recorder_count(recorder->get_recording_count());

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -69,6 +69,15 @@ enum Call_Data_Status { INITIAL,
                         SUCCESS,
                         RETRY,
                         FAILED };
+                  
+enum Recorder_Type { DEBUG,
+                      SIGMF,
+                      ANALOG,
+                      ANALOGC,
+                      P25,
+                      P25C,
+                      DMR };
+
 struct Call_Data_t {
   long talkgroup;
   std::vector<unsigned long> patched_talkgroups;

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -37,7 +37,7 @@ std::vector<float> design_filter(double interpolation, double deci) {
   return result;
 }
 
-analog_recorder_sptr make_analog_recorder(Source *src, std::string type) {
+analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type) {
   return gnuradio::get_initial_sptr(new analog_recorder(src, type));
 }
 
@@ -66,7 +66,7 @@ void analog_recorder::calculate_iir_taps(double tau) {
   d_fbtaps[1] = -p1;
 }
 
-analog_recorder::analog_recorder(Source *src, std::string type)
+analog_recorder::analog_recorder(Source *src, Recorder_Type type)
     : gr::hier_block2("analog_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -61,13 +61,13 @@ typedef std::shared_ptr<analog_recorder> analog_recorder_sptr;
 
 int plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
 
-analog_recorder_sptr make_analog_recorder(Source *src);
+analog_recorder_sptr make_analog_recorder(Source *src, std::string type);
 
 class analog_recorder : public gr::hier_block2, public Recorder {
-  friend analog_recorder_sptr make_analog_recorder(Source *src);
+  friend analog_recorder_sptr make_analog_recorder(Source *src, std::string type);
 
 protected:
-  analog_recorder(Source *src);
+  analog_recorder(Source *src, std::string type);
 
 public:
   ~analog_recorder();

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -61,13 +61,13 @@ typedef std::shared_ptr<analog_recorder> analog_recorder_sptr;
 
 int plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
 
-analog_recorder_sptr make_analog_recorder(Source *src, std::string type);
+analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
 
 class analog_recorder : public gr::hier_block2, public Recorder {
-  friend analog_recorder_sptr make_analog_recorder(Source *src, std::string type);
+  friend analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
 
 protected:
-  analog_recorder(Source *src, std::string type);
+  analog_recorder(Source *src, Recorder_Type type);
 
 public:
   ~analog_recorder();

--- a/trunk-recorder/recorders/debug_recorder_impl.cc
+++ b/trunk-recorder/recorders/debug_recorder_impl.cc
@@ -148,7 +148,7 @@ debug_recorder_impl::debug_recorder_impl(Source *src, std::string address, int p
     : gr::hier_block2("debug_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder("D") {
+      Recorder(DEBUG) {
   source = src;
   chan_freq = source->get_center();
   center_freq = source->get_center();

--- a/trunk-recorder/recorders/dmr_recorder.h
+++ b/trunk-recorder/recorders/dmr_recorder.h
@@ -26,7 +26,7 @@ typedef boost::shared_ptr<dmr_recorder> dmr_recorder_sptr;
 typedef std::shared_ptr<dmr_recorder> dmr_recorder_sptr;
 #endif
 
-dmr_recorder_sptr make_dmr_recorder(Source *src);
+dmr_recorder_sptr make_dmr_recorder(Source *src, std::string type);
 
 class dmr_recorder : virtual public gr::hier_block2, virtual public Recorder {
 

--- a/trunk-recorder/recorders/dmr_recorder.h
+++ b/trunk-recorder/recorders/dmr_recorder.h
@@ -26,7 +26,7 @@ typedef boost::shared_ptr<dmr_recorder> dmr_recorder_sptr;
 typedef std::shared_ptr<dmr_recorder> dmr_recorder_sptr;
 #endif
 
-dmr_recorder_sptr make_dmr_recorder(Source *src, std::string type);
+dmr_recorder_sptr make_dmr_recorder(Source *src, Recorder_Type type);
 
 class dmr_recorder : virtual public gr::hier_block2, virtual public Recorder {
 

--- a/trunk-recorder/recorders/dmr_recorder_impl.cc
+++ b/trunk-recorder/recorders/dmr_recorder_impl.cc
@@ -6,7 +6,7 @@
 #include "../plugin_manager/plugin_manager.h"
 #include <boost/log/trivial.hpp>
 
-dmr_recorder_sptr make_dmr_recorder(Source *src, std::string type) {
+dmr_recorder_sptr make_dmr_recorder(Source *src, Recorder_Type type) {
   dmr_recorder *recorder = new dmr_recorder_impl(src, type);
 
   return gnuradio::get_initial_sptr(recorder);
@@ -46,7 +46,7 @@ void dmr_recorder_impl::generate_arb_taps() {
   }
 }
 
-dmr_recorder_impl::dmr_recorder_impl(Source *src, std::string type)
+dmr_recorder_impl::dmr_recorder_impl(Source *src, Recorder_Type type)
     : gr::hier_block2("dmr_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),

--- a/trunk-recorder/recorders/dmr_recorder_impl.cc
+++ b/trunk-recorder/recorders/dmr_recorder_impl.cc
@@ -6,8 +6,8 @@
 #include "../plugin_manager/plugin_manager.h"
 #include <boost/log/trivial.hpp>
 
-dmr_recorder_sptr make_dmr_recorder(Source *src) {
-  dmr_recorder *recorder = new dmr_recorder_impl(src);
+dmr_recorder_sptr make_dmr_recorder(Source *src, std::string type) {
+  dmr_recorder *recorder = new dmr_recorder_impl(src, type);
 
   return gnuradio::get_initial_sptr(recorder);
 }
@@ -46,11 +46,11 @@ void dmr_recorder_impl::generate_arb_taps() {
   }
 }
 
-dmr_recorder_impl::dmr_recorder_impl(Source *src)
+dmr_recorder_impl::dmr_recorder_impl(Source *src, std::string type)
     : gr::hier_block2("dmr_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder("DMR") {
+      Recorder(type) {
   initialize(src);
 }
 

--- a/trunk-recorder/recorders/dmr_recorder_impl.h
+++ b/trunk-recorder/recorders/dmr_recorder_impl.h
@@ -88,7 +88,7 @@ protected:
   void initialize(Source *src);
 
 public:
-  dmr_recorder_impl(Source *src);
+  dmr_recorder_impl(Source *src, std::string type);
   DecimSettings get_decim(long speed);
   void initialize_prefilter();
   void tune_offset(double f);

--- a/trunk-recorder/recorders/dmr_recorder_impl.h
+++ b/trunk-recorder/recorders/dmr_recorder_impl.h
@@ -88,7 +88,7 @@ protected:
   void initialize(Source *src);
 
 public:
-  dmr_recorder_impl(Source *src, std::string type);
+  dmr_recorder_impl(Source *src, Recorder_Type type);
   DecimSettings get_decim(long speed);
   void initialize_prefilter();
   void tune_offset(double f);

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -25,7 +25,7 @@ typedef boost::shared_ptr<p25_recorder> p25_recorder_sptr;
 typedef std::shared_ptr<p25_recorder> p25_recorder_sptr;
 #endif
 
-p25_recorder_sptr make_p25_recorder(Source *src, std::string type);
+p25_recorder_sptr make_p25_recorder(Source *src, Recorder_Type type);
 #include "../source.h"
 
 class p25_recorder : virtual public gr::hier_block2, virtual public Recorder {

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -25,7 +25,7 @@ typedef boost::shared_ptr<p25_recorder> p25_recorder_sptr;
 typedef std::shared_ptr<p25_recorder> p25_recorder_sptr;
 #endif
 
-p25_recorder_sptr make_p25_recorder(Source *src);
+p25_recorder_sptr make_p25_recorder(Source *src, std::string type);
 #include "../source.h"
 
 class p25_recorder : virtual public gr::hier_block2, virtual public Recorder {

--- a/trunk-recorder/recorders/p25_recorder_impl.cc
+++ b/trunk-recorder/recorders/p25_recorder_impl.cc
@@ -4,8 +4,8 @@
 #include "p25_recorder.h"
 #include <boost/log/trivial.hpp>
 
-p25_recorder_sptr make_p25_recorder(Source *src) {
-  p25_recorder *recorder = new p25_recorder_impl(src);
+p25_recorder_sptr make_p25_recorder(Source *src, std::string type) {
+  p25_recorder *recorder = new p25_recorder_impl(src, type);
 
   return gnuradio::get_initial_sptr(recorder);
 }
@@ -44,11 +44,11 @@ void p25_recorder_impl::generate_arb_taps() {
   }
 }
 
-p25_recorder_impl::p25_recorder_impl(Source *src)
+p25_recorder_impl::p25_recorder_impl(Source *src, std::string label)
     : gr::hier_block2("p25_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder("P25") {
+      Recorder(label) {
   initialize(src);
 }
 

--- a/trunk-recorder/recorders/p25_recorder_impl.cc
+++ b/trunk-recorder/recorders/p25_recorder_impl.cc
@@ -44,11 +44,11 @@ void p25_recorder_impl::generate_arb_taps() {
   }
 }
 
-p25_recorder_impl::p25_recorder_impl(Source *src, std::string label)
+p25_recorder_impl::p25_recorder_impl(Source *src, std::string type)
     : gr::hier_block2("p25_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder(label) {
+      Recorder(type) {
   initialize(src);
 }
 

--- a/trunk-recorder/recorders/p25_recorder_impl.cc
+++ b/trunk-recorder/recorders/p25_recorder_impl.cc
@@ -4,7 +4,7 @@
 #include "p25_recorder.h"
 #include <boost/log/trivial.hpp>
 
-p25_recorder_sptr make_p25_recorder(Source *src, std::string type) {
+p25_recorder_sptr make_p25_recorder(Source *src, Recorder_Type type) {
   p25_recorder *recorder = new p25_recorder_impl(src, type);
 
   return gnuradio::get_initial_sptr(recorder);
@@ -44,7 +44,7 @@ void p25_recorder_impl::generate_arb_taps() {
   }
 }
 
-p25_recorder_impl::p25_recorder_impl(Source *src, std::string type)
+p25_recorder_impl::p25_recorder_impl(Source *src, Recorder_Type type)
     : gr::hier_block2("p25_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),

--- a/trunk-recorder/recorders/p25_recorder_impl.h
+++ b/trunk-recorder/recorders/p25_recorder_impl.h
@@ -70,7 +70,7 @@ protected:
   void initialize(Source *src);
 
 public:
-  p25_recorder_impl(Source *src);
+  p25_recorder_impl(Source *src, std::string type);
   DecimSettings get_decim(long speed);
   void initialize_prefilter();
   void initialize_qpsk();

--- a/trunk-recorder/recorders/p25_recorder_impl.h
+++ b/trunk-recorder/recorders/p25_recorder_impl.h
@@ -70,7 +70,7 @@ protected:
   void initialize(Source *src);
 
 public:
-  p25_recorder_impl(Source *src, std::string type);
+  p25_recorder_impl(Source *src, Recorder_Type type);
   DecimSettings get_decim(long speed);
   void initialize_prefilter();
   void initialize_qpsk();

--- a/trunk-recorder/recorders/recorder.cc
+++ b/trunk-recorder/recorders/recorder.cc
@@ -2,7 +2,7 @@
 #include "../source.h"
 #include <boost/algorithm/string.hpp>
 
-Recorder::Recorder(std::string type) {
+Recorder::Recorder(Recorder_Type type) {
   this->type = type;
 }
 
@@ -16,4 +16,25 @@ boost::property_tree::ptree Recorder::get_stats() {
   node.put("duration", recording_duration);
   node.put("state", get_state());
   return node;
+}
+
+std::string Recorder::get_type_string() {
+  switch(type) {
+    case DEBUG:
+      return "Debug";
+    case SIGMF:
+      return "SIGMF";
+    case ANALOGC:
+      return "AnalogC";
+    case ANALOG:
+      return "Analog";
+    case P25:
+      return "P25";
+    case P25C:
+      return "P25C";
+    case DMR:
+      return "DMR";
+    default:
+      return "Unknown";
+  }
 }

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -70,7 +70,7 @@ public:
     long decim2;
   };
 
-  Recorder(std::string type);
+  Recorder(Recorder_Type  type);
   virtual void tune_offset(double f){};
   virtual void tune_freq(double f){};
   virtual bool start(Call *call) { return false; };
@@ -87,7 +87,8 @@ public:
   virtual long get_talkgroup() { return 0; };
   virtual void set_record_more_transmissions(bool more){};
   virtual State get_state() { return INACTIVE; };
-  virtual std::string get_type() { return type; }
+  std::string get_type_string();
+  Recorder_Type get_type() { return type; }
   virtual bool is_active() { return false; };
   virtual bool is_analog() { return false; };
   virtual bool is_idle() { return true; };
@@ -110,7 +111,7 @@ protected:
   int recording_count;
   bool d_enable_audio_streaming;
   double recording_duration;
-  std::string type;
+  Recorder_Type  type;
 };
 
 #endif

--- a/trunk-recorder/recorders/sigmf_recorder_impl.cc
+++ b/trunk-recorder/recorders/sigmf_recorder_impl.cc
@@ -14,7 +14,7 @@ sigmf_recorder_impl::sigmf_recorder_impl(Source *src)
     : gr::hier_block2("sigmf_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder("D") {
+      Recorder(SIGMF) {
   source = src;
   freq = source->get_center();
   center = source->get_center();

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -138,7 +138,7 @@ int Source::get_if_gain() {
 analog_recorder_sptr Source::create_conventional_recorder(gr::top_block_sptr tb) {
   // Not adding it to the vector of analog_recorders. We don't want it to be available for trunk recording.
   // Conventional recorders are tracked seperately in analog_conv_recorders
-  analog_recorder_sptr log = make_analog_recorder(this, "AnalogC");
+  analog_recorder_sptr log = make_analog_recorder(this, ANALOGC);
   analog_conv_recorders.push_back(log);
   tb->connect(source_block, 0, log, 0);
   return log;
@@ -148,7 +148,7 @@ void Source::create_analog_recorders(gr::top_block_sptr tb, int r) {
   max_analog_recorders = r;
 
   for (int i = 0; i < max_analog_recorders; i++) {
-    analog_recorder_sptr log = make_analog_recorder(this, "Analog");
+    analog_recorder_sptr log = make_analog_recorder(this, ANALOG);
     analog_recorders.push_back(log);
     tb->connect(source_block, 0, log, 0);
   }
@@ -189,7 +189,7 @@ void Source::create_digital_recorders(gr::top_block_sptr tb, int r) {
   max_digital_recorders = r;
 
   for (int i = 0; i < max_digital_recorders; i++) {
-    p25_recorder_sptr log = make_p25_recorder(this, "P25");
+    p25_recorder_sptr log = make_p25_recorder(this, P25);
     digital_recorders.push_back(log);
     tb->connect(source_block, 0, log, 0);
   }
@@ -198,7 +198,7 @@ void Source::create_digital_recorders(gr::top_block_sptr tb, int r) {
 p25_recorder_sptr Source::create_digital_conventional_recorder(gr::top_block_sptr tb) {
   // Not adding it to the vector of digital_recorders. We don't want it to be available for trunk recording.
   // Conventional recorders are tracked seperately in digital_conv_recorders
-  p25_recorder_sptr log = make_p25_recorder(this, "P25C");
+  p25_recorder_sptr log = make_p25_recorder(this, P25C);
   digital_conv_recorders.push_back(log);
   tb->connect(source_block, 0, log, 0);
   return log;
@@ -207,7 +207,7 @@ p25_recorder_sptr Source::create_digital_conventional_recorder(gr::top_block_spt
 dmr_recorder_sptr Source::create_dmr_conventional_recorder(gr::top_block_sptr tb) {
   // Not adding it to the vector of digital_recorders. We don't want it to be available for trunk recording.
   // Conventional recorders are tracked seperately in digital_conv_recorders
-  dmr_recorder_sptr log = make_dmr_recorder(this, "DMR");
+  dmr_recorder_sptr log = make_dmr_recorder(this, DMR);
   dmr_conv_recorders.push_back(log);
   tb->connect(source_block, 0, log, 0);
   return log;
@@ -271,35 +271,35 @@ void Source::print_recorders() {
        it != digital_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type_string() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<p25_recorder_sptr>::iterator it = digital_conv_recorders.begin();
        it != digital_conv_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type_string() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<dmr_recorder_sptr>::iterator it = dmr_conv_recorders.begin();
        it != dmr_conv_recorders.end(); it++) {
     dmr_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type_string() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<analog_recorder_sptr>::iterator it = analog_recorders.begin();
        it != analog_recorders.end(); it++) {
     analog_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type_string() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<analog_recorder_sptr>::iterator it = analog_conv_recorders.begin();
        it != analog_conv_recorders.end(); it++) {
     analog_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type_string() << "\tState: " << format_state(rx->get_state());
   }
 }
 

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -136,10 +136,10 @@ int Source::get_if_gain() {
 }
 
 analog_recorder_sptr Source::create_conventional_recorder(gr::top_block_sptr tb) {
-
-  analog_recorder_sptr log = make_analog_recorder(this);
-
-  analog_recorders.push_back(log);
+  // Not adding it to the vector of analog_recorders. We don't want it to be available for trunk recording.
+  // Conventional recorders are tracked seperately in analog_conv_recorders
+  analog_recorder_sptr log = make_analog_recorder(this, "AnalogC");
+  analog_conv_recorders.push_back(log);
   tb->connect(source_block, 0, log, 0);
   return log;
 }
@@ -148,7 +148,7 @@ void Source::create_analog_recorders(gr::top_block_sptr tb, int r) {
   max_analog_recorders = r;
 
   for (int i = 0; i < max_analog_recorders; i++) {
-    analog_recorder_sptr log = make_analog_recorder(this);
+    analog_recorder_sptr log = make_analog_recorder(this,"Analog");
     analog_recorders.push_back(log);
     tb->connect(source_block, 0, log, 0);
   }
@@ -189,7 +189,7 @@ void Source::create_digital_recorders(gr::top_block_sptr tb, int r) {
   max_digital_recorders = r;
 
   for (int i = 0; i < max_digital_recorders; i++) {
-    p25_recorder_sptr log = make_p25_recorder(this);
+    p25_recorder_sptr log = make_p25_recorder(this, "P25");
     digital_recorders.push_back(log);
     tb->connect(source_block, 0, log, 0);
   }
@@ -197,14 +197,18 @@ void Source::create_digital_recorders(gr::top_block_sptr tb, int r) {
 
 p25_recorder_sptr Source::create_digital_conventional_recorder(gr::top_block_sptr tb) {
   // Not adding it to the vector of digital_recorders. We don't want it to be available for trunk recording.
-  p25_recorder_sptr log = make_p25_recorder(this);
+  // Conventional recorders are tracked seperately in digital_conv_recorders
+  p25_recorder_sptr log = make_p25_recorder(this, "P25C");
+  digital_conv_recorders.push_back(log);
   tb->connect(source_block, 0, log, 0);
   return log;
 }
 
 dmr_recorder_sptr Source::create_dmr_conventional_recorder(gr::top_block_sptr tb) {
   // Not adding it to the vector of digital_recorders. We don't want it to be available for trunk recording.
-  dmr_recorder_sptr log = make_dmr_recorder(this);
+  // Conventional recorders are tracked seperately in digital_conv_recorders
+  dmr_recorder_sptr log = make_dmr_recorder(this, "DMR");
+  dmr_conv_recorders.push_back(log);
   tb->connect(source_block, 0, log, 0);
   return log;
 }
@@ -261,20 +265,41 @@ Recorder *Source::get_sigmf_recorder() {
 }
 
 void Source::print_recorders() {
-  BOOST_LOG_TRIVIAL(info) << "[ " << device << " ]  ";
+  BOOST_LOG_TRIVIAL(info) << "[ Source " << src_num << ": " << format_freq(center) << " ] " << device ;
 
   for (std::vector<p25_recorder_sptr>::iterator it = digital_recorders.begin();
        it != digital_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "[ D" << rx->get_num() << " ] State: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+  }
+
+  for (std::vector<p25_recorder_sptr>::iterator it = digital_conv_recorders.begin();
+       it != digital_conv_recorders.end(); it++) {
+    p25_recorder_sptr rx = *it;
+
+    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+  }
+
+  for (std::vector<dmr_recorder_sptr>::iterator it = dmr_conv_recorders.begin();
+       it != dmr_conv_recorders.end(); it++) {
+    dmr_recorder_sptr rx = *it;
+
+    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<analog_recorder_sptr>::iterator it = analog_recorders.begin();
        it != analog_recorders.end(); it++) {
     analog_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "[ A" << rx->get_num() << " ] State: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+  }
+
+  for (std::vector<analog_recorder_sptr>::iterator it = analog_conv_recorders.begin();
+       it != analog_conv_recorders.end(); it++) {
+    analog_recorder_sptr rx = *it;
+
+    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
   }
 }
 
@@ -289,11 +314,11 @@ void Source::tune_digital_recorders() {
 }
 
 int Source::digital_recorder_count() {
-  return digital_recorders.size();
+  return digital_recorders.size() + digital_conv_recorders.size() + dmr_conv_recorders.size();
 }
 
 int Source::analog_recorder_count() {
-  return analog_recorders.size();
+  return analog_recorders.size() + analog_conv_recorders.size();
 }
 
 int Source::debug_recorder_count() {
@@ -500,7 +525,22 @@ std::vector<Recorder *> Source::get_recorders() {
     recorders.push_back((Recorder *)rx.get());
   }
 
+  for (std::vector<p25_recorder_sptr>::iterator it = digital_conv_recorders.begin(); it != digital_conv_recorders.end(); it++) {
+    p25_recorder_sptr rx = *it;
+    recorders.push_back((Recorder *)rx.get());
+  }
+
+  for (std::vector<dmr_recorder_sptr>::iterator it = dmr_conv_recorders.begin(); it != dmr_conv_recorders.end(); it++) {
+    dmr_recorder_sptr rx = *it;
+    recorders.push_back((Recorder *)rx.get());
+  }
+
   for (std::vector<analog_recorder_sptr>::iterator it = analog_recorders.begin(); it != analog_recorders.end(); it++) {
+    analog_recorder_sptr rx = *it;
+    recorders.push_back((Recorder *)rx.get());
+  }
+
+  for (std::vector<analog_recorder_sptr>::iterator it = analog_conv_recorders.begin(); it != analog_conv_recorders.end(); it++) {
     analog_recorder_sptr rx = *it;
     recorders.push_back((Recorder *)rx.get());
   }

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -271,35 +271,35 @@ void Source::print_recorders() {
        it != digital_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<p25_recorder_sptr>::iterator it = digital_conv_recorders.begin();
        it != digital_conv_recorders.end(); it++) {
     p25_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<dmr_recorder_sptr>::iterator it = dmr_conv_recorders.begin();
        it != dmr_conv_recorders.end(); it++) {
     dmr_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<analog_recorder_sptr>::iterator it = analog_recorders.begin();
        it != analog_recorders.end(); it++) {
     analog_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
   }
 
   for (std::vector<analog_recorder_sptr>::iterator it = analog_conv_recorders.begin();
        it != analog_conv_recorders.end(); it++) {
     analog_recorder_sptr rx = *it;
 
-    BOOST_LOG_TRIVIAL(info) << "  [ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
+    BOOST_LOG_TRIVIAL(info) << "\t[ " << rx->get_num() << " ] " << rx->get_type() << "\tState: " << format_state(rx->get_state());
   }
 }
 

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -148,7 +148,7 @@ void Source::create_analog_recorders(gr::top_block_sptr tb, int r) {
   max_analog_recorders = r;
 
   for (int i = 0; i < max_analog_recorders; i++) {
-    analog_recorder_sptr log = make_analog_recorder(this,"Analog");
+    analog_recorder_sptr log = make_analog_recorder(this, "Analog");
     analog_recorders.push_back(log);
     tb->connect(source_block, 0, log, 0);
   }

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -50,9 +50,12 @@ class Source {
   Config *config;
 
   std::vector<p25_recorder_sptr> digital_recorders;
+  std::vector<p25_recorder_sptr> digital_conv_recorders;
   std::vector<debug_recorder_sptr> debug_recorders;
   std::vector<sigmf_recorder_sptr> sigmf_recorders;
   std::vector<analog_recorder_sptr> analog_recorders;
+  std::vector<analog_recorder_sptr> analog_conv_recorders;
+  std::vector<dmr_recorder_sptr> dmr_conv_recorders;
   std::vector<Gain_Stage_t> gain_stages;
   std::string driver;
   std::string device;


### PR DESCRIPTION
Conventional recorders are not displayed in plugins such as MQTT or status-server, or in console logs.

This is addressed by giving each type of conventional recorder (P25c, Analog Conventional, DMR) a separate vector that will be represented in such functions as: `get_recorders()`, `print_recorders()`, `digital_recorder_count()`, and `analog_recorder_count()`.

Analog _conventional_ recorders are currently listed in `analog_recorders` along with _trunked_ recorders. While it seems unlikely that a trunked system would be able to preempt an idle conventional recorder, a separate vector for conventional analog addresses any potential overlap between system types.

To differentiate conventional recorders from their trunked counterparts, `make_xxxx_recorder()` functions accept a `type` string instead of relying on a hard-coded value when the recorder instance is created.  This way, status plugins will not not only display conventional recorders, but can show "P25" or "P25C".

Conventional recorder types are now visible in the periodic console message, along with the center frequency of each source.  This status message has also been indented to match the `Currently Active Calls` display immediately above it.
```
(info)   [ Source 0: 455.562500 MHz ] rtl=01,bias=1
(info)   	[ 9 ] P25C	State: idle
(info)   	[ 10 ] P25C	State: idle
(info)   	[ 11 ] AnalogC	State: idle
(info)   [ Source 1: 770.068750 MHz ] rtl=02
(info)   	[ 0 ] P25	State: available
(info)   	[ 1 ] P25	State: available
(info)   	[ 2 ] P25	State: available
(info)   	[ 3 ] P25	State: available
(info)   	[ 4 ] P25	State: available
(info)   	[ 5 ] P25	State: available
(info)   [ Source 2: 771.506250 MHz ] rtl=03
(info)   	[ 6 ] P25	State: available
(info)   	[ 7 ] P25	State: recording
(info)   	[ 8 ] P25	State: available
```
Any installed MQTT plugins will need to be recompiled after these changes, but no further action is required to display conventional recorders in messages.