### PR TITLE
Plugin smart retry

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -4,6 +4,7 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
+const int Call_Concluder::MAX_RETRY = 2;
 std::list<std::future<Call_Data_t>> Call_Concluder::call_data_workers = {};
 std::list<Call_Data_t> Call_Concluder::retry_call_list = {};
 
@@ -417,16 +418,16 @@ void Call_Concluder::conclude_call(Call *call, System *sys, Config config) {
     return;
   }
   else if (call_info.transmission_list.size()== 0 && call_info.min_transmissions_removed == 0) {
-    BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\t Freq: " << format_freq(call_info.freq) << "\tNo Transmissions were recorded!";
+    BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tNo Transmissions were recorded!";
     return;
   }
   else if (call_info.transmission_list.size() == 0 && call_info.min_transmissions_removed > 0) {
-    BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\t Freq: " << format_freq(call_info.freq) << "\tNo Transmissions were recorded! " << call_info.min_transmissions_removed << " tranmissions less than " << sys->get_min_tx_duration() << " seconds were removed.";
+    BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tNo Transmissions were recorded! " << call_info.min_transmissions_removed << " tranmissions less than " << sys->get_min_tx_duration() << " seconds were removed.";
     return;
   }
 
   if (call_info.length <= sys->get_min_duration()) {
-    BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\t Freq: " << format_freq(call_info.freq) << "\t Call length: " << call_info.length << " is less than min duration: " << sys->get_min_duration();
+    BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tCall length: " << call_info.length << " is less than min duration: " << sys->get_min_duration();
     remove_call_files(call_info);
     return;
   }
@@ -447,13 +448,13 @@ void Call_Concluder::manage_call_data_workers() {
 
         if (call_info.retry_attempt > Call_Concluder::MAX_RETRY) {
           remove_call_files(call_info);
-          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m Failed to conclude call - TG: " << call_info.talkgroup_display << "\t" << std::put_time(std::localtime(&start_time), "%c %Z");
+          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tFailed to conclude call - TG: " << call_info.talkgroup_display << "\t" << std::put_time(std::localtime(&start_time), "%c %Z");
         } else {
           long jitter = rand() % 10;
           long backoff = (2 ^ call_info.retry_attempt * 60) + jitter;
           call_info.process_call_time = time(0) + backoff;
           retry_call_list.push_back(call_info);
-          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m \tTG: " << call_info.talkgroup_display << "\t" << std::put_time(std::localtime(&start_time), "%c %Z") << " retry attempt " << call_info.retry_attempt << " in " << backoff << "s\t retry queue: " << retry_call_list.size() << " calls";
+          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\t" << std::put_time(std::localtime(&start_time), "%c %Z") << " retry attempt " << call_info.retry_attempt << " in " << backoff << "s\t retry queue: " << retry_call_list.size() << " calls";
         }
       }
       it = call_data_workers.erase(it);

