### PR TITLE
Fix channel CSV parsing, allow for freqs in MHz, other config parsing fixes

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -455,7 +455,7 @@ This file allows for you to specify additional information about conventional ch
 | Column Name | Required | Value |
 |-------------|----------|-------|
 | TG Number     | ✔️        | The Talkgroup Number formatted as a decimal number. This has to be the first column |
-| Frequency        |  ✔️       | The frequency in Hz for the channel |
+| Frequency        |  ✔️       | The frequency in MHz or Hz for the channel (decimal point must be used for MHz) |
 | Tone | ✔️        | The Tone for the talkgroup. This value is not used. *Tone based squelch is currently not supported.* |
 | Alpha Tag |       | A 16 character description that is intended as a shortened display on radio displays |
 | Category |    |  The category for the Talkgroup |

--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -11,7 +11,7 @@
 
 struct Broadcastify_System_Key {
   std::string api_key;
-  std::string system_id;
+  int system_id;
   std::string short_name;
 };
 
@@ -37,14 +37,14 @@ public:
     return "";
   }
 
-  std::string get_system_id(std::string short_name) {
+  int get_system_id(std::string short_name) {
     for (std::vector<Broadcastify_System_Key>::iterator it = data.keys.begin(); it != data.keys.end(); ++it) {
       Broadcastify_System_Key key = *it;
       if (key.short_name == short_name) {
         return key.system_id;
       }
     }
-    return "";
+    return 0;
   }
 
   static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp) {
@@ -122,9 +122,9 @@ public:
     std::string response_buffer;
 
     std::string api_key = get_api_key(call_info.short_name);
-    std::string system_id = get_system_id(call_info.short_name);
+    int system_id = get_system_id(call_info.short_name);
 
-    if ((api_key.size() ==0) || (system_id.size() ==0)) {
+    if ((api_key.size() == 0) || (system_id == 0)) {
       return 0;
     }
 
@@ -157,7 +157,7 @@ public:
     curl_formadd(&formpost,
                  &lastptr,
                  CURLFORM_COPYNAME, "systemId",
-                 CURLFORM_COPYCONTENTS, system_id.c_str(),
+                 CURLFORM_COPYCONTENTS, std::to_string(system_id).c_str(),
                  CURLFORM_END);
 
     curl_formadd(&formpost,
@@ -293,7 +293,7 @@ public:
           BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\tTG: " << call_info.talkgroup << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Upload REJECTED: " << message;
           return 0;
       }
-      
+
       if (code != "0") {
         BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\tTG: " << call_info.talkgroup << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Metadata Upload Error: " << message;
         return 1;
@@ -351,7 +351,7 @@ public:
       if (broadcastify_exists) {
         Broadcastify_System_Key key;
         key.api_key = element.value("broadcastifyApiKey", "");
-        key.system_id = element.value("broadcastifySystemId", "");
+        key.system_id = element.value("broadcastifySystemId", 0);
         key.short_name = element.value("shortName", "");
         BOOST_LOG_TRIVIAL(info) << "Uploading calls for: " << key.short_name;
         this->data.keys.push_back(key);

--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -14,7 +14,7 @@
 struct Rdio_Scanner_System {
   std::string api_key;
   std::string short_name;
-  std::string system_id;
+  int system_id;
   std::string talkgroupsFile;
   Talkgroups *talkgroups;
   bool compress_wav;
@@ -45,7 +45,7 @@ public:
 
   int upload(Call_Data_t call_info) {
     std::string api_key;
-    std::string system_id;
+    int system_id;
     std::string talkgroup_group = call_info.talkgroup_group;
     std::string talkgroup_tag = call_info.talkgroup_tag;
     std::string talkgroup_alpha_tag = call_info.talkgroup_alpha_tag;
@@ -66,7 +66,7 @@ public:
     if (api_key.size() == 0) {
       return 0;
     }
-    
+
     std::ostringstream freq;
     std::string freq_string;
     freq << std::fixed << std::setprecision(0);
@@ -106,7 +106,7 @@ public:
 
     if (call_info.patched_talkgroups.size()>1){
       for (unsigned long i = 0; i < call_info.patched_talkgroups.size(); i++) {
-        if (i!=0) { 
+        if (i!=0) {
           patch_list << ",";
         }
         patch_list << (int)call_info.patched_talkgroups[i];
@@ -125,8 +125,8 @@ public:
 
     if (call_info.transmission_error_list.size() != 0) {
       for (std::size_t i = 0; i < call_info.transmission_error_list.size(); i++) {
-          freq_list << "{\"freq\": " << std::fixed << std::setprecision(0) << call_info.freq << ", \"time\": " << call_info.transmission_error_list[i].time << ", \"pos\": " << std::fixed << std::setprecision(2) << call_info.transmission_error_list[i].position << ", \"len\": " << call_info.transmission_error_list[i].total_len  << ", \"errorCount\": " << std::setprecision(0) <<call_info.transmission_error_list[i].error_count << ", \"spikeCount\": " << call_info.transmission_error_list[i].spike_count << "}"; 
-  
+          freq_list << "{\"freq\": " << std::fixed << std::setprecision(0) << call_info.freq << ", \"time\": " << call_info.transmission_error_list[i].time << ", \"pos\": " << std::fixed << std::setprecision(2) << call_info.transmission_error_list[i].position << ", \"len\": " << call_info.transmission_error_list[i].total_len  << ", \"errorCount\": " << std::setprecision(0) <<call_info.transmission_error_list[i].error_count << ", \"spikeCount\": " << call_info.transmission_error_list[i].spike_count << "}";
+
         if (i < (call_info.transmission_error_list.size() - 1)) {
           freq_list << ", ";
         } else {
@@ -246,7 +246,7 @@ public:
     curl_formadd(&formpost,
                  &lastptr,
                  CURLFORM_COPYNAME, "system",
-                 CURLFORM_COPYCONTENTS, system_id.c_str(),
+                 CURLFORM_COPYCONTENTS, std::to_string(system_id).c_str(),
                  CURLFORM_END);
 
     curl_formadd(&formpost,
@@ -399,16 +399,16 @@ public:
     if (!regex_match(this->data.server.c_str(), what, ex)) {
       BOOST_LOG_TRIVIAL(error) << "Unable to parse Rdio Scanner Server URL\n";
       return 1;
-    } 
+    }
 
         // Gets the API key for each system, if defined
-      for (json element : config_data["systems"]) {  
+      for (json element : config_data["systems"]) {
         bool rdioscanner_exists = element.contains("apiKey");
        if (rdioscanner_exists) {
          Rdio_Scanner_System sys;
 
          sys.api_key = element.value("apiKey", "");
-         sys.system_id = element.value("systemId", "");
+         sys.system_id = element.value("systemId", 0);
          sys.short_name = element.value("shortName", "");
          BOOST_LOG_TRIVIAL(info) << "Uploading calls for: " << sys.short_name;
          this->data.systems.push_back(sys);
@@ -423,7 +423,7 @@ public:
     return 0;
   }
 
-  
+
  /*
    int start() { return 0; }
    int stop() { return 0; }

--- a/trunk-recorder/talkgroups.cc
+++ b/trunk-recorder/talkgroups.cc
@@ -127,10 +127,10 @@ void Talkgroups::load_channels(int sys_num, std::string filename) {
   std::vector<std::string> headers = reader.get_col_names();
   std::vector<std::string> defined_headers = {"TG Number", "Tone", "Frequency", "Alpha Tag", "Description", "Category", "Tag", "Enable", "Comment"};
 
-  if (headers[0] != "Decimal") {
+  if (headers[0] != "TG Number") {
 
     BOOST_LOG_TRIVIAL(error) << "Column Headers are required for Channel CSV files";
-    BOOST_LOG_TRIVIAL(error) << "The first column must be 'Decimal'";
+    BOOST_LOG_TRIVIAL(error) << "The first column must be 'TG Number'";
     BOOST_LOG_TRIVIAL(error) << "Required columns are: 'TG Number', 'Tone', 'Frequency',";
     BOOST_LOG_TRIVIAL(error) << "Optional columns are: 'Alpha Tag', 'Description', 'Category', 'Tag', 'Enable', 'Comment'";
     exit(0);
@@ -188,8 +188,12 @@ void Talkgroups::load_channels(int sys_num, std::string filename) {
       tone = row["Tone"].get<double>();
     }
 
-    if ((reader.index_of("Frequency") >= 0) && row["Frequency"].is_float()) {
+    if ((reader.index_of("Frequency") >= 0) && row["Frequency"].is_num()) {
       freq = row["Frequency"].get<double>();
+      // If this is a float under 1000, it must be in MHz so convert to Hz
+      if (row["Frequency"].is_float() && freq < 1000.0) {
+        freq = freq * 1e+6;
+      }
     }
 
     if ((reader.index_of("Enable") >= 0) && row["Enable"].is_str()) {


### PR DESCRIPTION
It seems like there was a copy-paste error in the new talkgroup/channel CSV parsing, so the channel CSV was incorrectly expecting a Decimal column header. This fixes it to the right column header.

Additionally, the new logic expects a float for frequency, which is backwards-incompatible with the frequencies in existing CSVs. To work around this, while also supporting the RadioReference format of MHz freqs, it will instead check if it's either an int or a float, and if it's a float (and under 1000), will convert the MHz frequency to Hz.

Third, the config parser expected the system IDs for Boadcastify and Rdio Uploader to be strings when they really should be ints (and were previously). This updates the actual data types to be int, so there are no type issues.