### PR TITLE
Update call_concluder.h

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.h
+++ b/trunk-recorder/call_concluder/call_concluder.h
@@ -1,6 +1,7 @@
 #ifndef CALL_CONCLUDER_H
 #define CALL_CONCLUDER_H
 #include <boost/regex.hpp>
+#include <sys/stat.h>
 #include <ctime>
 #include <future>
 #include <list>


### PR DESCRIPTION
Added <sys/stat.h> to `call_concluder` to allow trunk recorder to compile on Ubuntu and pass github Buildx checks after #796.