### PR TITLE
InstanceId

### DIFF
--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -13,7 +13,7 @@ std::string Call_impl::get_capture_dir() {
   return this->config.capture_dir;
 }
 
-int Call_impl::get_instance_id() {
+std::string Call_impl::get_instance_id() {
     return this->config.instance_id;
 }
 /*

--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -12,6 +12,10 @@
 std::string Call_impl::get_capture_dir() {
   return this->config.capture_dir;
 }
+
+int Call_impl::get_instance_id() {
+    return this->config.instance_id;
+}
 /*
 Call * Call::make(long t, double f, System *s, Config c) {
 
@@ -417,33 +421,33 @@ boost::property_tree::ptree Call_impl::get_stats() {
   boost::property_tree::ptree freq_list_node;
   boost::property_tree::ptree source_list_node;
   call_node.put("id", boost::lexical_cast<std::string>(this->get_sys_num()) + "_" + boost::lexical_cast<std::string>(this->get_talkgroup()) + "_" + boost::lexical_cast<std::string>(this->get_start_time()));
-  call_node.put("callNum", this->get_call_num());
+  call_node.put("instance_id", this->get_instance_id());
+  call_node.put("call_num", this->get_call_num());
   call_node.put("freq", this->get_freq());
-  call_node.put("sysNum", this->get_sys_num());
-  call_node.put("shortName", this->get_short_name());
+  call_node.put("sys_num", this->get_sys_num());
+  call_node.put("short_name", this->get_short_name());
   call_node.put("talkgroup", this->get_talkgroup());
-  call_node.put("talkgrouptag", this->get_talkgroup_tag());
+  call_node.put("talkgroup_alpha_tag", this->get_talkgroup_tag());
   call_node.put("elapsed", this->elapsed());
   if (get_state() == RECORDING)
-    call_node.put("length", this->get_current_length());
+    call_node.put("duration", this->get_current_length());
   else
-    call_node.put("length", this->get_final_length());
-  call_node.put("state", this->get_state());
-  call_node.put("monState", this->get_monitoring_state());
-  call_node.put("phase2", this->get_phase2_tdma());
+    call_node.put("duration", this->get_final_length());
+  call_node.put("call_state", this->get_state());
+  call_node.put("monitor_state", this->get_monitoring_state());
+  call_node.put("phase_2", this->get_phase2_tdma());
   call_node.put("conventional", this->is_conventional());
   call_node.put("encrypted", this->get_encrypted());
   call_node.put("emergency", this->get_emergency());
-  call_node.put("startTime", this->get_start_time());
-  call_node.put("stopTime", this->get_stop_time());
-  call_node.put("srcId", this->get_current_source_id());
-
+  call_node.put("start_time", this->get_start_time());
+  call_node.put("stop_time", this->get_stop_time());
+  call_node.put("src_id", this->get_current_source_id());
   Recorder *recorder = this->get_recorder();
 
   if (recorder) {
-    call_node.put("recNum", recorder->get_num());
-    call_node.put("srcNum", recorder->get_source()->get_num());
-    call_node.put("recState", recorder->get_state());
+    call_node.put("rec_num", recorder->get_num());
+    call_node.put("src_num", recorder->get_source()->get_num());
+    call_node.put("rec_state", recorder->get_state());
     call_node.put("analog", recorder->is_analog());
   }
 

--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -422,32 +422,32 @@ boost::property_tree::ptree Call_impl::get_stats() {
   boost::property_tree::ptree source_list_node;
   call_node.put("id", boost::lexical_cast<std::string>(this->get_sys_num()) + "_" + boost::lexical_cast<std::string>(this->get_talkgroup()) + "_" + boost::lexical_cast<std::string>(this->get_start_time()));
   call_node.put("instance_id", this->get_instance_id());
-  call_node.put("call_num", this->get_call_num());
+  call_node.put("callNum", this->get_call_num());
   call_node.put("freq", this->get_freq());
-  call_node.put("sys_num", this->get_sys_num());
-  call_node.put("short_name", this->get_short_name());
+  call_node.put("sysNum", this->get_sys_num());
+  call_node.put("shortName", this->get_short_name());
   call_node.put("talkgroup", this->get_talkgroup());
-  call_node.put("talkgroup_alpha_tag", this->get_talkgroup_tag());
+  call_node.put("talkgrouptag", this->get_talkgroup_tag());
   call_node.put("elapsed", this->elapsed());
   if (get_state() == RECORDING)
-    call_node.put("duration", this->get_current_length());
+    call_node.put("length", this->get_current_length());
   else
-    call_node.put("duration", this->get_final_length());
-  call_node.put("call_state", this->get_state());
-  call_node.put("monitor_state", this->get_monitoring_state());
-  call_node.put("phase_2", this->get_phase2_tdma());
+    call_node.put("length", this->get_final_length());
+  call_node.put("state", this->get_state());
+  call_node.put("monState", this->get_monitoring_state());
+  call_node.put("phase2", this->get_phase2_tdma());
   call_node.put("conventional", this->is_conventional());
   call_node.put("encrypted", this->get_encrypted());
   call_node.put("emergency", this->get_emergency());
-  call_node.put("start_time", this->get_start_time());
-  call_node.put("stop_time", this->get_stop_time());
-  call_node.put("src_id", this->get_current_source_id());
+  call_node.put("startTime", this->get_start_time());
+  call_node.put("stopTime", this->get_stop_time());
+  call_node.put("srcId", this->get_current_source_id());
   Recorder *recorder = this->get_recorder();
 
   if (recorder) {
-    call_node.put("rec_num", recorder->get_num());
-    call_node.put("src_num", recorder->get_source()->get_num());
-    call_node.put("rec_state", recorder->get_state());
+    call_node.put("recNum", recorder->get_num());
+    call_node.put("srcNum", recorder->get_source()->get_num());
+    call_node.put("recState", recorder->get_state());
     call_node.put("analog", recorder->is_analog());
   }
 

--- a/trunk-recorder/call_impl.h
+++ b/trunk-recorder/call_impl.h
@@ -38,7 +38,7 @@ public:
   Recorder *get_recorder();
   double get_freq();
   int get_sys_num();
-  int get_instance_id();
+  std::string get_instance_id();
   std::string get_short_name();
   std::string get_capture_dir();
   void set_freq(double f);

--- a/trunk-recorder/call_impl.h
+++ b/trunk-recorder/call_impl.h
@@ -38,6 +38,7 @@ public:
   Recorder *get_recorder();
   double get_freq();
   int get_sys_num();
+  int get_instance_id();
   std::string get_short_name();
   std::string get_capture_dir();
   void set_freq(double f);

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -23,7 +23,6 @@ struct Config {
   std::string bcfy_calls_server;
   std::string status_server;
   std::string instance_key;
-  std::string instance_id;
   std::string capture_dir;
   std::string debug_recorder_address;
   std::string log_dir;
@@ -37,6 +36,7 @@ struct Config {
   bool enable_audio_streaming;
   bool record_uu_v_calls;
   int frequency_format;
+  int instance_id;
 };
 
 struct Call_Source {

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -182,7 +182,7 @@ bool load_config(string config_file) {
     BOOST_LOG_TRIVIAL(info) << "Status Server: " << config.status_server;
     config.instance_key = pt.get<std::string>("instanceKey", "");
     BOOST_LOG_TRIVIAL(info) << "Instance Key: " << config.instance_key;
-    config.instance_id = pt.get<int>("instanceId", 0);
+    config.instance_id = pt.get<std::string>("instanceId", "");
     BOOST_LOG_TRIVIAL(info) << "Instance Id: " << config.instance_id;
     config.broadcast_signals = pt.get<bool>("broadcastSignals", false);
     BOOST_LOG_TRIVIAL(info) << "Broadcast Signals: " << config.broadcast_signals;

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -182,7 +182,7 @@ bool load_config(string config_file) {
     BOOST_LOG_TRIVIAL(info) << "Status Server: " << config.status_server;
     config.instance_key = pt.get<std::string>("instanceKey", "");
     BOOST_LOG_TRIVIAL(info) << "Instance Key: " << config.instance_key;
-    config.instance_id = pt.get<std::string>("instanceId", "");
+    config.instance_id = pt.get<int>("instanceId", 0);
     BOOST_LOG_TRIVIAL(info) << "Instance Id: " << config.instance_id;
     config.broadcast_signals = pt.get<bool>("broadcastSignals", false);
     BOOST_LOG_TRIVIAL(info) << "Broadcast Signals: " << config.broadcast_signals;

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -70,7 +70,7 @@ analog_recorder::analog_recorder(Source *src, Recorder_Type type)
     : gr::hier_block2("analog_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder(type) {
+      Recorder(type, src->get_config()) {
   // int nchars;
 
   source = src;

--- a/trunk-recorder/recorders/debug_recorder_impl.cc
+++ b/trunk-recorder/recorders/debug_recorder_impl.cc
@@ -148,7 +148,7 @@ debug_recorder_impl::debug_recorder_impl(Source *src, std::string address, int p
     : gr::hier_block2("debug_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder(DEBUG) {
+      Recorder(DEBUG, src->get_config()) {
   source = src;
   chan_freq = source->get_center();
   center_freq = source->get_center();

--- a/trunk-recorder/recorders/dmr_recorder_impl.cc
+++ b/trunk-recorder/recorders/dmr_recorder_impl.cc
@@ -50,7 +50,7 @@ dmr_recorder_impl::dmr_recorder_impl(Source *src, Recorder_Type type)
     : gr::hier_block2("dmr_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder(type) {
+      Recorder(type, src->get_config()) {
   initialize(src);
 }
 

--- a/trunk-recorder/recorders/p25_recorder_impl.cc
+++ b/trunk-recorder/recorders/p25_recorder_impl.cc
@@ -48,7 +48,7 @@ p25_recorder_impl::p25_recorder_impl(Source *src, Recorder_Type type)
     : gr::hier_block2("p25_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder(type) {
+      Recorder(type, src->get_config()) {
   initialize(src);
 }
 

--- a/trunk-recorder/recorders/recorder.cc
+++ b/trunk-recorder/recorders/recorder.cc
@@ -2,22 +2,22 @@
 #include "../source.h"
 #include <boost/algorithm/string.hpp>
 
-Recorder::Recorder(Recorder_Type type, Config c) {
+Recorder::Recorder(Recorder_Type type, Config* config) {
   this->type = type;
-  config = c;
+  this->config = *config;
 }
 
 int Recorder::get_instance_id() {
-    return this->config.instance_id;
+    return config.instance_id;
 }
 
 boost::property_tree::ptree Recorder::get_stats() {
   boost::property_tree::ptree node;
   node.put("id", boost::lexical_cast<std::string>(get_source()->get_num()) + "_" + boost::lexical_cast<std::string>(get_num()));
-  node.put("instance_id", get_instance_id);
+  node.put("instance_id", get_instance_id());
   node.put("type", get_type_string());
-  node.put("src_num", get_source()->get_num());
-  node.put("rec_num", get_num());
+  node.put("srcNum", get_source()->get_num());
+  node.put("recNum", get_num());
   node.put("count", recording_count);
   node.put("duration", recording_duration);
   node.put("state", get_state());

--- a/trunk-recorder/recorders/recorder.cc
+++ b/trunk-recorder/recorders/recorder.cc
@@ -7,7 +7,7 @@ Recorder::Recorder(Recorder_Type type, Config* config) {
   this->config = *config;
 }
 
-int Recorder::get_instance_id() {
+std::string Recorder::get_instance_id() {
     return config.instance_id;
 }
 

--- a/trunk-recorder/recorders/recorder.cc
+++ b/trunk-recorder/recorders/recorder.cc
@@ -2,16 +2,22 @@
 #include "../source.h"
 #include <boost/algorithm/string.hpp>
 
-Recorder::Recorder(Recorder_Type type) {
+Recorder::Recorder(Recorder_Type type, Config c) {
   this->type = type;
+  config = c;
+}
+
+int Recorder::get_instance_id() {
+    return this->config.instance_id;
 }
 
 boost::property_tree::ptree Recorder::get_stats() {
   boost::property_tree::ptree node;
   node.put("id", boost::lexical_cast<std::string>(get_source()->get_num()) + "_" + boost::lexical_cast<std::string>(get_num()));
+  node.put("instance_id", get_instance_id);
   node.put("type", get_type_string());
-  node.put("srcNum", get_source()->get_num());
-  node.put("recNum", get_num());
+  node.put("src_num", get_source()->get_num());
+  node.put("rec_num", get_num());
   node.put("count", recording_count);
   node.put("duration", recording_duration);
   node.put("state", get_state());

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -70,7 +70,7 @@ public:
     long decim2;
   };
 
-  Recorder(Recorder_Type  type);
+  Recorder(Recorder_Type  type, Config* config);
   virtual void tune_offset(double f){};
   virtual void tune_freq(double f){};
   virtual bool start(Call *call) { return false; };
@@ -106,12 +106,15 @@ public:
   virtual int get_output_channels() { return 1; }
   virtual bool get_enable_audio_streaming() { return d_enable_audio_streaming; };
   virtual void set_enable_audio_streaming(bool enable_audio_streaming) { d_enable_audio_streaming = enable_audio_streaming; };
+  int get_instance_id();
 
 protected:
   int recording_count;
   bool d_enable_audio_streaming;
   double recording_duration;
-  Recorder_Type  type;
+  Recorder_Type type;
+  Config config;
+
 };
 
 #endif

--- a/trunk-recorder/recorders/recorder.h
+++ b/trunk-recorder/recorders/recorder.h
@@ -106,7 +106,7 @@ public:
   virtual int get_output_channels() { return 1; }
   virtual bool get_enable_audio_streaming() { return d_enable_audio_streaming; };
   virtual void set_enable_audio_streaming(bool enable_audio_streaming) { d_enable_audio_streaming = enable_audio_streaming; };
-  int get_instance_id();
+  std::string get_instance_id();
 
 protected:
   int recording_count;

--- a/trunk-recorder/recorders/sigmf_recorder_impl.cc
+++ b/trunk-recorder/recorders/sigmf_recorder_impl.cc
@@ -14,7 +14,7 @@ sigmf_recorder_impl::sigmf_recorder_impl(Source *src)
     : gr::hier_block2("sigmf_recorder",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(0, 0, sizeof(float))),
-      Recorder(SIGMF) {
+      Recorder(SIGMF,src->get_config()) {
   source = src;
   freq = source->get_center();
   center = source->get_center();


### PR DESCRIPTION
Added a global config of InstanceID that is an integer. It helps differentiate stats when using MQTT on multiple instances of trunk recorder. Previously you could not tell what instance the recorder data was coming from. now there is an instance_id field in the json data. The call is the same with a instance_id in the call data both implementations are int he get_stats() function of each.

This way you can sort calls, and recorders from MQTT stats by using the instance_id.