### PR TITLE
fixes conventionalDMR plugin support

### DIFF
--- a/trunk-recorder/recorders/dmr_recorder_impl.cc
+++ b/trunk-recorder/recorders/dmr_recorder_impl.cc
@@ -227,7 +227,8 @@ void dmr_recorder_impl::initialize(Source *src) {
   framer = gr::op25_repeater::frame_assembler::make("file:///tmp/out1.raw", verbosity, 1, rx_queue);
   // op25_frame_assembler = gr::op25_repeater::p25_frame_assembler::make(0, silence_frames, udp_host, udp_port, verbosity, do_imbe, do_output, do_msgq, rx_queue, do_audio_output, do_tdma, do_nocrypt);
   levels = gr::blocks::multiply_const_ff::make(1);
-  plugin_sink = gr::blocks::plugin_wrapper_impl::make(std::bind(&dmr_recorder_impl::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
+  plugin_sink_slot0 = gr::blocks::plugin_wrapper_impl::make(std::bind(&dmr_recorder_impl::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
+  plugin_sink_slot1 = gr::blocks::plugin_wrapper_impl::make(std::bind(&dmr_recorder_impl::plugin_callback_handler, this, std::placeholders::_1, std::placeholders::_2));
 
   // Squelch DB
   // on a trunked network where you know you will have good signal, a carrier
@@ -249,7 +250,8 @@ void dmr_recorder_impl::initialize(Source *src) {
   connect(framer, 1, wav_sink_slot1, 0);
 
   if (use_streaming) {
-    connect(framer, 0, plugin_sink, 0);
+    connect(framer, 0, plugin_sink_slot0, 0);
+    connect(framer, 1, plugin_sink_slot1, 0);
   }
 }
 

--- a/trunk-recorder/recorders/dmr_recorder_impl.cc
+++ b/trunk-recorder/recorders/dmr_recorder_impl.cc
@@ -160,6 +160,12 @@ void dmr_recorder_impl::initialize(Source *src) {
   recording_count = 0;
   recording_duration = 0;
 
+  bool use_streaming = false;
+
+  if (config != NULL) {
+    use_streaming = config->enable_audio_streaming;
+  }
+
   state = INACTIVE;
 
   timestamp = time(NULL);
@@ -241,10 +247,14 @@ void dmr_recorder_impl::initialize(Source *src) {
   connect(slicer, 0, framer, 0);
   connect(framer, 0, wav_sink_slot0, 0);
   connect(framer, 1, wav_sink_slot1, 0);
+
+  if (use_streaming) {
+    connect(framer, 0, plugin_sink, 0);
+  }
 }
 
 void dmr_recorder_impl::plugin_callback_handler(int16_t *samples, int sampleCount) {
-  // plugman_audio_callback(_recorder, samples, sampleCount);
+  plugman_audio_callback(call, this, samples, sampleCount);
 }
 
 void dmr_recorder_impl::switch_tdma(bool phase2) {

--- a/trunk-recorder/recorders/dmr_recorder_impl.h
+++ b/trunk-recorder/recorders/dmr_recorder_impl.h
@@ -195,7 +195,8 @@ private:
   gr::blocks::multiply_const_ff::sptr levels;
   gr::blocks::transmission_sink::sptr wav_sink_slot0;
   gr::blocks::transmission_sink::sptr wav_sink_slot1;
-  gr::blocks::plugin_wrapper::sptr plugin_sink;
+  gr::blocks::plugin_wrapper::sptr plugin_sink_slot0;
+  gr::blocks::plugin_wrapper::sptr plugin_sink_slot1;
 };
 
 #endif // ifndef dmr_recorder_H


### PR DESCRIPTION
This PR fixes plugin support for conventionalDMR. please see the following discord [discussion](https://discord.com/channels/928800455444791306/928807616048685086/1120466421206487090) for background.

This PR changes the following:
- Adds the use_streaming variable to dmr_recorder_impl.cc following the pattern from analog_recorder.cc.  
- Adds a connect() between framer and the plugin sink
- Changes the variables passed to plugman_audio_callback

Tests conducted and open questions:
- I have built and tested this code on Ubuntu 22.04
- I have confirmed the basic functions of simpleStreaming on a single channel conventionalDMR system.
- I do not know how this will function with more then one talkgroup.
- Do we need a plugin sink for each slot?, yes it appears so. 



The following configuration was used for testing:

```
{
        "ver":2,
	"audioStreaming": true,
        "sources":[
                {
                        "center":155000000.0,
                        "rate":3600000,
                        "gain":50,
                        "digitalRecorders":2,
                        "driver":"osmosdr"
                }
        ],
        "systems":[
                {
                        "channels": [155070000],
                        "type": "conventionalDMR",
                        "squelch": -70,
                        "shortName":"trbo",
            		"callLog": true,
            		"audioArchive": true
                }
	],
	"plugins":[
	   {
          "name":"simplestream",
          "library":"libsimplestream.so",
          "streams":[
            {
              "TGID": 0,
              "address":"127.0.0.1",
              "port": 55123,
              "sendTGID":false,
              "shortName":"trbo"
             }
           ]
	  }
	],
        "frequencyFormat":"mhz",
        "logLevel":"debug",
        "logFile":true,
        "defaultMode": "digital"
}
```

Thanks to @robotastic for pointing me in the right direction. 