### PR TITLE
call_info update

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -290,6 +290,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
   call_info.tdma_slot = call->get_tdma_slot();
   call_info.phase2_tdma = call->get_phase2_tdma();
   call_info.transmission_list = call->get_transmissions();
+  call_info.sys_num = sys->get_sys_num();
   call_info.short_name = sys->get_short_name();
   call_info.upload_script = sys->get_upload_script();
   call_info.audio_archive = sys->get_audio_archive();

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -110,6 +110,7 @@ struct Call_Data_t {
   char converted[300];
   int min_transmissions_removed;
 
+  int sys_num;
   std::string short_name;
   std::string upload_script;
   std::string audio_type;


### PR DESCRIPTION
The `Call_Data_t` struct currently does not contain the internal system number on which a call occurred.  Should plugins wish to use API functions to look up additional information related to a completed call, they cannot do so without some form of "reverse lookup" by `shortName` which is not guaranteed to be a unique identifier.

Including the internal system number in completed call data would allow direct and unique access to related system information through a simple numerical comparison.