### PR TITLE
Capture P25 RFSS and Site ID information.

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -951,6 +951,14 @@ void current_system_status(TrunkMessage message, System *sys) {
   }
 }
 
+void current_system_sysid(TrunkMessage message, System *sys) {
+  if ((sys->get_system_type() == "p25") || (sys->get_system_type() != "conventionalP25")) {
+    if (sys->update_sysid(message)) {
+      plugman_setup_system(sys);
+    }
+  }
+}
+
 void unit_registration(System *sys, long source_id) {
   plugman_unit_registration(sys, source_id);
 }
@@ -1200,6 +1208,7 @@ void handle_message(std::vector<TrunkMessage> messages, System *sys) {
       break;
 
     case SYSID:
+      current_system_sysid(message, sys);
       break;
 
     case STATUS:

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -952,7 +952,7 @@ void current_system_status(TrunkMessage message, System *sys) {
 }
 
 void current_system_sysid(TrunkMessage message, System *sys) {
-  if ((sys->get_system_type() == "p25") || (sys->get_system_type() != "conventionalP25")) {
+  if ((sys->get_system_type() == "p25") || (sys->get_system_type() == "conventionalP25")) {
     if (sys->update_sysid(message)) {
       plugman_setup_system(sys);
     }

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -194,6 +194,8 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
     // unsigned long f2   = channel_id_to_frequency(ch2, sys_num);
     message.message_type = SYSID;
     message.sys_id = syid;
+    message.sys_rfss = rfid;
+    message.sys_site_id = stid;
     os << "mbt3a rfss status: syid: " << syid << " rfid " << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1, sys_num) << ")";
     message.meta = os.str();
     BOOST_LOG_TRIVIAL(debug) << os.str();
@@ -856,6 +858,8 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
     unsigned long chan = bitset_shift_mask(tsbk, 24, 0xffff);
     message.message_type = SYSID;
     message.sys_id = syid;
+    message.sys_rfss = rfid;
+    message.sys_site_id = stid;
     os << "tsbk3a rfss status: syid: " << syid << " rfid " << rfid << " stid " << stid << " ch1 " << chan << "(" << channel_id_to_string(chan, sys_num) << ")";
     message.meta = os.str();
     BOOST_LOG_TRIVIAL(debug) << os.str();

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -45,6 +45,8 @@ struct TrunkMessage {
   long source;
   int sys_num;
   unsigned long sys_id;
+  int sys_rfss;
+  int sys_site_id;
   unsigned long nac;
   unsigned long wacn;
   PatchData patch_data;

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -98,9 +98,12 @@ public:
   virtual unsigned long get_sys_id() = 0;
   virtual unsigned long get_wacn() = 0;
   virtual unsigned long get_nac() = 0;
+  virtual int get_sys_rfss() = 0;
+  virtual int get_sys_site_id() = 0;
   virtual void set_xor_mask(unsigned long sys_id, unsigned long wacn, unsigned long nac) = 0;
   virtual const char *get_xor_mask() = 0;
   virtual bool update_status(TrunkMessage message) = 0;
+  virtual bool update_sysid(TrunkMessage message) = 0;
   virtual int get_sys_num() = 0;
   virtual void set_system_type(std::string) = 0;
   virtual std::string get_talkgroups_file() = 0;

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -82,6 +82,8 @@ System_impl::System_impl(int sys_num) {
   sys_id = 0;
   wacn = 0;
   nac = 0;
+  sys_rfss = 0;
+  sys_site_id = 0;
   current_control_channel = 0;
   xor_mask_len = 0;
   xor_mask = NULL;
@@ -141,6 +143,19 @@ bool System_impl::update_status(TrunkMessage message) {
   return false;
 }
 
+bool System_impl::update_sysid(TrunkMessage message) {
+  if (!sys_rfss || !sys_site_id) {
+    sys_rfss = message.sys_rfss;
+    sys_site_id = message.sys_site_id;
+    BOOST_LOG_TRIVIAL(error) << "[" << short_name << "]\tDecoding System Site"
+                            << " RFSS: " << std::setw(3) << std::setfill('0') << message.sys_rfss
+                            << " SITE ID: " << std::setw(3) << std::setfill('0') << message.sys_site_id
+                            << " (" << std::setw(3) << std::setfill('0') << message.sys_rfss << "-" << std::setw(3) << std::setfill('0') << message.sys_site_id << ")";
+    return true;
+  }
+  return false;
+}
+
  gr::msg_queue::sptr System_impl::get_msg_queue() {
   return msg_queue;
  }
@@ -163,6 +178,14 @@ unsigned long System_impl::get_nac() {
 
 unsigned long System_impl::get_wacn() {
   return this->wacn;
+}
+
+int System_impl::get_sys_rfss(){
+  return this->sys_rfss;
+}
+
+int System_impl::get_sys_site_id(){
+  return this->sys_site_id;
 }
 
 bool System_impl::get_call_log() {

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -45,6 +45,8 @@ class System_impl : public System {
   unsigned long sys_id;
   unsigned long wacn;
   unsigned long nac;
+  int sys_rfss;
+  int sys_site_id;
 
 public:
   Talkgroups *talkgroups;
@@ -156,9 +158,12 @@ public:
   unsigned long get_sys_id();
   unsigned long get_wacn();
   unsigned long get_nac();
+  int get_sys_rfss();
+  int get_sys_site_id();
   void set_xor_mask(unsigned long sys_id, unsigned long wacn, unsigned long nac);
   const char *get_xor_mask();
   bool update_status(TrunkMessage message);
+  bool update_sysid(TrunkMessage message);
   int get_sys_num();
   void set_system_type(std::string);
   std::string get_talkgroups_file();


### PR DESCRIPTION
Store P25 RFSS and Site ID in the system object and display them on initial decode. This should help with optimizing deduplication and other future enhancements.