### PR TITLE
fix for elusive crashing issue

### DIFF
--- a/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
+++ b/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
@@ -232,7 +232,7 @@ p25_frame_assembler_impl::general_work (int noutput_items,
       }
   consume_each(ninput_items[0]);
   // Tell runtime system how many output items we actually produced.
-  return amt_produce;
+  return noutput_items;
 }
 
     void p25_frame_assembler_impl::clear_silence_frame_count() {


### PR DESCRIPTION
see https://www.ruby-forum.com/t/s-d-bufsize-failed/59342/4

randomly this issue started raising its head again...

and on further investigation found this similar issue that involved almost the exact same pseudo-code,

I made the change and it appears to have stabilized a crashing issue that has been persisting for the past couple of days out of nowhere for some reason, appears from the debug logs I posted before to be the same issue, will delete this if it doesn't solve it upon further testing