### PR TITLE
Ignore missing files

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -156,13 +156,21 @@ Call_Data_t upload_call_worker(Call_Data_t call_info) {
     std::string shell_command_string;
     std::string files;
 
+    struct stat statbuf;
     // loop through the transmission list, pull in things to fill in totals for call_info
     // Using a for loop with iterator
     for (std::vector<Transmission>::iterator it = call_info.transmission_list.begin(); it != call_info.transmission_list.end(); ++it) {
       Transmission t = *it;
 
-      files.append(t.filename);
-      files.append(" ");
+      if (stat(t.filename, &statbuf) == 0)
+      {
+          files.append(t.filename);
+          files.append(" ");
+      }
+      else
+      {
+          BOOST_LOG_TRIVIAL(error) << "Somehow, " << t.filename << " doesn't exist, not attempting to provide it to sox";
+      }
     }
 
     combine_wav(files, call_info.filename);


### PR DESCRIPTION
Occasionally, trunk-recorder tries to combine two wav files into one, but one of them doesn't actually exist. This fixes the issue by checking for file existence before sending files to sox - which will preserve any audio that exists in the remaining file.

This situation was causing a `Failed to combine recordings, see above error. Make sure you have sox and fdkaac installed.` error occasionally, and resulted in the audio not being properly saved.
