### PR TITLE
Dockerfile - SDR v4 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
     libsoapysdr-dev \
     libssl-dev \
     libuhd-dev \
+    libusb-dev \
     libusb-1.0-0-dev \
     libxtrx-dev \
     pkg-config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,11 @@ RUN apt-get update && \
     libmirisdr-dev \
     liborc-0.4-dev \
     libpthread-stubs0-dev \
-    librtlsdr-dev \
     libsndfile1-dev \
     libsoapysdr-dev \
     libssl-dev \
     libuhd-dev \
-    libusb-dev \
+    libusb-1.0-0-dev \
     libxtrx-dev \
     pkg-config \
     software-properties-common \
@@ -45,6 +44,20 @@ RUN apt-get update && \
 # Fix the error message level for SmartNet
 
 RUN sed -i 's/log_level = debug/log_level = info/g' /etc/gnuradio/conf.d/gnuradio-runtime.conf
+
+# Compile librtlsdr-dev 2.0 for SDR-Blog v4 support and other updates
+# Ubuntu 22.04 LTS has librtlsdr 0.6.0
+RUN cd /tmp && \
+  git clone https://github.com/steve-m/librtlsdr.git && \
+  cd librtlsdr && \
+  mkdir build && \
+  cd build && \
+  cmake .. && \
+  make -j$(nproc) && \
+  make install && \
+  ldconfig && \
+  cd /tmp && \
+  rm -rf librtlsdr
 
 # Compile gr-osmosdr ourselves using a fork with various patches included
 RUN cd /tmp && \


### PR DESCRIPTION
The present dockerfile utilizes an updated fork of `gr-osmosdr`, but the Ubuntu 22.04 LTS base does not include the corresponding librtlsdr 2.0 drivers.  This update to the docker file manually builds librtlsdr from source to provide updated rtl drivers for Ubuntu LTS.

This will allow docker users to utilize RTL-SDR Blog v4 devices, as well as benefit from any fixes that have occurred since librtlsdr 0.6.

As of librtlsdr 2.0, this also requires the inclusion of `libusb-1.0-0-dev`.