### PR TITLE
Cleanup dropped samples logging.

### DIFF
--- a/trunk-recorder/gr_blocks/transmission_sink.cc
+++ b/trunk-recorder/gr_blocks/transmission_sink.cc
@@ -305,7 +305,13 @@ int transmission_sink::work(int noutput_items, gr_vector_const_void_star &input_
     char formattedTalkgroup[62];
     snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, 35, d_current_call_talkgroup, 0x1B);
     std::string talkgroup_display = boost::lexical_cast<std::string>(formattedTalkgroup);
-    BOOST_LOG_TRIVIAL(error) << "[" << d_current_call_short_name << "]\t\033[0;34m" << d_current_call_num << "C\033[0m\tTG: " << formattedTalkgroup << "\tFreq: " << format_freq(d_current_call_freq) << "\tDropping samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
+
+    if(noutput_items == 1){
+      BOOST_LOG_TRIVIAL(trace) << "[" << d_current_call_short_name << "]\t\033[0;34m" << d_current_call_num << "C\033[0m\tTG: " << formattedTalkgroup << "\tFreq: " << format_freq(d_current_call_freq) << "\tDropping " << noutput_items << " samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
+    }
+    else{
+      BOOST_LOG_TRIVIAL(error) << "[" << d_current_call_short_name << "]\t\033[0;34m" << d_current_call_num << "C\033[0m\tTG: " << formattedTalkgroup << "\tFreq: " << format_freq(d_current_call_freq) << "\tDropping " << noutput_items << " samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
+    }
 
     return noutput_items;
   }

--- a/trunk-recorder/gr_blocks/transmission_sink.cc
+++ b/trunk-recorder/gr_blocks/transmission_sink.cc
@@ -306,6 +306,8 @@ int transmission_sink::work(int noutput_items, gr_vector_const_void_star &input_
     snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, 35, d_current_call_talkgroup, 0x1B);
     std::string talkgroup_display = boost::lexical_cast<std::string>(formattedTalkgroup);
 
+    // It is possible the P25 Frame Assembler passes a TDU after the call has timed out.
+    // In this case, the termination tag will be transferred on a blank sample and can safely be ignored.
     if(noutput_items == 1){
       BOOST_LOG_TRIVIAL(trace) << "[" << d_current_call_short_name << "]\t\033[0;34m" << d_current_call_num << "C\033[0m\tTG: " << formattedTalkgroup << "\tFreq: " << format_freq(d_current_call_freq) << "\tDropping " << noutput_items << " samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
     }


### PR DESCRIPTION
When an inactive P25 call is stopped, occasionally there can still be a single tagged sample used to pass the terminate tag that transmission_sink attempts to process, resulting in a "current_call is null" error. This PR would make the log trace-level if only a single sample is dropped, and make it an error-level when more samples are dropped.
```
[2022-12-13 17:36:42.010653] (info)   [ramsey]  923C     - Stopping P25 Recorder Num [1] TG:           EMSMRCC (      2142)   Freq: 852.662500 MHz    TDMA: false     Slot: 0 Hz Error: -926
[2022-12-13 17:36:42.011798] (info)   [ramsey]  923C     TG: 2142     Freq: 852.662500 MHz    - Transmission src: 121148 pos: 0 length: 1.08
[2022-12-13 17:36:42.012359] (error)   [ramsey] 923C     TG: 2142     Freq: 852.662500 MHz    Dropping samples - current_call is null        Rec State: available   Since close: 1
```