### PR TITLE
Increment conventional call numbers on restart_call()

### DIFF
--- a/trunk-recorder/call_conventional.cc
+++ b/trunk-recorder/call_conventional.cc
@@ -8,6 +8,7 @@ Call_conventional::Call_conventional(long t, double f, System *s, Config c) : Ca
 }
 
 void Call_conventional::restart_call() {
+  call_num = call_counter++;
   idle_count = 0;
   signal = 999;
   noise = 999;


### PR DESCRIPTION
Conventional calls are assigned a call number when they are first created, and continue to reuse that same `call_num` for every subsequent call.

While this reuse has no negative technical effects, it is not ideal from the standpoint of logging or reporting to have non-unique numbers as a call identifier.

This patch simply increments the `call_num` on each `Call_conventional::restart_call()`.