### PR TITLE
Add TSBK Stream Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ list(APPEND trunk_recorder_sources
   trunk-recorder/formatter.cc
   trunk-recorder/source.cc
   trunk-recorder/call_conventional.cc
+  trunk-recorder/tsbk_socket.cc
   trunk-recorder/systems/smartnet_trunking.cc
   trunk-recorder/systems/p25_trunking.cc
   trunk-recorder/systems/smartnet_parser.cc

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -214,6 +214,11 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
     config.frequency_format = frequency_format;
     BOOST_LOG_TRIVIAL(info) << "Frequency format: " << get_frequency_format();
 
+    config.tsbk_stream_server = pt.get<std::string>("tsbkStreamServer", "");
+    BOOST_LOG_TRIVIAL(info) << "TSBK Stream Host: " << config.tsbk_stream_server;
+    config.tsbk_stream_port = pt.get<int>("tsbkStreamPort", 5678);
+    BOOST_LOG_TRIVIAL(info) << "TSBK Stream Port: " << config.tsbk_stream_port;
+
     statusAsString = data.value("statusAsString", statusAsString);
     BOOST_LOG_TRIVIAL(info) << "Status as String: " << statusAsString;
     std::string log_level = data.value("logLevel", "info");

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -27,6 +27,7 @@ struct Config {
   std::string temp_dir;
   std::string debug_recorder_address;
   std::string log_dir;
+  std::string tsbk_stream_server;
   std::string default_mode;
   bool new_call_from_update;
   bool debug_recorder;
@@ -42,6 +43,7 @@ struct Config {
   bool soft_vocoder;
   bool record_uu_v_calls;
   int frequency_format;
+  int tsbk_stream_port;
 };
 
 struct Call_Source {

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -45,6 +45,7 @@
 
 #include "call.h"
 #include "call_conventional.h"
+#include "tsbk_socket.h"
 #include "systems/p25_parser.h"
 #include "systems/p25_trunking.h"
 #include "systems/parser.h"
@@ -1144,14 +1145,17 @@ int main(int argc, char **argv) {
 
   tb = gr::make_top_block("Trunking");
 
-  smartnet_parser = new SmartnetParser(); // this has to eventually be generic;
-  p25_parser = new P25Parser();
-
   std::string uri = "ws://localhost:3005";
 
   if (!load_config(config_file, config, tb, sources, systems)) {
     exit(1);
   }
+
+  // start up after config load
+  smartnet_parser = new SmartnetParser(); // this has to eventually be generic;
+  p25_parser = new P25Parser();
+
+  tsbk_socket = new TSBK_Socket(config.tsbk_stream_server, config.tsbk_stream_port);
 
   start_plugins(sources, systems);
 

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -93,8 +93,6 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
   TrunkMessage message;
   std::ostringstream os;
 
-  //TODO: blast this across the UDP socket
-
   message.message_type = UNKNOWN;
   message.source = -1;
   message.wacn = 0;
@@ -1065,7 +1063,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
     }
     mbt_data <<= 32; // for missing crc
 
-    //tsbk_socket->send_tsbk(mbt_data, system);
+    tsbk_socket->send_mbt(mbt_data, system);
 
     unsigned long opcode = bitset_shift_mask(header, 32, 0x3f);
     unsigned long link_id = bitset_shift_mask(header, 48, 0xffffff);

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -93,6 +93,8 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
   TrunkMessage message;
   std::ostringstream os;
 
+  //TODO: blast this across the UDP socket
+
   message.message_type = UNKNOWN;
   message.source = -1;
   message.wacn = 0;
@@ -1024,6 +1026,8 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
     }
     b <<= 16; // for missing crc
 
+    tsbk_socket->send_tsbk(b, system);
+
     return decode_tsbk(b, nac, sys_num);
   } else if (type == 12) { // # trunk: MBT
     std::string s1 = s.substr(0, 10);
@@ -1060,6 +1064,9 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
       }
     }
     mbt_data <<= 32; // for missing crc
