### PR TITLE
rdio-scanner: Fix systemID to match the datatype used in rdio-scanner

### DIFF
--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -14,7 +14,7 @@
 struct Rdio_Scanner_System {
   std::string api_key;
   std::string short_name;
-  std::string system_id;
+  uint32_t    system_id;
   std::string talkgroupsFile;
   Talkgroups *talkgroups;
   bool compress_wav;
@@ -45,7 +45,7 @@ public:
 
   int upload(Call_Data_t call_info) {
     std::string api_key;
-    std::string system_id;
+    uint32_t system_id;
     std::string talkgroup_group = call_info.talkgroup_group;
     std::string talkgroup_tag = call_info.talkgroup_tag;
     std::string talkgroup_alpha_tag = call_info.talkgroup_alpha_tag;
@@ -246,7 +246,7 @@ public:
     curl_formadd(&formpost,
                  &lastptr,
                  CURLFORM_COPYNAME, "system",
-                 CURLFORM_COPYCONTENTS, system_id.c_str(),
+                 CURLFORM_COPYCONTENTS, std::to_string(system_id).c_str(),
                  CURLFORM_END);
 
     curl_formadd(&formpost,
@@ -408,7 +408,7 @@ public:
          Rdio_Scanner_System sys;
 
          sys.api_key = element.value("apiKey", "");
-         sys.system_id = element.value("systemId", "");
+         sys.system_id = element.value("systemId", 0);
          sys.short_name = element.value("shortName", "");
          BOOST_LOG_TRIVIAL(info) << "Uploading calls for: " << sys.short_name;
          this->data.systems.push_back(sys);


### PR DESCRIPTION
rdio-scanner uses a Go uint (uint32_t is the C equivalent) to store the system ID: https://github.com/chuot/rdio-scanner/blob/c9c4ea4530f906dc2f1a9d67706ca987e5f82131/server/system.go#L29

This also prevents https://github.com/robotastic/trunk-recorder/commit/47460b1582ec5187ed99eac0df93ae41ab93017f from making this doc wrong, as the current state of the code requires `systemID` to be a string: https://github.com/robotastic/trunk-recorder/blob/713049ad540423392db5ed8b7fba3507bb0c0fea/docs/Plugins.md?plain=1#L50
https://github.com/robotastic/trunk-recorder/blob/713049ad540423392db5ed8b7fba3507bb0c0fea/docs/Plugins.md?plain=1#L66