### PR TITLE
Bcfy pluginfix

### DIFF
--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -135,11 +135,11 @@ public:
     curl_mimepart *part;
 
     mime = curl_mime_init(curl);
-    part = curl_mime_addpart(mime);
 
-    curl_mime_filedata(part, call_info.converted);
-    curl_mime_type(part, "application/octet-stream"); /* content-type for this part */
-    curl_mime_name(part, "call");
+    part = curl_mime_addpart(mime);
+    curl_mime_filedata(part, call_info.status_filename);
+    curl_mime_type(part, "application/json");
+    curl_mime_name(part, "metadata");
 
     part = curl_mime_addpart(mime);
     curl_mime_data(part, call_info.converted, CURL_ZERO_TERMINATED);

--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -155,7 +155,7 @@ public:
 
     part = curl_mime_addpart(mime);
     curl_mime_data(part, api_key.c_str(), CURL_ZERO_TERMINATED);
-    curl_mime_name(part, "api_key");
+    curl_mime_name(part, "apiKey");
 
     multi_handle = curl_multi_init();
 

--- a/plugins/openmhz_uploader/openmhz_uploader.cc
+++ b/plugins/openmhz_uploader/openmhz_uploader.cc
@@ -318,7 +318,7 @@ public:
     BOOST_LOG_TRIVIAL(info) << log_prefix << "OpenMHz Server: " << this->data.openmhz_server;
 
     // from: http://www.zedwood.com/article/cpp-boost-url-regex
-    boost::regex api_regex("(.{29})(.*)?");
+    boost::regex api_regex("(.*)(.{2}$)");
     boost::regex ex("(http|https)://([^/ :]+):?([^/ ]*)(/?[^ #?]*)\\x3f?([^ #]*)#?([^ ]*)");
     boost::cmatch what;
 
@@ -336,7 +336,7 @@ public:
         sys.openmhz_sysid = element.value("openmhzSystemId", sys.short_name);
         regex_match(sys.api_key.c_str(), what, api_regex);
         std::string redacted_api(what[2].first, what[2].second);
-        BOOST_LOG_TRIVIAL(info) << log_prefix << "Uploading calls for: " << sys.short_name << "\t OpenMHz System: " << sys.openmhz_sysid << "\t API Key: *****" << redacted_api;
+        BOOST_LOG_TRIVIAL(info) << log_prefix << "Uploading calls for: " << sys.short_name << "\t OpenMHz System: " << sys.openmhz_sysid << "\t API Key: ******" << redacted_api;
         this->data.systems.push_back(sys);
       }
     }

--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -362,7 +362,7 @@ public:
     BOOST_LOG_TRIVIAL(info) << log_prefix << "Rdio Scanner Server: " << this->data.server;
 
     // from: http://www.zedwood.com/article/cpp-boost-url-regex
-    boost::regex api_regex("(.{33})(.*)?");
+    boost::regex api_regex("(.*)(.{2}$)");
     boost::regex ex("(http|https)://([^/ :]+):?([^/ ]*)(/?[^ #?]*)\\x3f?([^ #]*)#?([^ ]*)");
     boost::cmatch what;
 
@@ -381,7 +381,7 @@ public:
         sys.short_name = element.value("shortName", "");
         regex_match(sys.api_key.c_str(), what, api_regex);
         std::string redacted_api(what[2].first, what[2].second);
-        BOOST_LOG_TRIVIAL(info) << log_prefix << "Uploading calls for: " << sys.short_name  << "\t Rdio System: " << sys.system_id << "\t API Key: *****" << redacted_api;;
+        BOOST_LOG_TRIVIAL(info) << log_prefix << "Uploading calls for: " << sys.short_name  << "\t Rdio System: " << sys.system_id << "\t API Key: ******" << redacted_api;
         this->data.systems.push_back(sys);
       }
     }


### PR DESCRIPTION
The 5.0 curl upgrade is inadvertently using `api_key` instead of `apiKey` in the Broadcastify Plugin.  It also lacks the `metadata` upload, and attempts to upload the call audio prior to receiving the upload URL back from the server.

This reverts to the correct API key name, uploads the t-r metadata as before, and removes an early upload attempt for call audio.

Startup message have also been adjusted for clarity and identifying serviced endpoints:
```
(info)   Setting up plugin -  Name: broadcastify_uploader     Library file: libbroadcastify_uploader.so
(info)       [Broadcastify]    Broadcastify Server: https://api.broadcastify.com/call-upload
(info)       [Broadcastify]    Uploading calls for: clmrn_I     Broadcastify System: 12347568     API Key: ******b9
(info)       [Broadcastify]    Uploading calls for: clmrn_G     Broadcastify System: 99999999     API Key: ******b9
```

An additional fix was included to use a less-messy regex in the other two uploaders.