### PR TITLE
Added missing include that caused builds to fail on Fedora 38

### DIFF
--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -8,6 +8,7 @@
 #include <stdio.h>
 //#include "../source.h"
 #include "parser.h"
+#include <iomanip>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push


### PR DESCRIPTION
Builds were failing on Fedora 38 without an explicit include for `iomanip`