### PR TITLE
use iterators for std::fill, fix out of bounds access

### DIFF
--- a/lib/op25_repeater/lib/ambe_encoder_sb_impl.cc
+++ b/lib/op25_repeater/lib/ambe_encoder_sb_impl.cc
@@ -79,9 +79,8 @@ ambe_encoder_sb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_it
 {
    /* produces 1 36-byte-block sample per 160 samples input
     */
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_samples_reqd = 160.0 * (nof_output_items);
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/lib/op25_repeater/lib/dmr_bs_tx_bb_impl.cc
+++ b/lib/op25_repeater/lib/dmr_bs_tx_bb_impl.cc
@@ -368,10 +368,9 @@ dmr_bs_tx_bb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items
 {
    // reads three ambe codewords (216 bits = 108 dibits) for each 144 dibit output burst
    // the three codewords though are only read from one of the two inputs per burst
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_bursts = nof_output_items / 144.0;
    const int nof_samples_reqd = 3 * ((nof_bursts+1)>>1);
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/lib/op25_repeater/lib/dstar_tx_sb_impl.cc
+++ b/lib/op25_repeater/lib/dstar_tx_sb_impl.cc
@@ -152,10 +152,9 @@ void
 dstar_tx_sb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items_reqd)
 {
    // each 96-bit output frame contains one voice code word=160 samples input
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_vcw = nof_output_items / 96.0;
    const int nof_samples_reqd = nof_vcw * 160;
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/lib/op25_repeater/lib/fsk4_demod_ff_impl.cc
+++ b/lib/op25_repeater/lib/fsk4_demod_ff_impl.cc
@@ -220,7 +220,7 @@ namespace gr {
     fsk4_demod_ff_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required)
     {
       const int nof_samples_reqd = static_cast<int>(ceil(d_block_rate * noutput_items));
-      std::fill(&ninput_items_required[0], &ninput_items_required[ninput_items_required.size()], nof_samples_reqd);
+      std::fill(ninput_items_required.begin(), ninput_items_required.end(), nof_samples_reqd);
     }
 
     int

--- a/lib/op25_repeater/lib/vocoder_impl.cc
+++ b/lib/op25_repeater/lib/vocoder_impl.cc
@@ -99,9 +99,8 @@ vocoder_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items_reqd
     *
     * Thanks to Matt Mills for catching a bug where this value wasn't set correctly
     */
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_samples_reqd = (opt_encode_flag) ? (1.66667 * nof_output_items) : (0.2 * nof_output_items);
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/lib/op25_repeater/lib/ysf_tx_sb_impl.cc
+++ b/lib/op25_repeater/lib/ysf_tx_sb_impl.cc
@@ -378,10 +378,9 @@ void
 ysf_tx_sb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items_reqd)
 {
    // each 480-dibit output frame contains five voice code words=800 samples
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_vcw = nof_output_items / 480.0;
    const int nof_samples_reqd = nof_vcw * 5 * 160;
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 


### PR DESCRIPTION
I debugged this with @ZeroChaos-

This fixes #779. The effective behaviour does not change as `std::fill` does nothing if `first > last`, but it avoids the UB of accessing the non-existant element.