### PR TITLE
UnitID alpha improvements and decode error display

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -277,12 +277,13 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
     }
 
     std::string tag = sys->find_unit_tag(t.source);
+    std::string display_tag = "";
     if (tag != "") {
-      tag = " (\033[0;34m" + tag + "\033[0m)";
+      display_tag = " (\033[0;34m" + tag + "\033[0m)";
     }
 
     std::stringstream transmission_info;
-    transmission_info << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\t- Transmission src: " << t.source << tag << " pos: " << format_time(total_length) << " length: " << format_time(t.length);
+    transmission_info << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\t- Transmission src: " << t.source << display_tag << " pos: " << format_time(total_length) << " length: " << format_time(t.length);
 
     if (t.error_count < 1) {
       BOOST_LOG_TRIVIAL(info) << transmission_info.str();

--- a/trunk-recorder/formatter.cc
+++ b/trunk-recorder/formatter.cc
@@ -26,6 +26,10 @@ boost::format FormatSamplingRate(float f) {
   return boost::format("%.0f") % f;
 }
 
+boost::format format_time(float f) {
+  return boost::format("%5.2f") % f;
+}
+
 std::string format_state(State state) {
   if (statusAsString) {
     if (state == MONITORING)

--- a/trunk-recorder/formatter.h
+++ b/trunk-recorder/formatter.h
@@ -7,6 +7,7 @@
 
 extern boost::format format_freq(double f);
 extern boost::format FormatSamplingRate(float f);
+extern boost::format format_time(float f);
 extern std::string format_state(State state);
 extern std::string format_state(State state, MonitoringState monitoringState);
 std::string get_frequency_format();

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -646,7 +646,12 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
     call->set_state(MONITORING);
     call->set_monitoring_state(ENCRYPTED);
     if (sys->get_hideEncrypted() == false) {
-      BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\t\033[0;34m" << call->get_call_num() << "C\033[0m\tTG: " << call->get_talkgroup_display() << "\tFreq: " << format_freq(call->get_freq()) << "\t\u001b[31mNot Recording: ENCRYPTED\u001b[0m ";
+      long unit_id = call->get_current_source_id();
+      std::string tag = sys->find_unit_tag(unit_id);
+      if (tag != "") {
+        tag = " (\033[0;34m" + tag + "\033[0m)";
+      }
+      BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\t\033[0;34m" << call->get_call_num() << "C\033[0m\tTG: " << call->get_talkgroup_display() << "\tFreq: " << format_freq(call->get_freq()) << "\t\u001b[31mNot Recording: ENCRYPTED\u001b[0m - src: " << unit_id << tag;
     }
     return false;
   }

--- a/trunk-recorder/unit_tags.cc
+++ b/trunk-recorder/unit_tags.cc
@@ -84,7 +84,7 @@ std::string UnitTags::find_unit_tag(long tg_number) {
     UnitTag *tg = (UnitTag *)*it;
 
     if (regex_match(tg_num_str, tg->pattern)) {
-      tag = regex_replace(tg_num_str, tg->pattern, tg->tag, boost::regex_constants::format_no_copy);
+      tag = regex_replace(tg_num_str, tg->pattern, tg->tag, boost::regex_constants::format_no_copy | boost::regex_constants::format_all);
       break;
     }
   }


### PR DESCRIPTION
This commit will display UnitID alpha in console messages to improve the view of trunk-recorder operations at the `info` logging level and aid in any UID regex debugging.  UnitID alpha was previously displayed in trunk-recorder 3.x console logs, and this commit would restore some of that functionality.

When a call ends, Call_Concluder will now display known UnitID alpha and any reported errors/spikes for that transmission.  Call times are formatted to two decimal places to avoid the initial `pos:  0` creating text alignment issues.

If `hideEncrypted` is false (default), UnitID and alpha will also be displayed to provide some insight into the nature of those transmissions.

Per discussion re: #764 with @EricTendian, the `format_all` flag is included to allow complex regex matches and conditional substitutions with the `unitTagsFile` in addition to the current behavior.