### PR TITLE
Update signaling decoders to print logs via boost info log instead of plain stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     build-essential \
     ca-certificates \
     cmake \
+    curl \
     docker.io \
     fdkaac \
     git \

--- a/trunk-recorder/gr_blocks/decoders/signal_decoder_sink_impl.cc
+++ b/trunk-recorder/gr_blocks/decoders/signal_decoder_sink_impl.cc
@@ -91,7 +91,7 @@ void mdc_callback(int frameCount, // 1 or 2 - if 2 then extra0-3 are valid
                                              "\"ex3\":\"%02x\"}\n",
            (int)time(NULL), op, arg, unitID, extra0, extra1, extra2, extra3);
 
-  fprintf(stdout, "%s\n", json_buffer);
+  BOOST_LOG_TRIVIAL(info) << json_buffer;
 
   signal_decoder_sink_impl *decoder = (signal_decoder_sink_impl *)context;
 
@@ -116,7 +116,8 @@ void fsync_callback(int cmd, int subcmd, int from_fleet, int from_unit, int to_f
            to_fleet, to_unit, allflag,
            payload_len, payload,
            is_fsync2, is_2400);
-  fprintf(stdout, "%s\n", json_buffer);
+
+  BOOST_LOG_TRIVIAL(info) << json_buffer;
 
   signal_decoder_sink_impl *decoder = (signal_decoder_sink_impl *)context;
   decoder->log_decoder_msg(from_unit, "FLEETSYNC", SignalType::Normal);
@@ -131,7 +132,8 @@ void star_callback(int unitID, int tag, int status, int message, void *context) 
                                              "\"status\":\"%d\","
                                              "\"message\":\"%d\"}\n",
            (int)time(NULL), unitID, tag, status, message);
-  fprintf(stdout, "%s\n", json_buffer);
+
+  BOOST_LOG_TRIVIAL(info) << json_buffer;
 
   signal_decoder_sink_impl *decoder = (signal_decoder_sink_impl *)context;
   decoder->log_decoder_msg(unitID, "STAR", SignalType::Normal);


### PR DESCRIPTION
I noticed that the signaling decoders were printing out decoded signals to stdout, instead of via a `BOOST_LOG_TRIVIAL` call. This can get pretty noisy if there's a lot of transmissions being decoded. By using the info log, someone can set a different loglevel to exclude them.

This changes the logs from:

```
{"type":"MDC1200","timestamp":"1672355479","op":"01","arg":"00","unitID":"5bad","ex0":"00","ex1":"00","ex2":"00","ex3":"00"}
```

to:

```
[2022-12-29 23:11:19.361464] (info)   {"type":"MDC1200","timestamp":"1672355479","op":"01","arg":"00","unitID":"5bad","ex0":"00","ex1":"00","ex2":"00","ex3":"00"}
```

Besides this change, I also added `curl` to the Dockerfile since it can be useful for upload scripts that need to call APIs (and there's no other http client currently present).