### PR TITLE
fix rdio uploader

### DIFF
--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -224,7 +224,6 @@ public:
     curl_mime_data(part, call_info.short_name.c_str(), CURL_ZERO_TERMINATED);
     curl_mime_name(part, "systemLabel");
 
-    curl = curl_easy_init();
     multi_handle = curl_multi_init();
 
     /* initialize custom header list (stating that Expect: 100-continue is not wanted */
@@ -343,6 +342,7 @@ public:
   }
 
   int parse_config(json config_data) {
+    std::string log_prefix = "\t[Rdio Scanner]\t";
     /*
           system->set_rdioscanner_api_key(node.second.get<std::string>("rdioscannerApiKey", ""));
       BOOST_LOG_TRIVIAL(info) << "Rdio Scanner API Key: " << system->get_rdioscanner_api_key();
@@ -359,14 +359,15 @@ public:
     }
 
     this->data.server = config_data.value("server", "");
-    BOOST_LOG_TRIVIAL(info) << "Rdio Scanner Server: " << this->data.server;
+    BOOST_LOG_TRIVIAL(info) << log_prefix << "Rdio Scanner Server: " << this->data.server;
 
     // from: http://www.zedwood.com/article/cpp-boost-url-regex
+    boost::regex api_regex("(.{33})(.*)?");
     boost::regex ex("(http|https)://([^/ :]+):?([^/ ]*)(/?[^ #?]*)\\x3f?([^ #]*)#?([^ ]*)");
     boost::cmatch what;
 
     if (!regex_match(this->data.server.c_str(), what, ex)) {
-      BOOST_LOG_TRIVIAL(error) << "Unable to parse Rdio Scanner Server URL\n";
+      BOOST_LOG_TRIVIAL(error) << log_prefix << "Unable to parse Rdio Scanner Server URL\n";
       return 1;
     }
 
@@ -375,17 +376,18 @@ public:
       bool rdioscanner_exists = element.contains("apiKey");
       if (rdioscanner_exists) {
         Rdio_Scanner_System sys;
-
         sys.api_key = element.value("apiKey", "");
         sys.system_id = element.value("systemId", 0);
         sys.short_name = element.value("shortName", "");
-        BOOST_LOG_TRIVIAL(info) << "Uploading calls for: " << sys.short_name;
+        regex_match(sys.api_key.c_str(), what, api_regex);
+        std::string redacted_api(what[2].first, what[2].second);
+        BOOST_LOG_TRIVIAL(info) << log_prefix << "Uploading calls for: " << sys.short_name  << "\t Rdio System: " << sys.system_id << "\t API Key: *****" << redacted_api;;
         this->data.systems.push_back(sys);
       }
     }
 
     if (this->data.systems.size() == 0) {
-      BOOST_LOG_TRIVIAL(error) << "Rdio Scanner Server set, but no Systems are configured\n";
+      BOOST_LOG_TRIVIAL(error) << log_prefix << "Rdio Scanner Server set, but no Systems are configured\n";
       return 1;
     }
 


### PR DESCRIPTION
A stray initialization of curl was causing issues with the libcurl library found in older, stable, distros.  This includes the Ubuntu 22.04 LTS base used in the trunk-recorder docker image.

Newer versions of libcurl appear to handle this gracefully, but it will wipe the data accumulated in the curl object and revert the POST request to a GET when using older libraries.

Additionally, the Rdio Scanner startup messages have been cleaned up to mirror #907 
```
(info)   Setting up plugin -  Name: Rdio-Scanner	 Library file: librdioscanner_uploader.so
(info)   	[Rdio Scanner]	Rdio Scanner Server: https://server.net:3000
(info)   	[Rdio Scanner]	Uploading calls for: test	 Rdio System: 1111	 API Key: *****555
(info)   	[Rdio Scanner]	Uploading calls for: clmrn_I	 Rdio System: 3333	 API Key: *****555
(info)   	[Rdio Scanner]	Uploading calls for: clmrn_G	 Rdio System: 3333	 API Key: *****555
```