### PR TITLE
Standardize Talkgroup Class

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -238,10 +238,10 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
 
   Talkgroup *tg = sys->find_talkgroup(call->get_talkgroup());
   if (tg != NULL) {
-    call_info.talkgroup_tag = tg->tag;
-    call_info.talkgroup_alpha_tag = tg->alpha_tag;
-    call_info.talkgroup_description = tg->description;
-    call_info.talkgroup_group = tg->group;
+    call_info.talkgroup_tag = tg->get_tag();
+    call_info.talkgroup_alpha_tag = tg->get_alpha_tag();
+    call_info.talkgroup_description = tg->get_description();
+    call_info.talkgroup_group = tg->get_group();
   } else {
     call_info.talkgroup_tag = "";
     call_info.talkgroup_alpha_tag = "";

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -638,12 +638,12 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
   }
 
   if (talkgroup) {
-    call->set_talkgroup_tag(talkgroup->alpha_tag);
+    call->set_talkgroup_tag(talkgroup->get_alpha_tag());
   } else {
     call->set_talkgroup_tag("-");
   }
 
-  if (call->get_encrypted() == true || (talkgroup && (talkgroup->mode.compare("E") == 0 || talkgroup->mode.compare("TE") == 0 || talkgroup->mode.compare("DE") == 0))) {
+  if (call->get_encrypted() == true || (talkgroup && (talkgroup->get_mode().compare("E") == 0 || talkgroup->get_mode().compare("TE") == 0 || talkgroup->get_mode().compare("DE") == 0))) {
     call->set_state(MONITORING);
     call->set_monitoring_state(ENCRYPTED);
     if (sys->get_hideEncrypted() == false) {
@@ -669,7 +669,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
             }
           }
         }
