### PR TITLE
Potential docker enhancements & two-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,4 @@ WORKDIR /app
 ENV HOME=/tmp
 
 #USER nobody
-#CMD trunk-recorder --config=/app/config.json
-ENTRYPOINT ["/bin/bash"]
+CMD trunk-recorder --config=/app/config.json

--- a/docs/Install/INSTALL-DOCKER.md
+++ b/docs/Install/INSTALL-DOCKER.md
@@ -10,9 +10,8 @@ To get started, create a directory and place your **config.json** file there and
 
 ```bash
 docker run -it \
-  --privileged -e TZ=$(cat /etc/timezone) --user "$(id -u):$(id -g)" \
+  --devices "/dev/bus/usb:/dev/bus/usb:rwm" -e TZ=$(cat /etc/timezone) --user "$(id -u):$(id -g)" \
   -v $(pwd):/app \
-  -v /dev/bus/usb:/dev/bus/usb \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket \
   robotastic/trunk-recorder:latest
@@ -21,15 +20,14 @@ docker run -it \
 To use it as part of a [Docker Compose](https://docs.docker.com/compose/) file:
 
 ```yaml
-version: '3'
 services:
   recorder:
     image: robotastic/trunk-recorder:latest
     container_name: trunk-recorder
     restart: always
-    privileged: true
+    devices:
+      - "/dev/bus/usb:/dev/bus/usb:rwm"
     volumes:
-      - /dev/bus/usb:/dev/bus/usb
       - /var/run/dbus:/var/run/dbus 
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
       - ./:/app

--- a/utils/README.md
+++ b/utils/README.md
@@ -30,9 +30,9 @@ This maps in the current directory, so you can try building files from you local
 
 `docker run -v ${PWD}:/src -it tr-ubuntu /bin/bash`  
 
-`docker run --privileged --ulimit core=-1 -v ${PWD}:/src -v /dev/bus/usb:/dev/bus/usb  -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket -v /home/luke/trunk-recorder-docker:/app -it tr-arch-aur /bin/bash`
+`docker run --devices "/dev/bus/usb:/dev/bus/usb:rwm" --ulimit core=-1 -v ${PWD}:/src  -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket -v /home/luke/trunk-recorder-docker:/app -it tr-arch-aur /bin/bash`
 
-`docker run --privileged --ulimit core=-1 -v ${PWD}:/src -v /dev/bus/usb:/dev/bus/usb  -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket -v /home/luke/trunk-recorder-docker:/app -it tr-fedora /bin/bash`
+`docker run --devices "/dev/bus/usb:/dev/bus/usb:rwm" --ulimit core=-1 -v ${PWD}:/src -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket -v /home/luke/trunk-recorder-docker:/app -it tr-fedora /bin/bash`
 
 *On an M1 based Mac:*
 `docker run --platform=linux/amd64 -v ${PWD}:/src -it tr-arch  /bin/bash` 
@@ -44,6 +44,6 @@ In the */utils* directory, run the following command to build the AUR package:
 `docker build -t tr-arch-aur --build-arg AUR_PACKAGE=trunk-recorder -f utils/Dockerfile.arch-latest-aur.dev .`
 
 In a directory with a config.json file you want to test, run this command. It will mirror your current directory to */app*.
-`docker run --privileged --ulimit core=-1 -v ${PWD}:/app -v /dev/bus/usb:/dev/bus/usb  -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket -it tr-arch-aur /bin/bash` 
+`docker run --devices "/dev/bus/usb:/dev/bus/usb:rwm" --ulimit core=-1 -v ${PWD}:/app  -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket -it tr-arch-aur /bin/bash` 
 
 If you want to capture a core dump: https://stackoverflow.com/questions/28335614/how-to-generate-core-file-in-docker-container


### PR DESCRIPTION
Good day,

The attached PR makes two slight changes only to the docker workflow.  The first is changing from privileged to device with rwm.  The latter is common in the sdr docker world and reduces the privilege of the container.  It is still running as root, but now as least it has the basic limitations. This change works both on the existing image (the one you would pull from docker pull today) and the two-stage build included (since ideally that build works identically, just smaller).

The second change is a conversion from a single to dual stage build.  This allows a ~2.5 GB reduction in size of the image.  This is accomplished by building trunk-recorder (and first gr-osmosdr) and copying those over to the final image.  The other change is that the final image only has the runtime packages and not the full dev packages.  One of the larger changes here is only adding the gnuradio dependencies that trunk-recorder actually needs instead of gnuradio.  gnuradio has a qt dependency if that gets added to the build you pull in the xorg stack and several kitchen sinks.  

It is possible when the ubuntu image moves forward, the associated apt-get library lines will need updating as there isn't a metapackage.  For example, Debian is on libgnuradio-network3.10.5 instead of .1, so that would need tweaking when the bump to the next ubuntu LTS happens.

This needs testing of course, but it's working fine for me so far and it should work the same as the previous image.  Just much smaller.

```
❯ docker images
REPOSITORY                  TAG       IMAGE ID       CREATED          SIZE
jquagga/trunk-recorder      4.7.1     ff7f233d4460   13 minutes ago   603MB
robotastic/trunk-recorder   latest    a87c76a618d6   3 months ago     2.96GB
```