+
+    //tsbk_socket->send_tsbk(mbt_data, system);
+
     unsigned long opcode = bitset_shift_mask(header, 32, 0x3f);
     unsigned long link_id = bitset_shift_mask(header, 48, 0xffffff);
     /*BOOST_LOG_TRIVIAL(debug) << "RAW  Data    " <<b;

--- a/trunk-recorder/systems/p25_parser.h
+++ b/trunk-recorder/systems/p25_parser.h
@@ -7,6 +7,7 @@
 #include <gnuradio/message.h>
 #include "system.h"
 #include "system_impl.h"
+#include "../tsbk_socket.h"
 #include <iomanip>
 #include <iostream>
 #include <map>

--- a/trunk-recorder/tsbk_socket.cc
+++ b/trunk-recorder/tsbk_socket.cc
@@ -44,3 +44,30 @@ void TSBK_Socket::send_tsbk(boost::dynamic_bitset<> &tsbk, System *system) {
          (struct sockaddr*)&m_servaddr, m_servlen);
     return 0;
   }
+
+void TSBK_Socket::send_mbt(boost::dynamic_bitset<> &tsbk, System *system) {
+
+    if (m_server.empty())
+      return;
+
+    boost::property_tree::ptree root;
+
+    root.put("version", "V1");
+    root.put("type", "mbt");
+    root.put("sysName", system->get_short_name());
+    root.put("tsbk", tsbk);
+
+    std::stringstream tsbk_str;
+    boost::property_tree::write_json(tsbk_str, root);
+
+    // std::cout << stats_str;
+    TSBK_Socket::send_msg(tsbk_str.str());
+  }
+
+  int TSBK_Socket::send_msg(std::string val) {
+    char* c = const_cast<char*>(val.c_str());
+
+    sendto(m_sockfd, c, strlen(c), 0,
+         (struct sockaddr*)&m_servaddr, m_servlen);
+    return 0;
+  }

--- a/trunk-recorder/tsbk_socket.cc
+++ b/trunk-recorder/tsbk_socket.cc
@@ -1,0 +1,46 @@
+#include "tsbk_socket.h"
+
+TSBK_Socket::TSBK_Socket(std::string server_addr, int port) : m_server(""), m_port(5678) {
+    m_server = server_addr;
+    m_port = port;
+
+    
+    m_servlen = sizeof(m_servaddr);
+
+    if ( (m_sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) {
+        BOOST_LOG_TRIVIAL(error) << "Failure in creating TSBK UDP socket.";
+        exit(EXIT_FAILURE);
+    }
+
+    m_servaddr.sin_family = AF_INET;
+    m_servaddr.sin_port = htons(m_port);
+    char* c_server = const_cast<char*>(m_server.c_str());
+    m_servaddr.sin_addr.s_addr = inet_addr(c_server);
+}
+
+void TSBK_Socket::send_tsbk(boost::dynamic_bitset<> &tsbk, System *system) {
+
+    if (m_server.empty())
+      return;
+
+    boost::property_tree::ptree root;
+
+    root.put("version", "V1");
+    root.put("type", "tsbk");
+    root.put("sysName", system->get_short_name());
+    root.put("tsbk", tsbk);
+
+    std::stringstream tsbk_str;
+    boost::property_tree::write_json(tsbk_str, root);
+
+    // std::cout << stats_str;
+    TSBK_Socket::send_msg(tsbk_str.str());
+  }
+
+  int TSBK_Socket::send_msg(std::string val) {
+    char* c = const_cast<char*>(val.c_str());
+
+    sendto(m_sockfd, c, strlen(c), 0,
+         (struct sockaddr*)&m_servaddr, m_servlen);
+    return 0;
+  }

--- a/trunk-recorder/tsbk_socket.h
+++ b/trunk-recorder/tsbk_socket.h
@@ -1,0 +1,33 @@
+#if !defined(__TSBK_Socket_H__)
+#define __TSBK_Socket_H__
+
+#include <bits/stdc++.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/dynamic_bitset.hpp>
+#include "systems/system.h"
+
+class TSBK_Socket {
+
+    public:
+    TSBK_Socket(std::string server_addr, int port);
+    void send_tsbk(boost::dynamic_bitset<> &tsbk, System *system);
+    int send_msg(std::string val);
+
+    private:
+    std::string m_server;
+    int m_port;
+    int m_sockfd;
+    struct sockaddr_in m_servaddr;
+    int m_servlen;
+
+};
+
+inline TSBK_Socket *tsbk_socket;
+
+#endif


### PR DESCRIPTION
This PR adds the ability to send TSBKs to an external UDP host for further analysis. Simply add the following lines to your config in the main section:

```"tsbkStreamServer": "1.2.3.4",
"tsbkStreamPort": 5678```

And you will get all incoming TSBKs (single-block and multi-block) sent over the UDP socket to the host and port of your choice.