### PR TITLE
OpenMHz Uploader update

### DIFF
--- a/plugins/openmhz_uploader/openmhz_uploader.cc
+++ b/plugins/openmhz_uploader/openmhz_uploader.cc
@@ -52,6 +52,16 @@ public:
     freq << std::fixed << std::setprecision(0);
     freq << call_info.freq;
 
+    std::ostringstream error_count;
+    std::string error_count_string;
+    error_count << std::fixed << std::setprecision(0);
+    error_count << call_info.error_count;
+
+    std::ostringstream spike_count;
+    std::string spike_count_string;
+    spike_count << std::fixed << std::setprecision(0);
+    spike_count << call_info.spike_count;
+
     std::ostringstream call_length;
     std::string call_length_string;
     call_length << std::fixed << std::setprecision(0);
@@ -77,28 +87,6 @@ public:
       source_list << "]";
     }
 
-
-    std::ostringstream freq_list;
-    std::string freq_list_string;
-    freq_list << std::fixed << std::setprecision(2);
-    freq_list << "[";
-
-    if (call_info.transmission_error_list.size() != 0) {
-      for (std::size_t i = 0; i < call_info.transmission_error_list.size(); i++) {
-          freq_list << "{\"freq\": " << std::fixed << std::setprecision(0) << call_info.freq << ", \"time\": " << call_info.transmission_error_list[i].time << ", \"pos\": " << std::fixed << std::setprecision(2) << call_info.transmission_error_list[i].position << ", \"len\": " << call_info.transmission_error_list[i].total_len  << ", \"error_count\": \"" << std::setprecision(0) <<call_info.transmission_error_list[i].error_count << "\", \"spike_count\": \"" << call_info.transmission_error_list[i].spike_count << "\"}"; 
-  
-        if (i < (call_info.transmission_error_list.size() - 1)) {
-          freq_list << ", ";
-        } else {
-          freq_list << "]";
-        }
-      }
-    }else {
-      freq_list << "]";
-    }
-
-
-
     char formattedTalkgroup[62];
     snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, 35, call_info.talkgroup, 0x1B);
     std::string talkgroup_display = boost::lexical_cast<std::string>(formattedTalkgroup);
@@ -108,9 +96,10 @@ public:
     int still_running = 0;
     std::string response_buffer;
     freq_string = freq.str();
+    error_count_string = error_count.str();
+    spike_count_string = spike_count.str();
 
     source_list_string = source_list.str();
-    freq_list_string = freq_list.str();
     call_length_string = call_length.str();
 
     struct curl_httppost *formpost = NULL;
@@ -130,6 +119,18 @@ public:
                  &lastptr,
                  CURLFORM_COPYNAME, "freq",
                  CURLFORM_COPYCONTENTS, freq_string.c_str(),
+                 CURLFORM_END);
+
+    curl_formadd(&formpost,
+                 &lastptr,
+                 CURLFORM_COPYNAME, "error_count",
+                 CURLFORM_COPYCONTENTS, error_count_string.c_str(),
+                 CURLFORM_END);
+
+    curl_formadd(&formpost,
+                 &lastptr,
+                 CURLFORM_COPYNAME, "spike_count",
+                 CURLFORM_COPYCONTENTS, spike_count_string.c_str(),
                  CURLFORM_END);
 
     curl_formadd(&formpost,
@@ -172,11 +173,6 @@ public:
                  &lastptr,
                  CURLFORM_COPYNAME, "source_list",
                  CURLFORM_COPYCONTENTS, source_list_string.c_str(),
-                 CURLFORM_END);
-    curl_formadd(&formpost,
-                 &lastptr,
-                 CURLFORM_COPYNAME, "freq_list",
-                 CURLFORM_COPYCONTENTS, freq_list_string.c_str(),
                  CURLFORM_END);
 
     curl = curl_easy_init();

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -216,6 +216,8 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
   call_info.status = INITIAL;
   call_info.process_call_time = time(0);
   call_info.retry_attempt = 0;
+  call_info.error_count = 0;
+  call_info.spike_count = 0;
   call_info.freq = call->get_freq();
   call_info.encrypted = call->get_encrypted();
   call_info.emergency = call->get_emergency();
@@ -291,6 +293,8 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
     std::string tag = sys->find_unit_tag(t.source);
     Call_Source call_source = {t.source, t.start_time, total_length, false, "", tag};
     Call_Error call_error = {t.start_time, total_length, t.length, t.error_count, t.spike_count};
+    call_info.error_count = call_info.error_count + t.error_count;
+    call_info.spike_count = call_info.spike_count + t.spike_count;
     call_info.transmission_source_list.push_back(call_source);
     call_info.transmission_error_list.push_back(call_error);
 

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -120,6 +120,8 @@ public:
   virtual int channel_count() = 0;
   virtual int get_message_count() = 0;
   virtual void set_message_count(int count) = 0;
+  virtual void set_decode_rate(int rate) = 0;
+  virtual int get_decode_rate() = 0;
   virtual void add_channel(double channel) = 0;
   virtual void add_conventional_recorder(analog_recorder_sptr rec) = 0;
   virtual std::vector<analog_recorder_sptr> get_conventional_recorders() = 0;

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -98,6 +98,7 @@ System_impl::System_impl(int sys_num) {
   d_tps_enabled = false;
   retune_attempts = 0;
   message_count = 0;
+  decode_rate = 0;
 }
 
 void System_impl::set_xor_mask(unsigned long sys_id, unsigned long wacn, unsigned long nac) {
@@ -368,6 +369,15 @@ int System_impl::get_message_count() {
 void System_impl::set_message_count(int count) {
   message_count = count;
 }
+
+void System_impl::set_decode_rate(int rate) {
+  decode_rate = rate;
+}
+
+int System_impl::get_decode_rate() {
+  return decode_rate;
+}
+
 void System_impl::add_control_channel(double control_channel) {
   if (control_channels.size() == 0) {
     control_channels.push_back(control_channel);

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -62,6 +62,7 @@ public:
   std::string upload_script;
   int bcfy_system_id;
   int message_count;
+  int decode_rate;
   int retune_attempts;
   time_t last_message_time;
   std::string bandplan;
@@ -174,6 +175,8 @@ public:
   int control_channel_count();
   int get_message_count();
   void set_message_count(int count);
+  int get_decode_rate();
+  void set_decode_rate(int rate);
   void add_control_channel(double channel);
   double get_next_control_channel();
   double get_current_control_channel();


### PR DESCRIPTION
Changes the way Error Count and Spike Count are sent to OpenMHz. It removes the Freq List and just sends the values as part of the main form. There is only one freq per call now, so no need for a list anymore.