### PR TITLE
actual crash fix this time

### DIFF
--- a/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
+++ b/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
@@ -183,6 +183,10 @@ p25_frame_assembler_impl::general_work (int noutput_items,
         //BOOST_LOG_TRIVIAL(trace) << "P25 Frame Assembler -  output_queue: " << output_queue.size() << " noutput_items: " <<  noutput_items << " ninput_items: " << ninput_items[0];
 
       if (amt_produce > 0) {
+          if (amt_produce >= 32768) {
+            BOOST_LOG_TRIVIAL(error) << "just saved you from a crash, amt_produce = " << amt_produce;
+            amt_produce = 32767; // buffer limit is 32768, see gnuradio/gnuradio-runtime/lib/../include/gnuradio/buffer.h:186
+          }
           long src_id = p1fdma.get_curr_src_id();
           long grp_id = p1fdma.get_curr_grp_id();
           // If a SRC wasn't received on the voice channel since the last check, it will be -1

--- a/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
+++ b/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
@@ -184,7 +184,8 @@ p25_frame_assembler_impl::general_work (int noutput_items,
 
       if (amt_produce > 0) {
           if (amt_produce >= 32768) {
-            BOOST_LOG_TRIVIAL(error) << "just saved you from a crash, amt_produce = " << amt_produce;
+            BOOST_LOG_TRIVIAL(error) << "P25 Frame Assembler -  output_queue size: " << output_queue.size() << " max size: " << output_queue.max_size() << " limiting amt_produce to  32767 ";
+            
             amt_produce = 32767; // buffer limit is 32768, see gnuradio/gnuradio-runtime/lib/../include/gnuradio/buffer.h:186
           }
           long src_id = p1fdma.get_curr_src_id();


### PR DESCRIPTION
this is the actual crash fix i kept messing up and submitting pull requests for, for real this time

honestly this is probably not the best way to solve it, but there is a case where amt_produce ends up going over 32768 and it crashes the program faithfully every time, and this has appeared to solve it for me without any obvious negative side effects, there is probably a better way to go about doing this and its pretty much a hack, but it's a hack that works at least