### PR TITLE
Fix bad link in INSTALL-LINUX.md

### DIFF
--- a/docs/Install/INSTALL-LINUX.md
+++ b/docs/Install/INSTALL-LINUX.md
@@ -213,7 +213,7 @@ Now restart to make sure these drivers are not loaded.
 
 ## Configuring Trunk Recorder
 
-The next step is to [configure Trunk Recorder](CONFIGURE.md) for the system you are trying to capture.
+The next step is to [configure Trunk Recorder](../CONFIGURE.md) for the system you are trying to capture.
 
 ## Running trunk recorder. 
 


### PR DESCRIPTION
This fixes a typo hyperlink in the build/INSTALL-LINUX.md documentation.