### PR TITLE
Update simplestream.cc 

### DIFF
--- a/plugins/simplestream/simplestream.cc
+++ b/plugins/simplestream/simplestream.cc
@@ -3,6 +3,7 @@
 #include <boost/dll/alias.hpp> // for BOOST_DLL_ALIAS
 #include <boost/foreach.hpp>
 #include <boost/asio.hpp>
+#include <boost/array.hpp>
 
 using namespace boost::asio;
 


### PR DESCRIPTION
fix  error: variable ‘boost::array<boost::asio::mutable_buffer, 2> buf1’ has initializer but incomplete type