-        if (talkgroup->mode.compare("A") == 0) {
+        if (talkgroup->get_mode().compare("A") == 0) {
           recorder = source->get_analog_recorder(talkgroup, priority, call);
           call->set_is_analog(true);
         } else {
@@ -1136,7 +1136,7 @@ void handle_call_grant(TrunkMessage message, System *sys) {
     Talkgroup *talkgroup = sys->find_talkgroup(call->get_talkgroup());
 
     if (talkgroup) {
-      call->set_talkgroup_tag(talkgroup->alpha_tag);
+      call->set_talkgroup_tag(talkgroup->get_alpha_tag());
     } else {
       call->set_talkgroup_tag("-");
     }
@@ -1542,8 +1542,8 @@ bool setup_convetional_channel(System *system, double frequency, long channel_in
       Call_conventional *call = NULL;
       if (system->has_channel_file()) {
         Talkgroup *tg = system->find_talkgroup_by_freq(frequency);
-        call = new Call_conventional(tg->number, tg->freq, system, config);
-        call->set_talkgroup_tag(tg->alpha_tag);
+        call = new Call_conventional(tg->get_number(), tg->get_freq(), system, config);
+        call->set_talkgroup_tag(tg->get_alpha_tag());
       } else {
         call = new Call_conventional(channel_index, frequency, system, config);
       }
@@ -1594,10 +1594,10 @@ bool setup_conventional_system(System *system) {
     for (vector<Talkgroup *>::iterator tg_it = talkgroups.begin(); tg_it != talkgroups.end(); tg_it++) {
       Talkgroup *tg = *tg_it;
 
-      bool channel_added = setup_convetional_channel(system, tg->freq, tg->number);
+      bool channel_added = setup_convetional_channel(system, tg->get_freq(), tg->get_number());
 
       if (!channel_added) {
-        BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "]\t Unable to find a source for this conventional channel! Channel not added: " << format_freq(tg->freq) << " Talkgroup: " << tg->number;
+        BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "]\t Unable to find a source for this conventional channel! Channel not added: " << format_freq(tg->get_freq()) << " Talkgroup: " << tg->get_number();
         // return false;
       } else {
         system_added = true;

--- a/trunk-recorder/talkgroup.cc
+++ b/trunk-recorder/talkgroup.cc
@@ -44,23 +44,90 @@ std::string Talkgroup::menu_string() {
   return buffAsStdStr;
 }
 
-int Talkgroup::get_priority() {
-  return priority;
+long Talkgroup::get_number() {
+  return number;
 }
 
-unsigned long Talkgroup::get_preferredNAC() {
-  return preferredNAC;
-}
-
-void Talkgroup::set_priority(int new_priority) {
-  priority = new_priority;
-  return;
+int Talkgroup::get_sys_num() {
+  return sys_num;
 }
 
 bool Talkgroup::is_active() {
   return active;
 }
 
-void Talkgroup::set_active(bool a) {
-  active = a;
+void Talkgroup::set_active(bool new_active) {
+  active = new_active;
+}
+
+int Talkgroup::get_priority() {
+  return priority;
+}
+
+void Talkgroup::set_priority(int new_priority) {
+  priority = new_priority;
+}
+
+unsigned long Talkgroup::get_preferredNAC() {
+  return preferredNAC;
+}
+
+void Talkgroup::set_preferredNAC(unsigned long new_preferredNAC){
+  preferredNAC = new_preferredNAC;
+}
+
+std::string Talkgroup::get_mode() {
+  return mode;
+}
+
+void Talkgroup::set_mode(std::string new_mode) {
+  mode = new_mode;
+}
+
+std::string Talkgroup::get_alpha_tag() {
+  return alpha_tag;
+}
+
+void Talkgroup::set_alpha_tag(std::string new_alpha_tag) {
+  alpha_tag = new_alpha_tag;
+}
+
+std::string Talkgroup::get_description() {
+  return description;
+}
+
+void Talkgroup::set_description(std::string new_description) {
+  description = new_description;
+}
+
+std::string Talkgroup::get_tag() {
+  return tag;
+}
+
+void Talkgroup::set_tag(std::string new_tag) {
+  tag = new_tag;
+}
+
+std::string Talkgroup::get_group() {
+  return group;
+}
+
+void Talkgroup::set_group(std::string new_group) {
+  group = new_group;
+}
+  
+double Talkgroup::get_freq() {
+  return freq;
+}
+
+void Talkgroup::set_freq(double new_freq) {
+  freq = new_freq;
+}
+
+double Talkgroup::get_tone() {
+  return tone;
+}
+
+void Talkgroup::set_tone(double new_tone) {
+  tone = new_tone;
 }

--- a/trunk-recorder/talkgroup.h
+++ b/trunk-recorder/talkgroup.h
@@ -8,6 +8,46 @@
 
 class Talkgroup {
 public:
+  Talkgroup(int sys_num, long num, std::string mode, std::string alpha_tag, std::string description, std::string tag, std::string group, int priority, unsigned long preferredNAC);
+  Talkgroup(int sys_num, long num, double freq, double tone, std::string alpha_tag, std::string description, std::string tag, std::string group);
+
+  long get_number();
+  int get_sys_num();
+
+  bool is_active();
+  void set_active(bool new_active);
+  
+  int get_priority();
+  void set_priority(int new_priority);
+
+  unsigned long get_preferredNAC();
+  void set_preferredNAC(unsigned long new_preferredNAC);
+
+  std::string get_mode();
+  void set_mode(std::string new_mode);
+
+  std::string get_alpha_tag();
+  void set_alpha_tag(std::string new_alpha_tag);
+
+  std::string get_description();
+  void set_description(std::string new_description);
+
+  std::string get_tag();
+  void set_tag(std::string new_tag);
+
+  std::string get_group();
+  void set_group(std::string new_group);
+
+  double get_freq();
+  void set_freq(double new_freq);
+
+  double get_tone();
+  void set_tone(double new_tone);
+
+  std::string menu_string();
+
+private:
+  bool active;
   long number;
   std::string mode;
   std::string alpha_tag;
@@ -16,25 +56,11 @@ public:
   std::string group;
   int priority;
   int sys_num;
-
+  unsigned long preferredNAC;
 
   // For Conventional
   double freq;
   double tone;
-
-  Talkgroup(int sys_num, long num, std::string mode, std::string alpha_tag, std::string description, std::string tag, std::string group, int priority, unsigned long preferredNAC);
-  Talkgroup(int sys_num, long num, double freq, double tone, std::string alpha_tag, std::string description, std::string tag, std::string group);
-
-  bool is_active();
-  int get_priority();
-  unsigned long get_preferredNAC();
-  void set_priority(int new_priority);
-  void set_active(bool a);
-  std::string menu_string();
-
-private:
-  unsigned long preferredNAC;
-  bool active;
 };
 
 #endif

--- a/trunk-recorder/talkgroups.cc
+++ b/trunk-recorder/talkgroups.cc
@@ -201,7 +201,7 @@ Talkgroup *Talkgroups::find_talkgroup(int sys_num, long tg_number) {
   for (std::vector<Talkgroup *>::iterator it = talkgroups.begin(); it != talkgroups.end(); ++it) {
     Talkgroup *tg = (Talkgroup *)*it;
 
-    if ((tg->sys_num == sys_num) && (tg->number == tg_number)) {
+    if ((tg->get_sys_num() == sys_num) && (tg->get_number() == tg_number)) {
       tg_match = tg;
       break;
     }
@@ -215,7 +215,7 @@ Talkgroup *Talkgroups::find_talkgroup_by_freq(int sys_num, double freq) {
   for (std::vector<Talkgroup *>::iterator it = talkgroups.begin(); it != talkgroups.end(); ++it) {
     Talkgroup *tg = (Talkgroup *)*it;
 
-    if ((tg->sys_num == sys_num) && (tg->freq == freq)) {
+    if ((tg->get_sys_num() == sys_num) && (tg->get_freq() == freq)) {
       tg_match = tg;
       break;
     }


### PR DESCRIPTION
This would standardize the talkgroup class to user getters/setters much like many of the other classes. This would also allow access to modify many of the talkgroup's settings from either within trunk-recorder or from the plugins.

I've modified the internal calls and verified the internal plugins work with these additions. This could potentially break any external plugins that are directly accessing the talkgroup members, but it seems like the added functionality would probably outweigh the minor changes needed to update these plugins.