### PR TITLE
Use more compatible cmake command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_minimum_required(VERSION 3.2)
 project(Trunk-Recorder LANGUAGES CXX C VERSION "4.5.0")
 
 configure_file(cmake.h.in "${PROJECT_BINARY_DIR}/cmake.h" @ONLY)
-ADD_COMPILE_DEFINITIONS(MANUAL_GITINFO="${MANUAL_GITINFO}")
+add_definitions(-DMANUAL_GITINFO="${MANUAL_GITINFO}")
 include_directories("${PROJECT_BINARY_DIR}")
 
 # Define the two required variables before including


### PR DESCRIPTION
`add_compile_definitions` was added in cmake 3.12.4, but is just some syntactical sugar for `add_definitions`. Fall back to that command to keep compatibility with the defined minimum cmake version (3.2). This also maintains compatibility with Ubuntu 18.04, as it ships with cmake 3.10.2.