### PR TITLE
better uint8_t fix

### DIFF
--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -973,13 +973,13 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
 
   // # nac is always 1st two bytes
   // ac = (ord(s[0]) << 8) + ord(s[1])
-  uint16_t s0 = (int)s[0];
-  uint16_t s1 = (int)s[1];
+  uint8_t s0 = (int)s[0];
+  uint8_t s1 = (int)s[1];
   int shift = s0 << 8;
   long nac = shift + s1;
 
   if (s.length() < 2) {
-    BOOST_LOG_TRIVIAL(error) << "P25 Parse error, s: " << s << " s0: " << s0 << " s1: " << s1 << " shift: " << shift << " nac: " << nac << " type: " << type << " Len: " << s.length();
+    BOOST_LOG_TRIVIAL(error) << "P25 Parse error, s: " << s << " s0: " << static_cast<int>(s0) << " s1: " << static_cast<int>(s1) << " shift: " << shift << " nac: " << nac << " type: " << type << " Len: " << s.length();
     messages.push_back(message);
     return messages;
   }


### PR DESCRIPTION
Adjusting the type causes more problems than adjusting the error message.  Downstream effects can be bad NACs and XOR masks.