### PR TITLE
Multisite updates and improvements

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -220,9 +220,9 @@ There is a list of available Plugins [here](./Plugins.md).
 
 When enabled, Multi-Site mode attempts to avoid recording duplicate calls by detecting simulcasted transmissions for the same talkgroup across multiple sites at the same time.
 
-For P25, Trunk Recorder will match calls that have the same WACN and same talkgroup number but a different NAC. For SmartNet, Trunk Recorder will match calls that have the same multiSiteSystemName and same talkgroup number but different multiSiteSystemNumber.
+For P25, Trunk Recorder will match calls that have the same WACN and talkgroup number but a different RFSS/SiteID. For SmartNet, Trunk Recorder will match calls that have the same multiSiteSystemName and same talkgroup number but different multiSiteSystemNumber.
 
-By default, Trunk Recorder will record the call from the first site to receive the grant and ignore the duplicate grants from the other related sites. If you want to specify the preferred site for a given talkgroup number you can specify the preferred NAC (in decimal format) in the [talkgroupsFile](#talkgroupsFile).
+By default, Trunk Recorder will record the call from the first site to receive the grant and ignore the duplicate grants from the other related sites. If you want to specify the preferred site for a given talkgroup number you can add a preferred NAC (in decimal format) or RFSS/SiteID (`RRRRssss`, e.g. `00010026`) to the [talkgroupsFile](#talkgroupsFile).
 
 Note: While multiSiteSystemName and multiSiteSystemNumber are normally used for SmartNet systems, these settings may also be used to override the default de-duplication logic for P25 systems where the mutliSite feature may not be correctly detecting duplicates. An example would be when two or more sites within a P25 system are using the same NAC and WACN. In such a deployment as a workaround, for each related system object, set multiSiteSystemName to a shared value and multiSiteSystemNumber to a unique value:
 
@@ -434,7 +434,7 @@ The columns are:
 | Category |    |  The category for the Talkgroup |
 | Tag       |   |  The Service Tag for the Talkgroup |
 | Priority |    | The priority field specifies the number of recorders the system must have available to record a new call for the talkgroup. For example, a priority of 1, the highest means as long as at least a single recorder is available, the system will record the new call. If the priority is 2, the system would at least 2 free recorders to record the new call, and so on. If there is no priority set for a talkgroup entry, a prioity of 1 is assumed. <br/> Talkgroups assigned a priority of -1 will never be recorded, regardless of the number of available recorders. |
-| Preferred NAC |     | In Multi-Site mode, the preferred NAC for a specific talk group is used to specify the site you prefer the talk group to be recorded from.|
+| Preferred NAC |     | In Multi-Site mode, the preferred NAC (`nnnn`, e.g. `1234`) or RFSS/SiteID (`RRRRssss`, e.g. `00010023`) to record a specific talkgroup.|
 | Comment |        | Use this field to capture comments about a talkgroup. It will be ignored by Trunk Recorder. |
 
 Here are the column headers and some sample data: 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -222,9 +222,7 @@ When enabled, Multi-Site mode attempts to avoid recording duplicate calls by det
 
 For P25, Trunk Recorder will match calls that have the same WACN and talkgroup number but a different RFSS/SiteID. For SmartNet, Trunk Recorder will match calls that have the same multiSiteSystemName and same talkgroup number but different multiSiteSystemNumber.
 
-By default, Trunk Recorder will record the call from the first site to receive the grant and ignore the duplicate grants from the other related sites. If you want to specify the preferred site for a given talkgroup number you can add a preferred NAC (in decimal format) or RFSS/SiteID (`RRRRssss`, e.g. `00010026`) to the [talkgroupsFile](#talkgroupsFile).
-
-Note: While multiSiteSystemName and multiSiteSystemNumber are normally used for SmartNet systems, these settings may also be used to override the default de-duplication logic for P25 systems where the mutliSite feature may not be correctly detecting duplicates. An example would be when two or more sites within a P25 system are using the same NAC and WACN. In such a deployment as a workaround, for each related system object, set multiSiteSystemName to a shared value and multiSiteSystemNumber to a unique value:
+By default, Trunk Recorder will record the call from the first site to receive the grant and ignore the duplicate grants from the other related sites. If you want to specify the preferred site for a given talkgroup number you can add a preferred NAC (in decimal format), RFSS/SiteID (`RRRRssss`, e.g. `00010026`), or multiSiteSystemNumber to the [talkgroupsFile](#talkgroupsFile).
 
 ```
 {
@@ -434,7 +432,7 @@ The columns are:
 | Category |    |  The category for the Talkgroup |
 | Tag       |   |  The Service Tag for the Talkgroup |
 | Priority |    | The priority field specifies the number of recorders the system must have available to record a new call for the talkgroup. For example, a priority of 1, the highest means as long as at least a single recorder is available, the system will record the new call. If the priority is 2, the system would at least 2 free recorders to record the new call, and so on. If there is no priority set for a talkgroup entry, a prioity of 1 is assumed. <br/> Talkgroups assigned a priority of -1 will never be recorded, regardless of the number of available recorders. |
-| Preferred NAC |     | In Multi-Site mode, the preferred NAC (`nnnn`, e.g. `1234`) or RFSS/SiteID (`RRRRssss`, e.g. `00010023`) to record a specific talkgroup.|
+| Preferred NAC |     | In Multi-Site mode, the preferred NAC (`nnnn`, e.g. `1234`), RFSS/SiteID (`RRRRssss`, e.g. `00010023`), or multiSiteSystemNumber to record a specific talkgroup.|
 | Comment |        | Use this field to capture comments about a talkgroup. It will be ignored by Trunk Recorder. |
 
 Here are the column headers and some sample data: 

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -581,8 +581,13 @@ void handle_call_grant(TrunkMessage message, System *sys, bool grant_message) {
     boost::format grant_call_data;
     
     if ((superseding_grant) || (duplicate_grant)){
-      original_call_data = boost::format("\u001b[36m%sC\u001b[0m: %X/%s-%s ") % original_call->get_call_num() % original_call->get_system()->get_wacn() % original_call->get_system()->get_sys_rfss() % original_call->get_system()->get_sys_site_id();
-      grant_call_data = boost::format("\u001b[36m%sC\u001b[0m: %X/%s-%s ") % call->get_call_num() % sys->get_wacn() % sys->get_sys_rfss() % + sys->get_sys_site_id();
+      if (original_call->get_system()->get_multiSiteSystemName() == "") {
+        original_call_data = boost::format("\u001b[36m%sC\u001b[0m: %X/%s-%s ") % original_call->get_call_num() % original_call->get_system()->get_wacn() % original_call->get_system()->get_sys_rfss() % original_call->get_system()->get_sys_site_id();
+        grant_call_data = boost::format("\u001b[36m%sC\u001b[0m: %X/%s-%s ") % call->get_call_num() % sys->get_wacn() % sys->get_sys_rfss() % + sys->get_sys_site_id();
+      } else {
+        original_call_data = boost::format("\u001b[36m%sC\u001b[0m: %s/%s ") % original_call->get_call_num() % original_call->get_system()->get_multiSiteSystemName() % original_call->get_system()->get_multiSiteSystemNumber();
+        grant_call_data = boost::format("\u001b[36m%sC\u001b[0m: %s/%s ") % call->get_call_num() % sys->get_multiSiteSystemName() % sys->get_multiSiteSystemNumber();        
+      }
     }
 
     if (superseding_grant) {

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -515,7 +515,7 @@ void handle_call_grant(TrunkMessage message, System *sys, bool grant_message) {
                 }
               }
 
-              // Secondary mode to match multiSiteSystemName and use 
+              // Secondary mode to match multiSiteSystemName and use multiSiteSystemNumber.
               // If a multiSiteSystemName has been manually entered;
               // We already know that Call's system number does not match the message system number.
               // In this case, we check that the multiSiteSystemName is present, and that the Call and System multiSiteSystemNames are the same.


### PR DESCRIPTION
Building on the improvements in #846, trunk-recorder should use RFSS and Site ID as the default discriminators when multisite is enabled for P25 systems.  This overcomes an issue where multiple P25 sites broadcasting the same NAC can circumvent de-duplication logic.

Prior to this, some P25 systems required manual setup using a `multiSiteSystemName`, and it may not have been apparent why it did not appear to be working using the default settings.

The existing "Preferred NAC" or `multiSiteSystemNumber` functionality has not changed, but users may additionally use a decimal RFSS/SiteID (in the form `RRRRssss`, e.g. `00030013`) to match talkgroups to preferred sites.

The console message has been updated to better show the "WACN/RFSS-Site" match when it occurs:
```
Duplicate Grant - 20C: BEE00/3-13 23C: BEE00/3-14  Source: 1819332 Call: 20C State: recording
```
Manually defining a multisite system with `multiSiteSystemName`or `multiSiteSystemNumber` remains unchanged, but the log message would look as below:
```
Duplicate Grant - 66C: CLMRN/0 67C: CLMRN/1  Source: 1849171 Call: 66C State: recording
```