### PR TITLE
Clean up a few debug warning messages.

### DIFF
--- a/plugins/openmhz_uploader/openmhz_uploader.cc
+++ b/plugins/openmhz_uploader/openmhz_uploader.cc
@@ -64,7 +64,7 @@ public:
 
 
     if (call_info.transmission_source_list.size() != 0) {
-      for (int i = 0; i < call_info.transmission_source_list.size(); i++) {
+      for (unsigned long i = 0; i < call_info.transmission_source_list.size(); i++) {
         source_list << "{ \"pos\": " << std::setprecision(2) << call_info.transmission_source_list[i].position << ", \"src\": " << std::setprecision(0) << call_info.transmission_source_list[i].source << " }";
 
         if (i < (call_info.transmission_source_list.size() - 1)) {

--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -91,7 +91,7 @@ public:
     boost::filesystem::path audioName = audioPath.filename();
 
     if (call_info.transmission_source_list.size() != 0) {
-      for (int i = 0; i < call_info.transmission_source_list.size(); i++) {
+      for (unsigned long i = 0; i < call_info.transmission_source_list.size(); i++) {
         source_list << "{ \"pos\": " << std::setprecision(2) << call_info.transmission_source_list[i].position << ", \"src\": " << std::setprecision(0) << call_info.transmission_source_list[i].source << " }";
 
         if (i < (call_info.transmission_source_list.size() - 1)) {
@@ -105,7 +105,7 @@ public:
     }
 
     if (call_info.patched_talkgroups.size()>1){
-      for (int i = 0; i < call_info.patched_talkgroups.size(); i++) {
+      for (unsigned long i = 0; i < call_info.patched_talkgroups.size(); i++) {
         if (i!=0) { 
           patch_list << ",";
         }

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -304,8 +304,6 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
 }
 
 void Call_Concluder::conclude_call(Call *call, System *sys, Config config) {
-  char formattedTalkgroup[62];
-
   Call_Data_t call_info = create_call_data(call, sys, config);
 
   if(call->get_state() == MONITORING && call->get_monitoring_state() == SUPERSEDED){


### PR DESCRIPTION
Came across a few warning messages when I had to build with debugging enabled. Super easy to cleanup.

- Removes unused formattedTalkgroup variable in call_concluder.
- Fixes a type mismatch comparison in OpenMHZ uploader plugin.
- Fixes a type mismatch comparison in Rdio-Scanner uploader plugin.