### PR TITLE
add -D_GLIBCXX_ASSERTIONS to CXXFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wno-unused-local-typedef -Wno-deprecated-decla
 
 SET(CMAKE_CXX_STANDARD 17)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wno-narrowing -fvisibility=hidden -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wno-narrowing -fvisibility=hidden -fPIC -D_GLIBCXX_ASSERTIONS")
 
 
 


### PR DESCRIPTION
Many linux distributions have switched this on by default, but TR does not have it on by default and so bugs are slipping through and hitting users.  Turn on bounds checking by default so that bugs are found quicker.

This WILL break users.  I'm sure of it.  It will cause program exit when running broken code, example being https://github.com/robotastic/trunk-recorder/issues/783 The performance penalty of this is minimal (none on modern distros where this is already teh default) and the bounds checking causing failure is better than simply running objectively wrong code.