### PR TITLE
Enable/Disable config sections

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -151,6 +151,7 @@ Here is a map of the different sections of the *config.json* file:
 | vga1Gain         |          |               | number                                                       | [bladeRF only] sets the **VGA1** gain.                       |
 | vga2Gain         |          |               | number                                                       | [bladeRF only] sets the **VGA2** gain.                       |
 | antenna          |          |               | string, e.g.: **"TX/RX"**                                    | [usrp] selects which antenna jack to use                     |
+| enabled          |          |     true      | **true** / **false**                                         | control whether a configured source is enabled or disabled   |
 
 
 #### System Object
@@ -195,6 +196,7 @@ Here is a map of the different sections of the *config.json* file:
 | decodeFSync            |          | false                          | **true** / **false**                                         | [ Conventional systems only ] enable the Fleet Sync signaling decoder. |
 | decodeStar             |          | false                          | **true** / **false**                                         | [ Conventional systems only ] enable the Star signaling decoder. |
 | decodeTPS              |          | false                          | **true** / **false**                                         | [ Conventional systems only ] enable the Motorola Tactical Public Safety (aka FDNY Fireground) signaling decoder. |
+| enabled                |          | true                           | **true** / **false**                                         | control whether a configured system is enabled or disabled                 |
 
 
 
@@ -204,6 +206,7 @@ Here is a map of the different sections of the *config.json* file:
 | ------- | :------: | ------------- | ------ | ------------------------------------------------------------ |
 | library |    ✓     |               | string | the name of the library that contains the plugin.            |
 | name    |    ✓     |               | string | the name of the plugin. This name is used to find the `<name>_plugin_new` method that creates a new instance of the plugin. |
+| enabled |          | true          | **true** / **false**    | control whether a configured plugin is enabled or disabled                 |
 |         |          |               |        | *Additional elements can be added, they will be passed into the `parse_config` method of the plugin.* |
 
 ##### Rdio Scanner Plugin

--- a/trunk-recorder/plugin_manager/plugin_manager.cc
+++ b/trunk-recorder/plugin_manager/plugin_manager.cc
@@ -41,9 +41,11 @@ void initialize_plugins(boost::property_tree::ptree &cfg, Config *config, std::v
     BOOST_FOREACH (boost::property_tree::ptree::value_type &node, cfg.get_child("plugins")) {
       std::string plugin_lib = node.second.get<std::string>("library", "");
       std::string plugin_name = node.second.get<std::string>("name", "");
-
-      Plugin *plugin = setup_plugin(plugin_lib, plugin_name);
-      plugin->api->parse_config(node.second);
+      bool plugin_enabled = node.second.get<bool>("enabled", true);
+      if (plugin_enabled) {
+        Plugin *plugin = setup_plugin(plugin_lib, plugin_name);
+        plugin->api->parse_config(node.second);
+      }
     }
 
     if (plugins.size() == 1) {


### PR DESCRIPTION
For the purpose of troubleshooting or managing a trunk-recorder setup, it is desirable to easily enable/disable portions of the config.json.  The only way to presently do so is to save a backup copy and delete portions of the config, or copy/paste any deleted portions back in.

This change simply adds a `"enabled": false` or `"enabled": true`(default) option to individual `sources`, `systems`, or `plugins`.  Disabled elements of the config file are simply ignored upon startup.