### PR TITLE
enable non free drivers for gr-osmosdr to get SDRplay for RSP1A support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN cd /tmp && \
   git apply ../airspy_source_c.cc.patch && \
   mkdir build && \
   cd build && \
-  cmake .. && \
+  cmake -DENABLE_NONFREE=TRUE .. && \
   make -j$(nproc) && \
   make install && \
   ldconfig && \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GNU Radio 3.7 - 3.10
 
 ...and SDRs:
 
-RTL-SDR dongles; HackRF; Ettus USRP B200, B210, B205; BladeRF; Airspy
+RTL-SDR dongles; HackRF; Ettus USRP B200, B210, B205; BladeRF; Airspy; SDRplay
 
 ---
 


### PR DESCRIPTION
as requested by @gisforgirard on the Discord who also kindly donated hardware to me to validate this change