### PR TITLE
Adjust integer config values to double

### DIFF
--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -146,7 +146,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
     BOOST_LOG_TRIVIAL(info) << "Broadcast Signals: " << config.broadcast_signals;
     config.default_mode = data.value("defaultMode", "digital");
     BOOST_LOG_TRIVIAL(info) << "Default Mode: " << config.default_mode;
-    config.call_timeout = data.value("callTimeout", 3);
+    config.call_timeout = data.value("callTimeout", 3.0);
     BOOST_LOG_TRIVIAL(info) << "Call Timeout (seconds): " << config.call_timeout;
     config.control_message_warn_rate = data.value("controlWarnRate", 10);
     BOOST_LOG_TRIVIAL(info) << "Control channel warning rate: " << config.control_message_warn_rate;
@@ -250,7 +250,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         bool qpsk_mod = true;
         double digital_levels = element.value("digitalLevels", 1.0);
         double analog_levels = element.value("analogLevels", 8.0);
-        double squelch_db = element.value("squelch", -160);
+        double squelch_db = element.value("squelch", -160.0);
         int max_dev = element.value("maxDev", 4000);
         double filter_width = element.value("filterWidth", 1.0);
         bool conversation_mode = element.value("conversationMode", true);

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -31,7 +31,7 @@ struct Config {
   bool new_call_from_update;
   bool debug_recorder;
   int debug_recorder_port;
-  int call_timeout;
+  double call_timeout;
   bool console_log;
   bool log_file;
   int control_message_warn_rate;


### PR DESCRIPTION
The value for `squelch_db` was previously read from the config file as a double, and is later used as a double during recorder setup.  Updating the default value would restore this behavior, and avoid truncating downward to an integer.

The value for `callTimeout` has previously been read from the config file as an integer, but the json library is now truncating the value instead of rounding.  Reports such as #875, and similar discussions on the discord, seem to indicate that users have been setting decimal values for this under one second, and the fact that it is now truncating down to 0 is causing multiple unexpected issues.

Much like other call-shaping parameters (`minDuration`, `maxDuration`, and `minTransmissionDuration`), `callTimeout` should also allow decimal values.  Adjusting the type in the config struct would correct this.