### PR TITLE
broadcastify_uploader.cc - minor log level adjustment

### DIFF
--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -280,7 +280,7 @@ public:
         return 0;
       }
       if (code == "1" && (message.rfind("REJECTED", 0) == 0)) {
-        BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\tTG: " << call_info.talkgroup << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Upload REJECTED: " << message;
+        BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\tTG: " << call_info.talkgroup << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Upload REJECTED: " << message;
         return 0;
       }
 


### PR DESCRIPTION
"Rejected" status currently logs at an 'info' level. This quick change will now show as an error if Broadcastify rejects your upload.