--- a/trunk-recorder/call_concluder/call_concluder.h
+++ b/trunk-recorder/call_concluder/call_concluder.h
@@ -18,9 +18,9 @@
 Call_Data_t upload_call_worker(Call_Data_t call_info);
 
 class Call_Concluder {
-  static const int MAX_RETRY = 2;
 
 public:
+  static const int MAX_RETRY;
   static std::list<Call_Data_t> retry_call_list;
   static std::list<std::future<Call_Data_t>> call_data_workers;
   

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -136,6 +136,7 @@ struct Call_Data_t {
   time_t process_call_time;
   int retry_attempt;
 
+  std::vector<int> plugin_retry_list;
   nlohmann::ordered_json call_json;
 };
 

--- a/trunk-recorder/plugin_manager/plugin_manager.cc
+++ b/trunk-recorder/plugin_manager/plugin_manager.cc
@@ -168,19 +168,46 @@ int plugman_call_start(Call *call) {
   return error;
 }
 
-int plugman_call_end(Call_Data_t call_info) {
-  int total_error = 0;
-  for (std::vector<Plugin *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
-    Plugin *plugin = *it;
-    if (plugin->state == PLUGIN_RUNNING) {
-      int plugin_error = plugin->api->call_end(call_info);
-      if (plugin_error) {
-        BOOST_LOG_TRIVIAL(error) << "Plugin Manager: call_end -  " << plugin->name << " failed";
+int plugman_call_end(Call_Data_t& call_info) {
+  std::vector<int> plugin_retry_list;
+
+  // On INITIAL, run call_end for all active plugins and note failues 
+  if (call_info.status == INITIAL)
+  {
+    for (std::vector<Plugin *>::iterator it = plugins.begin(); it != plugins.end(); it++) {
+      Plugin *plugin = *it;
+      if (plugin->state == PLUGIN_RUNNING) {
+        int plugin_error = plugin->api->call_end(call_info);
+        if (plugin_error) {
+          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tPlugin Manager: call_end -  " << plugin->name << " failed.";
+          int plugin_index = std::distance(plugins.begin(), it );
+          plugin_retry_list.push_back(plugin_index);
+        }
       }
-      total_error = total_error + plugin_error;
+    }
+  } 
+  // On RETRY, run call_end only for plugins reporting previous failue
+  else if (call_info.status == RETRY)
+  {
+    for (std::vector<int>::iterator it = call_info.plugin_retry_list.begin(); it != call_info.plugin_retry_list.end(); it++) {
+      Plugin *plugin = plugins[*it];
+      if (plugin->state == PLUGIN_RUNNING) {
+        BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tPlugin Manager: call_end - retry (" << call_info.retry_attempt << "/" << Call_Concluder::MAX_RETRY << ") - " << plugin->name;
+        int plugin_error = plugin->api->call_end(call_info);
+        if (plugin_error) {
+          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tPlugin Manager: call_end - retry (" << call_info.retry_attempt << "/" << Call_Concluder::MAX_RETRY << ") - " << plugin->name << " failed.";
+          plugin_retry_list.push_back(*it);
+        }
+      }
     }
   }
-  return total_error;
+
+  if (plugin_retry_list.size() == 0) {
+    return 0;
+  } else {
+    call_info.plugin_retry_list = plugin_retry_list;
+    return 1;
+  }
 }
 
 int plugman_calls_active(std::vector<Call *> calls) {

--- a/trunk-recorder/plugin_manager/plugin_manager.cc
+++ b/trunk-recorder/plugin_manager/plugin_manager.cc
@@ -170,6 +170,10 @@ int plugman_call_start(Call *call) {
 
 int plugman_call_end(Call_Data_t& call_info) {
   std::vector<int> plugin_retry_list;
+  
+  std::stringstream logstream;
+  logstream << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\t";
+  std::string loghdr = logstream.str();
 
   // On INITIAL, run call_end for all active plugins and note failues 
   if (call_info.status == INITIAL)
@@ -179,7 +183,7 @@ int plugman_call_end(Call_Data_t& call_info) {
       if (plugin->state == PLUGIN_RUNNING) {
         int plugin_error = plugin->api->call_end(call_info);
         if (plugin_error) {
-          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tPlugin Manager: call_end -  " << plugin->name << " failed.";
+          BOOST_LOG_TRIVIAL(error) << loghdr << "Plugin Manager: call_end -  " << plugin->name << " failed.";
           int plugin_index = std::distance(plugins.begin(), it );
           plugin_retry_list.push_back(plugin_index);
         }
@@ -192,10 +196,10 @@ int plugman_call_end(Call_Data_t& call_info) {
     for (std::vector<int>::iterator it = call_info.plugin_retry_list.begin(); it != call_info.plugin_retry_list.end(); it++) {
       Plugin *plugin = plugins[*it];
       if (plugin->state == PLUGIN_RUNNING) {
-        BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tPlugin Manager: call_end - retry (" << call_info.retry_attempt << "/" << Call_Concluder::MAX_RETRY << ") - " << plugin->name;
+        BOOST_LOG_TRIVIAL(info) << loghdr << "Plugin Manager: call_end - retry (" << call_info.retry_attempt << "/" << Call_Concluder::MAX_RETRY << ") - " << plugin->name;
         int plugin_error = plugin->api->call_end(call_info);
         if (plugin_error) {
-          BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tPlugin Manager: call_end - retry (" << call_info.retry_attempt << "/" << Call_Concluder::MAX_RETRY << ") - " << plugin->name << " failed.";
+          BOOST_LOG_TRIVIAL(error) << loghdr << "Plugin Manager: call_end - retry (" << call_info.retry_attempt << "/" << Call_Concluder::MAX_RETRY << ") - " << plugin->name << " failed.";
           plugin_retry_list.push_back(*it);
         }
       }

--- a/trunk-recorder/plugin_manager/plugin_manager.h
+++ b/trunk-recorder/plugin_manager/plugin_manager.h
@@ -35,7 +35,7 @@ void plugman_audio_callback(Call *call, Recorder *recorder, int16_t *samples, in
 int plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
 int plugman_trunk_message(std::vector<TrunkMessage> messages, System *system);
 int plugman_call_start(Call *call);
-int plugman_call_end(Call_Data_t call_info);
+int plugman_call_end(Call_Data_t& call_info);
 int plugman_calls_active(std::vector<Call *> calls);
 void plugman_setup_recorder(Recorder *recorder);
 void plugman_setup_system(System *system);


### PR DESCRIPTION
When a plugin returns a failure for a `call_end` API function, trunk-recorder puts the call into a retry queue to attempt delivery two more times before abandoning the call and cleaning up.  However, this process does not note *which* plugins report a failure, and *all* upload plugins will be retried on each attempt until *all* plugins are successful.

Problems are often seen when a config uses multiple plugins (OpenMHz, broadcastify, rdio-scanner, mqtt, etc...).  Should any one of those endpoints go down (or have a problem with their SSL certs), all the other plugins will upload duplicate calls on each re-attempt.

This plugin records which plugins report a `call_end` failure, and on retry only attempts those to avoid sending duplicates to other services.