### PR TITLE
Include TDMA slot number in transmission_sink().

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -256,7 +256,7 @@ Call_Data_t Call_Concluder::create_base_filename(Call *call, Call_Data_t call_in
   if (call->get_tdma_slot() == -1) {
     nchars = snprintf(base_filename, 255, "%s/%ld-%ld_%.0f", base_path_string.c_str(), call->get_talkgroup(), work_start_time, call->get_freq());
   } else {
-    // this is for the case when it is a DMR recorder and 2 wav files are created, the slot is needed to keep them separate.
+    // this is for the case when it is a P25P2 TDMA or DMR recorder and 2 wav files are created, the slot is needed to keep them separate.
     nchars = snprintf(base_filename, 255, "%s/%ld-%ld_%.0f.%d", base_path_string.c_str(), call->get_talkgroup(), work_start_time, call->get_freq(), call->get_tdma_slot());
   }
   if (nchars >= 255) {

--- a/trunk-recorder/gr_blocks/transmission_sink.cc
+++ b/trunk-recorder/gr_blocks/transmission_sink.cc
@@ -92,7 +92,7 @@ void transmission_sink::create_filename() {
   if (d_slot == -1) {
     nchars = snprintf(current_filename, 255, "%s/%ld-%ld_%.0f.wav", temp_path_string.c_str(), d_current_call_talkgroup, work_start_time, d_current_call_freq);
   } else {
-    // this is for the case when it is a DMR recorder and 2 wav files are created, the slot is needed to keep them separate.
+    // this is for the case when it is a P25P2 TDMA or DMR recorder and 2 wav files are created, the slot is needed to keep them separate.
     nchars = snprintf(current_filename, 255, "%s/%ld-%ld_%.0f.%d.wav", temp_path_string.c_str(), d_current_call_talkgroup, work_start_time, d_current_call_freq, d_slot);
   }
   if (nchars >= 255) {

--- a/trunk-recorder/recorders/p25_recorder_decode.cc
+++ b/trunk-recorder/recorders/p25_recorder_decode.cc
@@ -26,7 +26,13 @@ void p25_recorder_decode::stop() {
 
 void p25_recorder_decode::start(Call *call) {
   levels->set_k(call->get_system()->get_digital_levels());
-  wav_sink->start_recording(call);
+
+  if(call->get_phase2_tdma()){
+    wav_sink->start_recording(call, call->get_tdma_slot());
+  } else {
+    wav_sink->start_recording(call);
+  }
+  
   d_call = call;
 }
 


### PR DESCRIPTION
Addresses an issue where P25P2 TDMA transmissions may not be correctly recorded if the same talk group and frequency are being utilized on different TDMA slots in short intervals.