### PR TITLE
Fs copy fix for "Invalid cross-device link"

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -143,13 +143,15 @@ void remove_call_files(Call_Data_t call_info) {
       // if the files are being archived, move them to the capture directory
       for (std::vector<Transmission>::iterator it = call_info.transmission_list.begin(); it != call_info.transmission_list.end(); ++it) {
         Transmission t = *it;
-        boost::filesystem::path target_file = boost::filesystem::path(fs::path(call_info.filename ).replace_filename(fs::path(t.filename).filename()));
-        boost::filesystem::path transmission_file = t.filename;
+        // Prevent "boost::filesystem::copy_file: Invalid cross-device link" errors by using std::filesystem instead.
+        fs::path target_file = fs::path(fs::path(call_info.filename ).replace_filename(fs::path(t.filename).filename()));
+        fs::path transmission_file = t.filename;
+
         //boost::filesystem::path target_file = boost::filesystem::path(call_info.filename).replace_filename(transmission_file.filename()); // takes the capture dir from the call file and adds the transmission filename to it
         
         // Only move transmission wavs if they exist
         if (checkIfFile(t.filename)) {
-          boost::filesystem::copy_file(transmission_file, target_file); 
+          fs::copy_file(transmission_file, target_file); 
         }
       }
     } 


### PR DESCRIPTION
Sometime between linux 5.3 and 5.18, a regression prevented files from copying across devices using `copy_file_range()`.  Boost created a workaround for 1.78, and it was fixed in the 6.x kernel, but depending on what packages are offered in the distro, this problem may still remain.

Replicated with the following system:
```
libboost-all-dev/mantic,now 1.74.0.3ubuntu7 amd64 [installed]
libboost-filesystem-dev/mantic,now 1.74.0.3ubuntu7 amd64 [installed,automatic]

Linux system2 6.5.0-13-generic #13-Ubuntu SMP PREEMPT_DYNAMIC Fri Nov  3 12:16:05 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
```
A `boost::filesystem::copy_file: Invalid cross-device link:` will occur when `transmissionArchive` is true, and trunk-recorder attempts to copy the tx wavs from a ram-based `tempDir` to conventional storage at `captureDir` at the conclusion of a call.  Previous mitigation techniques were either to disable transmissionArchive, or move the tempDir to the same device as captureDir.

This should help address issues like #843 by allowing the users with affected kernels to manually install newer version of boost libs, or allow users with 6.x kernels and affected boost libs to use std::filesystem instead.