### PR TITLE
Fix SoapySDRPlay3 edgecase

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -525,6 +525,12 @@ bool load_config(string config_file) {
         Source *source = new Source(center, rate, error, driver, device, &config);
         BOOST_LOG_TRIVIAL(info) << "Max Frequency: " << format_freq(source->get_max_hz());
         BOOST_LOG_TRIVIAL(info) << "Min Frequency: " << format_freq(source->get_min_hz());
+
+        // SoapySDRPlay3 quirk: autogain must be disabled before any of the gains can be set
+        if (source->get_device().find("sdrplay") != std::string::npos) {
+          source->set_gain_mode(agc);
+        }
+
         if (node.second.count("gainSettings") != 0) {
           BOOST_FOREACH (boost::property_tree::ptree::value_type &sub_node, node.second.get_child("gainSettings")) {
             source->set_gain_by_name(sub_node.first, sub_node.second.get<double>("", 0));


### PR DESCRIPTION
Fixes #689 when using https://github.com/pothosware/SoapySDRPlay3. 

I have an SDRPlay device and a [set of Docker images](https://github.com/USA-RedDragon/trunk-recorder-soapysdrplay3) using SoapySDRPlay3 and the newer SDRPlay API. This works great with only this minor code change due to an edgecase with the SoapySDRPlay3 API.

In this case per https://github.com/pothosware/SoapySDRPlay3/blob/534a173996b0ca2a88ff1931950c869d244c90f8/Settings.cpp#L517, the autogain must be disabled before setting the gain to avoid gain not being set.

I've added a new call to `source->set_gain_mode(agc);` as opposed to repositioning the existing call to ensure compatibility with other devices isn't affected.

I didn't seem to be affected by this comment on the issue: https://github.com/robotastic/trunk-recorder/issues/689#issuecomment-1191776720 that required enabling AGC before disabling it.