### PR TITLE
fix parse error errors

### DIFF
--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -973,8 +973,8 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
 
   // # nac is always 1st two bytes
   // ac = (ord(s[0]) << 8) + ord(s[1])
-  uint8_t s0 = (int)s[0];
-  uint8_t s1 = (int)s[1];
+  uint16_t s0 = (int)s[0];
+  uint16_t s1 = (int)s[1];
   int shift = s0 << 8;
   long nac = shift + s1;
 


### PR DESCRIPTION
Debug variables `s0` and `s1` in `p25_parser.cc` are typed as `uint8_t`.  When displayed in an iostream, these variables will be presented as a character, not a number, since that type is interpreted as an alias for `unsigned char`.
```
BOOST_LOG_TRIVIAL(error) << "P25 Parse error, s: " << s << " s0: " << s0 << " s1: " << s1 << " shift: " << shift << " nac: " << nac << " type: " << type << " Len: " << s.length();
```
This console message can display when conditions are bad or other receiver problems occur, and it does not seem ideal to inject invalid, or random, UTF8 characters into the user's console or log files.  Additional examples of this can also be seen in #775.
```
[2023-11-13 15:14:18.618786] (error)   P25 Parse error, s:  s0:
 s1: � shift: 0 nac: 129 type: 65535 Len: 0
```
Using a `uint16_t` or `short` instead should avoid this in the future, and numerically display values for those variables.

Edit: An example of a "corrected" parse error message is below:
```
[2023-11-13 22:24:17.747166] (error)   P25 Parse error, s:  s0: 0 s1: 97 shift: 0 nac: 97 type: 65535 Len: 0
```