### PR TITLE
ci: push to both GHCR and Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   buildx:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       -
         name: Checkout
@@ -21,6 +24,7 @@ jobs:
         id: prepare
         run: |
           DOCKER_IMAGE=robotastic/trunk-recorder
+          GHCR_IMAGE=ghcr.io/robotastic/trunk-recorder
           DOCKER_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7
           VERSION=edge
 
@@ -32,14 +36,18 @@ jobs:
           fi
 
           TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS --tag ${GHCR_IMAGE}:${VERSION}"
           if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+            TAGS="$TAGS --tag ${GHCR_IMAGE}:latest"
           fi
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+            TAGS="$TAGS --tag ${GHCR_IMAGE}:latest"
           fi
           
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=ghcr_image::${GHCR_IMAGE}
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
             --build-arg VERSION=${VERSION} \
@@ -71,13 +79,21 @@ jobs:
             --cache-to "type=local,dest=/tmp/.buildx-cache" \
             --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
       -
-        name: Docker Login
+        name: Docker Hub Login
         if: success() && github.event_name != 'pull_request'
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      -
+        name: GHCR Login
+        if: success() && github.event_name != 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin ghcr.io
       -
         name: Docker Buildx (push)
         if: success() && github.event_name != 'pull_request'
@@ -90,6 +106,7 @@ jobs:
         if: always() && github.event_name != 'pull_request'
         run: |
           docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.ghcr_image }}:${{ steps.prepare.outputs.version }}
       -
         name: Clear
         if: always() && github.event_name != 'pull_request'


### PR DESCRIPTION
GHCR is free and it give you a redundant source for OCI images in the event that Docker Hub has an outage. No work required on your part, due to the `jobs.buildx.permissions.packages` write permission. `contents: read` is the default, but would be overridden if not present. Merging this would create `ghcr.io/robotastic/trunk-recorder`