### PR TITLE
Remove sys num

### DIFF
--- a/lib/op25_repeater/include/op25_repeater/frame_assembler.h
+++ b/lib/op25_repeater/include/op25_repeater/frame_assembler.h
@@ -50,7 +50,7 @@ namespace gr {
                  * class. op25_repeater::frame_assembler::make is the public interface for
                  * creating new instances.
                  */
-                static sptr make(int sys_num, const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue);
+                static sptr make(const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue);
                 virtual void set_xormask(const char*p) {}
                 virtual void set_nac(int nac) {}
                 virtual void set_slotid(int slotid) {}

--- a/lib/op25_repeater/include/op25_repeater/p25_frame_assembler.h
+++ b/lib/op25_repeater/include/op25_repeater/p25_frame_assembler.h
@@ -52,7 +52,7 @@ namespace gr {
        * class. op25_repeater::p25_frame_assembler::make is the public interface for
        * creating new instances.
        */
-      static sptr make(int sys_num, int silence_frames, const char* udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt);
+      static sptr make(int silence_frames, const char* udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt);
       virtual void set_xormask(const char*p) {}
       virtual void set_nac(int nac) {}
       virtual void set_slotid(int slotid) {}

--- a/lib/op25_repeater/lib/frame_assembler_impl.cc
+++ b/lib/op25_repeater/lib/frame_assembler_impl.cc
@@ -71,10 +71,10 @@ namespace gr {
         }
 
         frame_assembler::sptr
-            frame_assembler::make(int sys_num, const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue)
+            frame_assembler::make(const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue)
             {
                 return gnuradio::get_initial_sptr
-                    (new frame_assembler_impl(sys_num, options, debug, msgq_id, queue));
+                    (new frame_assembler_impl(options, debug, msgq_id, queue));
             }
 
         /*
@@ -92,7 +92,7 @@ namespace gr {
         /*
          * The private constructor
          */
-        frame_assembler_impl::frame_assembler_impl(int sys_num, const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue)
+        frame_assembler_impl::frame_assembler_impl(const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue)
             : gr::block("frame_assembler",
                     gr::io_signature::make (MIN_IN, MAX_IN, sizeof (char)),
 	                gr::io_signature::make ( 2, 2, sizeof(int16_t))),
@@ -107,7 +107,7 @@ namespace gr {
             else if (strcasecmp(options, "subchannel") == 0)
                 d_sync = new rx_subchannel(options, debug, msgq_id, queue);
             else
-                d_sync = new rx_sync(sys_num, options, debug, msgq_id, queue, output_queue);
+                d_sync = new rx_sync(options, debug, msgq_id, queue, output_queue);
         }
 
         int 

--- a/lib/op25_repeater/lib/frame_assembler_impl.h
+++ b/lib/op25_repeater/lib/frame_assembler_impl.h
@@ -60,7 +60,7 @@ namespace gr {
             public:
 
             public:
-                frame_assembler_impl(int sys_num, const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue);
+                frame_assembler_impl(const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue);
                 ~frame_assembler_impl();
 
                 // Where all the action really happens

--- a/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
+++ b/lib/op25_repeater/lib/p25_frame_assembler_impl.cc
@@ -44,7 +44,7 @@ namespace gr {
         return;
       if (d_msg_queue->full_p())
         return;
-      gr::message::sptr msg = gr::message::make_from_string(std::string((const char *)wbuf, 2), duid, d_sys_num, 0);
+      gr::message::sptr msg = gr::message::make_from_string(std::string((const char *)wbuf, 2), duid, 0);
       d_msg_queue->insert_tail(msg);
     }
 
@@ -75,8 +75,8 @@ namespace gr {
     }
 
     p25_frame_assembler::sptr
-    p25_frame_assembler::make(int sys_num, int silence_frames, const char *udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt) {
-      return gnuradio::get_initial_sptr(new p25_frame_assembler_impl(sys_num, silence_frames, udp_host, port, debug, do_imbe, do_output, do_msgq, queue, do_audio_output, do_phase2_tdma, do_nocrypt));
+    p25_frame_assembler::make(int silence_frames, const char *udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt) {
+      return gnuradio::get_initial_sptr(new p25_frame_assembler_impl(silence_frames, udp_host, port, debug, do_imbe, do_output, do_msgq, queue, do_audio_output, do_phase2_tdma, do_nocrypt));
     }
 
     /*
@@ -96,13 +96,13 @@ static const int MAX_IN = 1;	// maximum number of input streams
 /*
  * The private constructor
  */
-  p25_frame_assembler_impl::p25_frame_assembler_impl(int sys_num, int silence_frames, const char *udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt)
+  p25_frame_assembler_impl::p25_frame_assembler_impl(int silence_frames, const char *udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt)
       : gr::block("p25_frame_assembler",
 		   gr::io_signature::make (MIN_IN, MAX_IN, sizeof (char)),
 		   gr::io_signature::make ((do_output) ? 1 : 0, (do_output) ? 1 : 0, (do_audio_output && do_output) ? sizeof(int16_t) : ((do_output) ? sizeof(char) : 0 ))),
 	d_do_imbe(do_imbe),
 	d_do_output(do_output),
-  p1fdma(sys_num, op25audio, debug, do_imbe, do_output, do_msgq, queue, output_queue, do_audio_output, do_nocrypt),
+  p1fdma(op25audio, debug, do_imbe, do_output, do_msgq, queue, output_queue, do_audio_output, do_nocrypt),
 	d_do_audio_output(do_audio_output),
 	d_do_phase2_tdma(do_phase2_tdma),
 	d_do_nocrypt(do_nocrypt),

--- a/lib/op25_repeater/lib/p25_frame_assembler_impl.h
+++ b/lib/op25_repeater/lib/p25_frame_assembler_impl.h
@@ -54,7 +54,6 @@ namespace gr {
 	gr::msg_queue::sptr d_msg_queue;
 
   int d_input_rate;
-  int d_sys_num;
   int d_silence_frames;
   int silence_frame_count;
   long total_produced;
@@ -76,7 +75,7 @@ namespace gr {
   void set_phase2_tdma(bool p);
 
 public:
-      p25_frame_assembler_impl(int sys_num, int silence_frames, const char* udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt);
+      p25_frame_assembler_impl(int silence_frames, const char* udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt);
       ~p25_frame_assembler_impl();
 
       op25_audio op25audio;

--- a/lib/op25_repeater/lib/p25p1_fdma.cc
+++ b/lib/op25_repeater/lib/p25p1_fdma.cc
@@ -197,7 +197,7 @@ namespace gr {
                 fprintf(stderr, "%s p25p1_fdma::set_nac: 0x%03x\n", logts.get(d_msgq_id), d_nac);
         }
 
-        p25p1_fdma::p25p1_fdma(int sys_num,const op25_audio& udp, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, std::deque<int16_t> &output_queue, bool do_audio_output, bool do_nocrypt, int msgq_id) :
+        p25p1_fdma::p25p1_fdma(const op25_audio& udp, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, std::deque<int16_t> &output_queue, bool do_audio_output, bool do_nocrypt, int msgq_id) :
             write_bufp(0),
             d_debug(debug),
             d_do_imbe(do_imbe),
@@ -216,7 +216,6 @@ namespace gr {
             ess_algid(0x80),
             vf_tgid(0),
 			terminate_call(false),
-			d_sys_num(sys_num),
             p1voice_decode((debug > 0), udp, output_queue)
         {
 			rx_status.error_count = 0;
@@ -753,8 +752,7 @@ namespace gr {
             if (!d_do_msgq || d_msg_queue->full_p())
                 return;
             
-            gr::message::sptr msg = gr::message::make_from_string(msg_str, msg_type, d_sys_num, 0);     
-            //gr::message::sptr msg = gr::message::make_from_string(msg_str, get_msg_type(PROTOCOL_P25, msg_type), d_sys_num, 0);
+            gr::message::sptr msg = gr::message::make_from_string(msg_str, msg_type, 0);     
             d_msg_queue->insert_tail(msg);
         }
 

--- a/lib/op25_repeater/lib/p25p1_fdma.h
+++ b/lib/op25_repeater/lib/p25p1_fdma.h
@@ -98,7 +98,6 @@ namespace gr {
                 long curr_grp_id;
                 bool terminate_call;
                 const char *d_udp_host;
-                int  d_sys_num;
                 int  d_port;
 
                 ezpwd::RS<63,55> rs8;  // Reed-Solomon decoders for 8, 12 and 16 bit parity
@@ -117,7 +116,7 @@ namespace gr {
                 void set_nac(int nac);
                 void reset_timer();
                 void rx_sym (const uint8_t *syms, int nsyms);
-                p25p1_fdma(int sys_num, const op25_audio& udp, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, std::deque<int16_t> &output_queue, bool do_audio_output, bool do_nocrypt, int msgq_id = 0);
+                p25p1_fdma(const op25_audio& udp, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, std::deque<int16_t> &output_queue, bool do_audio_output, bool do_nocrypt, int msgq_id = 0);
                 ~p25p1_fdma();
                 uint32_t load_nid(const uint8_t *syms, int nsyms, const uint64_t fs);
                 bool load_body(const uint8_t * syms, int nsyms);

--- a/lib/op25_repeater/lib/rx_sync.cc
+++ b/lib/op25_repeater/lib/rx_sync.cc
@@ -204,7 +204,7 @@ void rx_sync::ysf_sync(const uint8_t dibitbuf[], bool& ysf_fullrate, bool& unmut
 		fprintf(stderr, "%s ysf_sync: muting audio: dt: %d, rc: %d\n", logts.get(d_msgq_id), d_shift_reg, rc);
 }
 
-rx_sync::rx_sync(int sys_num, const char * options, int debug, int msgq_id, gr::msg_queue::sptr queue, std::array<std::deque<int16_t>, 2> &output_queue) :	// constructor
+rx_sync::rx_sync(const char * options, int debug, int msgq_id, gr::msg_queue::sptr queue, std::array<std::deque<int16_t>, 2> &output_queue) :	// constructor
 	sync_timer(op25_timer(1000000)),
 	d_symbol_count(0),
 	d_sync_reg(0),
@@ -216,16 +216,14 @@ rx_sync::rx_sync(int sys_num, const char * options, int debug, int msgq_id, gr::
 	d_slot_mask(3),
 	d_slot_key(0),
 	output_queue(output_queue),
-	p25fdma(sys_num, d_audio, debug, true, false, true, queue, d_output_queue[0], true, true, msgq_id),
+	p25fdma( d_audio, debug, true, false, true, queue, d_output_queue[0], true, true, msgq_id),
 	p25tdma( d_audio, 0, debug, true, queue, d_output_queue[0], true, true, msgq_id),
 	dmr(debug, msgq_id, queue),
 	d_msgq_id(msgq_id),
 	d_msg_queue(queue),
-
 	d_stereo(true),
 	d_debug(debug),
-	d_audio(options, debug),
-	d_sys_num(sys_num)
+	d_audio(options, debug)
 {
 	if (msgq_id >= 0)
 		d_stereo = false; // single channel audio for trunking

--- a/lib/op25_repeater/lib/rx_sync.h
+++ b/lib/op25_repeater/lib/rx_sync.h
@@ -122,7 +122,7 @@ public:
 	void set_debug(int debug);
 	int get_src_id(int slot);
 	bool get_terminated(int slot);
-	rx_sync(int sys_num, const char * options, int debug, int msgq_id, gr::msg_queue::sptr queue, std::array<std::deque<int16_t>, 2> &output_queue);
+	rx_sync(const char * options, int debug, int msgq_id, gr::msg_queue::sptr queue, std::array<std::deque<int16_t>, 2> &output_queue);
 	~rx_sync();
 
 private:
@@ -171,7 +171,6 @@ private:
 	log_ts logts;
 	std::array<std::deque<int16_t>, 2> &output_queue;
 	//std::deque<int16_t> &output_queue[];
-	int d_sys_num;
 };
 
     } // end namespace op25_repeater

--- a/trunk-recorder/gr_blocks/decoder_wrapper_impl.cc
+++ b/trunk-recorder/gr_blocks/decoder_wrapper_impl.cc
@@ -40,17 +40,17 @@ namespace gr {
 namespace blocks {
 
 decoder_wrapper_impl::sptr
-decoder_wrapper_impl::make(unsigned int sample_rate, int src_num, decoder_callback callback) {
-  return gnuradio::get_initial_sptr(new decoder_wrapper_impl(sample_rate, src_num, callback));
+decoder_wrapper_impl::make(unsigned int sample_rate, decoder_callback callback) {
+  return gnuradio::get_initial_sptr(new decoder_wrapper_impl(sample_rate, callback));
 }
 
-decoder_wrapper_impl::decoder_wrapper_impl(unsigned int sample_rate, int src_num, decoder_callback callback)
+decoder_wrapper_impl::decoder_wrapper_impl(unsigned int sample_rate, decoder_callback callback)
     : hier_block2("decoder_wrapper_impl",
                   io_signature::make(1, 1, sizeof(float)),
                   io_signature::make(0, 0, 0)),
       d_callback(callback) {
   d_signal_decoder_sink = gr::blocks::signal_decoder_sink_impl::make(sample_rate, callback);
-  d_tps_decoder_sink = gr::blocks::tps_decoder_sink_impl::make(sample_rate, src_num, callback);
+  d_tps_decoder_sink = gr::blocks::tps_decoder_sink_impl::make(sample_rate, callback);
 
   connect(self(), 0, d_signal_decoder_sink, 0);
   connect(self(), 0, d_tps_decoder_sink, 0);

--- a/trunk-recorder/gr_blocks/decoder_wrapper_impl.h
+++ b/trunk-recorder/gr_blocks/decoder_wrapper_impl.h
@@ -50,9 +50,9 @@ public:
    * \param sample_rate Sample rate [S/s]
    * \param bits_per_sample 16 or 8 bit, default is 16
    */
-  static sptr make(unsigned int sample_rate, int src_num, decoder_callback callback);
+  static sptr make(unsigned int sample_rate, decoder_callback callback);
 
-  decoder_wrapper_impl(unsigned int sample_rate, int src_num, decoder_callback callback);
+  decoder_wrapper_impl(unsigned int sample_rate, decoder_callback callback);
   ~decoder_wrapper_impl();
 
   void set_mdc_enabled(bool b);

--- a/trunk-recorder/gr_blocks/decoders/tps_decoder_sink_impl.h
+++ b/trunk-recorder/gr_blocks/decoders/tps_decoder_sink_impl.h
@@ -40,7 +40,6 @@ namespace blocks {
 
 class tps_decoder_sink_impl : public tps_decoder_sink {
 private:
-  int d_src_num;
   decoder_callback d_callback;
 
   gr::op25_repeater::fsk4_demod_ff::sptr fsk4_demod;
@@ -50,9 +49,9 @@ private:
 
   void initialize_p25(void);
   void process_message(gr::message::sptr msg);
-  void parse_p25_json(int src_num, std::string json);
-  void decode_mbt_data(unsigned long opcode, boost::dynamic_bitset<> &header, boost::dynamic_bitset<> &mbt_data, unsigned long link_id, unsigned long nac, int sys_num);
-  void decode_tsbk(boost::dynamic_bitset<> &tsbk, unsigned long nac, int sys_num);
+  void parse_p25_json(std::string json);
+  void decode_mbt_data(unsigned long opcode, boost::dynamic_bitset<> &header, boost::dynamic_bitset<> &mbt_data, unsigned long link_id, unsigned long nac);
+  void decode_tsbk(boost::dynamic_bitset<> &tsbk, unsigned long nac);
 
   unsigned long bitset_shift_mask(boost::dynamic_bitset<> &tsbk, int shift, unsigned long long mask);
 
@@ -67,9 +66,9 @@ public:
 
   gr::msg_queue::sptr rx_queue;
 
-  static sptr make(unsigned int sample_rate, int src_num, decoder_callback callback);
+  static sptr make(unsigned int sample_rate, decoder_callback callback);
 
-  tps_decoder_sink_impl(unsigned int sample_rate, int src_num, decoder_callback callback);
+  tps_decoder_sink_impl(unsigned int sample_rate, decoder_callback callback);
 
   void set_enabled(bool b);
 

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -62,7 +62,6 @@
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/gr_complex.h>
 #include <gnuradio/message.h>
-#include <gnuradio/msg_queue.h>
 #include <gnuradio/top_block.h>
 #include <gnuradio/uhd/usrp_source.h>
 
@@ -83,7 +82,7 @@ std::map<long, long> unit_affiliations;
 std::vector<Call *> calls;
 
 gr::top_block_sptr tb;
-gr::msg_queue::sptr msg_queue;
+
 
 volatile sig_atomic_t exit_flag = 0;
 int exit_code = EXIT_SUCCESS;
@@ -1462,9 +1461,13 @@ void monitor_messages() {
 
     plugman_poll_one();
 
-    msg = msg_queue->delete_head_nowait();
 
-    if (msg != 0) {
+for (vector<System *>::iterator sys_it = systems.begin(); sys_it != systems.end(); sys_it++) {
+    System_impl *system = (System_impl *)*sys_it;
+
+    if ((system->get_system_type() == "P25") || (system->get_system_type() == "smartnet") ) {
+
+    while ((msg = system->get_msg_queue()->delete_head_nowait()) != 0) {
       sys_num = msg->arg1();
       sys = find_system(sys_num);
 
@@ -1477,7 +1480,7 @@ void monitor_messages() {
         }
 
         if (sys->get_system_type() == "p25") {
-          trunk_messages = p25_parser->parse_message(msg);
+          trunk_messages = p25_parser->parse_message(msg, sys);
           handle_message(trunk_messages, sys);
         }
       }
@@ -1487,7 +1490,9 @@ void monitor_messages() {
       }
 
       msg.reset();
-    } else {
+    } 
+    }
+}
       current_time = time(NULL);
 
       if ((current_time - management_timestamp) >= 1.0) {
@@ -1498,9 +1503,7 @@ void monitor_messages() {
 
       boost::this_thread::sleep(boost::posix_time::milliseconds(10));
       // usleep(1000 * 10);
-    }
-
-    current_time = time(NULL);
+    
 
     float decode_rate_check_time_diff = current_time - last_decode_rate_check;
 
@@ -1652,7 +1655,7 @@ bool setup_systems() {
             system->smartnet_trunking = make_smartnet_trunking(control_channel_freq,
                                                                source->get_center(),
                                                                source->get_rate(),
-                                                               msg_queue,
+                                                               system->get_msg_queue(),
                                                                system->get_sys_num());
             tb->connect(source->get_src_block(), 0, system->smartnet_trunking, 0);
           }
@@ -1663,7 +1666,7 @@ bool setup_systems() {
             system->p25_trunking = make_p25_trunking(control_channel_freq,
                                                      source->get_center(),
                                                      source->get_rate(),
-                                                     msg_queue,
+                                                     system->get_msg_queue(),
                                                      system->get_qpsk_mod(),
                                                      system->get_sys_num());
             tb->connect(source->get_src_block(), 0, system->p25_trunking, 0);
@@ -1736,7 +1739,7 @@ int main(int argc, char **argv) {
   tb = gr::make_top_block("Trunking");
   tb->start();
   tb->lock();
-  msg_queue = gr::msg_queue::make(100);
+  
   smartnet_parser = new SmartnetParser(); // this has to eventually be generic;
   p25_parser = new P25Parser();
 

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -207,7 +207,7 @@ analog_recorder::analog_recorder(Source *src, Recorder_Type type)
   }
 
   BOOST_LOG_TRIVIAL(info) << "\t Creating decoder sink..." << std::endl;
-  decoder_sink = gr::blocks::decoder_wrapper_impl::make(wav_sample_rate, src->get_num(), std::bind(&analog_recorder::decoder_callback_handler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  decoder_sink = gr::blocks::decoder_wrapper_impl::make(wav_sample_rate, std::bind(&analog_recorder::decoder_callback_handler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
   BOOST_LOG_TRIVIAL(info) << "\t Decoder sink created!" << std::endl;
 
   // Analog audio band pass from 300 to 3000 Hz

--- a/trunk-recorder/recorders/dmr_recorder_impl.cc
+++ b/trunk-recorder/recorders/dmr_recorder_impl.cc
@@ -218,7 +218,7 @@ void dmr_recorder_impl::initialize(Source *src) {
   rx_queue = gr::msg_queue::make(100);
   int verbosity = 0; // 10 = lots of debug messages
 
-  framer = gr::op25_repeater::frame_assembler::make(0, "file:///tmp/out1.raw", verbosity, 1, rx_queue);
+  framer = gr::op25_repeater::frame_assembler::make("file:///tmp/out1.raw", verbosity, 1, rx_queue);
   // op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(0, silence_frames, udp_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
   levels = gr::blocks::multiply_const_ff::make(1);
   plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&dmr_recorder_impl::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));

--- a/trunk-recorder/recorders/p25_recorder_decode.cc
+++ b/trunk-recorder/recorders/p25_recorder_decode.cc
@@ -93,7 +93,7 @@ void p25_recorder_decode::initialize(int silence_frames) {
   bool do_tdma = 0;
   bool do_nocrypt = 1;
 
-  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(0, silence_frames, udp_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
+  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(silence_frames, udp_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
 
   levels = gr::blocks::multiply_const_ss::make(1);
 

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -885,11 +885,11 @@ void printbincharpad(char c) {
   // std::cout << " | ";
 }
 
-std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg) {
+std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System *system) {
   std::vector<TrunkMessage> messages;
 
   long type = msg->type();
-  int sys_num = msg->arg1();
+  int sys_num = system->get_sys_num();
   TrunkMessage message;
   message.message_type = UNKNOWN;
   message.source = -1;

--- a/trunk-recorder/systems/p25_parser.h
+++ b/trunk-recorder/systems/p25_parser.h
@@ -5,6 +5,8 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/log/trivial.hpp>
 #include <gnuradio/message.h>
+#include "system.h"
+#include "system_impl.h"
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -35,7 +37,7 @@ public:
   void print_bitset(boost::dynamic_bitset<> &tsbk);
   void add_channel(int chan_id, Channel chan, int sys_num);
   double channel_id_to_frequency(int chan_id, int sys_num);
-  std::vector<TrunkMessage> parse_message(gr::message::sptr msg);
+  std::vector<TrunkMessage> parse_message(gr::message::sptr msg, System *system);
 };
 
 #endif

--- a/trunk-recorder/systems/p25_trunking.cc
+++ b/trunk-recorder/systems/p25_trunking.cc
@@ -259,7 +259,7 @@ void p25_trunking::initialize_p25() {
   bool do_audio_output = 0;
   bool do_tdma = 0;
   bool do_nocrypt = 1;
-  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(sys_num, silence_frames, wireshark_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
+  op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(silence_frames, wireshark_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
 
   connect(slicer, 0, op25_frame_assembler, 0);
 }

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -4,6 +4,7 @@
 #include "../unit_tags.h"
 #include <boost/foreach.hpp>
 #include <boost/log/trivial.hpp>
+#include <gnuradio/msg_queue.h>
 #include <stdio.h>
 //#include "../source.h"
 #include "parser.h"
@@ -92,7 +93,7 @@ public:
   virtual int get_max_dev() = 0;
   virtual void set_filter_width(double f) = 0;
   virtual double get_filter_width() = 0;
-
+  virtual gr::msg_queue::sptr get_msg_queue() = 0;
   virtual std::string get_system_type() = 0;
   virtual unsigned long get_sys_id() = 0;
   virtual unsigned long get_wacn() = 0;
@@ -132,7 +133,6 @@ public:
   virtual std::vector<double> get_channels() = 0;
   virtual std::vector<double> get_control_channels() = 0;
   virtual std::vector<Talkgroup *> get_talkgroups() = 0;
-
   virtual void set_bandplan(std::string) = 0;
   virtual std::string get_bandplan() = 0;
   virtual void set_bandfreq(int) = 0;

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -99,6 +99,7 @@ System_impl::System_impl(int sys_num) {
   retune_attempts = 0;
   message_count = 0;
   decode_rate = 0;
+  msg_queue = gr::msg_queue::make(100);
 }
 
 void System_impl::set_xor_mask(unsigned long sys_id, unsigned long wacn, unsigned long nac) {
@@ -140,6 +141,10 @@ bool System_impl::update_status(TrunkMessage message) {
   return false;
 }
 
+ gr::msg_queue::sptr System_impl::get_msg_queue() {
+  return msg_queue;
+ }
+ 
 const char *System_impl::get_xor_mask() {
   return xor_mask;
 }

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -151,7 +151,7 @@ public:
   int get_max_dev();
   void set_filter_width(double f);
   double get_filter_width();
-
+  gr::msg_queue::sptr get_msg_queue();
   std::string get_system_type();
   unsigned long get_sys_id();
   unsigned long get_wacn();
@@ -191,6 +191,7 @@ public:
   std::vector<double> get_channels();
   std::vector<double> get_control_channels();
   std::vector<Talkgroup *> get_talkgroups();
+  gr::msg_queue::sptr msg_queue;
   System_impl(int sys_id);
   void set_bandplan(std::string);
   std::string get_bandplan();


### PR DESCRIPTION
This cleans up the OP25 integration because it no longer tracks the `sys_num` in OP25. Instead, there is a separate queue for each System to hold it trunking messages.