### PR TITLE
Transmission archive fix

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -140,7 +140,6 @@ void remove_call_files(Call_Data_t call_info) {
     }
   } else {
     if (call_info.transmission_archive) {
-      struct stat statbuf;
       // if the files are being archived, move them to the capture directory
       for (std::vector<Transmission>::iterator it = call_info.transmission_list.begin(); it != call_info.transmission_list.end(); ++it) {
         Transmission t = *it;
@@ -149,9 +148,9 @@ void remove_call_files(Call_Data_t call_info) {
         //boost::filesystem::path target_file = boost::filesystem::path(call_info.filename).replace_filename(transmission_file.filename()); // takes the capture dir from the call file and adds the transmission filename to it
         
         // Only move transmission wavs if they exist
-        if (stat(t.filename, &statbuf) == 0) {
+        if (checkIfFile(t.filename)) {
           boost::filesystem::copy_file(transmission_file, target_file); 
-        } 
+        }
       }
     } 
 

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -140,14 +140,18 @@ void remove_call_files(Call_Data_t call_info) {
     }
   } else {
     if (call_info.transmission_archive) {
+      struct stat statbuf;
       // if the files are being archived, move them to the capture directory
       for (std::vector<Transmission>::iterator it = call_info.transmission_list.begin(); it != call_info.transmission_list.end(); ++it) {
         Transmission t = *it;
         boost::filesystem::path target_file = boost::filesystem::path(fs::path(call_info.filename ).replace_filename(fs::path(t.filename).filename()));
         boost::filesystem::path transmission_file = t.filename;
         //boost::filesystem::path target_file = boost::filesystem::path(call_info.filename).replace_filename(transmission_file.filename()); // takes the capture dir from the call file and adds the transmission filename to it
-        boost::filesystem::copy_file(transmission_file, target_file); 
-
+        
+        // Only move transmission wavs if they exist
+        if (stat(t.filename, &statbuf) == 0) {
+          boost::filesystem::copy_file(transmission_file, target_file); 
+        } 
       }
     } 
 


### PR DESCRIPTION
Beginning with trunk-recorder 4.6, transmission .wav files exist in a temporary directory and either get deleted, or moved to the `captureDir` structure if `transmissionArchive` is set in the config file.

Related to PR #796, trunk-recorder may crash if it attempts file operations on a non-existent transmission .wav in the `tempDir`.  

This fix simply uses the existing `checkIfFile()` to verify if the file exists before attempting to move a transmission .wav from the `captureDir`.