### PR TITLE
Save recorder and source number in Call_Data_t

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -63,6 +63,8 @@ int create_call_json(Call_Data_t& call_info) {
           {"freq_error", int(call_info.freq_error)},
           {"signal", int(call_info.signal)},
           {"noise", int(call_info.noise)},
+          {"source_num", int(call_info.source_num)},
+          {"recorder_num", int(call_info.recorder_num)},
           {"tdma_slot", int(call_info.tdma_slot)},
           {"phase2_tdma", int(call_info.phase2_tdma)},
           {"start_time", call_info.start_time},
@@ -306,6 +308,8 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
   call_info.freq_error = call->get_freq_error();
   call_info.signal = call->get_signal();
   call_info.noise = call->get_noise();
+  call_info.recorder_num = call->get_recorder()->get_num();
+  call_info.source_num = call->get_recorder()->get_source()->get_num();
   call_info.encrypted = call->get_encrypted();
   call_info.emergency = call->get_emergency();
   call_info.priority = call->get_priority();

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -99,6 +99,8 @@ struct Call_Data_t {
   long call_num;
   double freq;
   int freq_error;
+  int source_num;
+  int recorder_num;
   double signal;
   double noise;
   long start_time;


### PR DESCRIPTION
To aid in the analysis of `freq_error`, `signal`, and `noise` values in 5.0, it would be beneficial to track which SDR a call was recorded on.  This zero-indexed value will need to be compared against the source order in the config.json, but it will allow users interested in monitoring such information to correlate these metrics against unique devices.

This PR captures a call's source and recorder number in the `Call_Data_t` struct, and provides it to the call .json or any plugin seeking to use it.