### PR TITLE
Fix RecordUnknown behaviors

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -673,6 +673,7 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
   Recorder *sigmf_recorder;
 
   if (!talkgroup && (sys->get_record_unknown() == false)) {
+    call->set_state(MONITORING);
     call->set_monitoring_state(UNKNOWN_TG);
     if (sys->get_hideUnknown() == false) {
       BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\t\033[0;34m" << call->get_call_num() << "C\033[0m\tTG: " << call->get_talkgroup_display() << "\tFreq: " << format_freq(call->get_freq()) << "\t\u001b[33mNot Recording: TG not in Talkgroup File\u001b[0m ";

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -673,8 +673,9 @@ bool start_recorder(Call *call, TrunkMessage message, System *sys) {
   Recorder *sigmf_recorder;
 
   if (!talkgroup && (sys->get_record_unknown() == false)) {
+    call->set_monitoring_state(UNKNOWN_TG);
     if (sys->get_hideUnknown() == false) {
-      // BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\t\033[0;34m" << call->get_call_num() << "C\033[0m\tTG: " << call->get_talkgroup_display() << "\tFreq: " << format_freq(call->get_freq()) << "\t\u001b[33mNot Recording: TG not in Talkgroup File\u001b[0m ";
+      BOOST_LOG_TRIVIAL(info) << "[" << sys->get_short_name() << "]\t\033[0;34m" << call->get_call_num() << "C\033[0m\tTG: " << call->get_talkgroup_display() << "\tFreq: " << format_freq(call->get_freq()) << "\t\u001b[33mNot Recording: TG not in Talkgroup File\u001b[0m ";
     }
     return false;
   }


### PR DESCRIPTION
The monitoring state `UNKNOWN_TG` is currently unused, and appears to exist to flag calls that will not be recorded if `"recordUnknown": false` is set in a system config and the talkgroup cannot be found in the .csv.

The setting `hideUnknownTalkgroups` currently does nothing as the only use in trunk-recorder is commented out.  Per the documents, the expected logging behavior should be:
| Key | Required | Default Value | Type | Description |
| - | :-: | - | - | -- |
| hideUnknownTalkgroups  | | false | **true** / **false** | Hide unknown talkgroups log entries |

This small patch will flag a monitoring state when unknown talkgroups will not be recorded, and restore messages like the below unless otherwise configured: 
```
(info)   [name]  6C  TG: 12345 (  -)  Freq: 774.606250 MHz  Not Recording: TG not in Talkgroup File
``` 