### PR TITLE
load channelFile items into system channels vector

### DIFF
--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -298,6 +298,9 @@ void System_impl::set_channel_file(std::string channel_file) {
   BOOST_LOG_TRIVIAL(info) << "Loading Talkgroups...";
   this->channel_file = channel_file;
   this->talkgroups->load_channels(sys_num, channel_file);
+  for (auto& tg : this->get_talkgroups()) {
+    this->add_channel(tg->freq);
+  }
 }
 
 bool System_impl::has_channel_file() {


### PR DESCRIPTION
When a `channelFile` is used for conventional systems, these channels are successfully created and monitored, but are not added to the system `channels` vector.  Downstream plugins or other API calls may want to access a list of conventional channels assigned to a system with `sys->get_channels()` whether or not a channelFile is in use.

This change does not affect the methods trunk-recorder uses to set up conventional systems with a channelFile, it only loads those channels into the internal vector after the .csv file has been read.