### PR TITLE
README: add Prometheus plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ By default, Trunk Recorder just dumps a lot of recorded files into a directory. 
 * [MQTT Statistics](https://github.com/robotastic/trunk-recorder-mqtt-statistics): Publishes statistics about a Trunk Recorder instance over MQTT
 * [Decode rates logger](https://github.com/rosecitytransit/trunk-recorder-decode-rate): Logs trunking control channel decode rates to a CSV file, and includes a PHP file that outputs an SVG graph
 * [Daily call log and live Web page](https://github.com/rosecitytransit/trunk-recorder-daily-log): Creates a daily log of calls (instead of just individual JSON files) and includes an updating PHP Web page w/audio player
+* [Prometheus exporter](https://github.com/USA-RedDragon/trunk-recorder-prometheus): Publishes statistics to a metrics endpoint via HTTP
 
 ### Troubleshooting
 


### PR DESCRIPTION
I created a Prometheus metrics plugin at https://github.com/USA-RedDragon/trunk-recorder-prometheus, so I wanted to link it here. If this isn't something you want to link, feel free to close the PR, no hard feelings :)