### PR TITLE
Fix freq offset variable declarations in trunking messages

### DIFF
--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -847,7 +847,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
     unsigned long spac = bitset_shift_mask(tsbk, 48, 0x3ff);
     unsigned long freq = bitset_shift_mask(tsbk, 16, 0xffffffff);
     unsigned long toff_sign = (toff0 >> 8) & 1;
-    unsigned long toff = toff0 & 0xff;
+    long toff = toff0 & 0xff;
 
     if (toff_sign == 0) {
       toff = 0 - toff;

--- a/trunk-recorder/systems/p25_parser.h
+++ b/trunk-recorder/systems/p25_parser.h
@@ -12,7 +12,7 @@
 
 struct Channel {
   unsigned long id;
-  unsigned long offset;
+  long offset;
   unsigned long step;
   unsigned long frequency;
   bool phase2_tdma;


### PR DESCRIPTION
Frequency offsets calculated by the p25 parser can sometimes be negative, but are currently being stored as unsigned.  While this information does not appear to be used by trunk-recorder, it corrects malformed output when viewing logs at the `trace` level.