### PR TITLE
rc/v5.0 formatting fixes

### DIFF
--- a/plugins/openmhz_uploader/openmhz_uploader.cc
+++ b/plugins/openmhz_uploader/openmhz_uploader.cc
@@ -292,13 +292,13 @@ public:
         struct stat file_info;
         stat(call_info.converted, &file_info);
         std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\tOpenMHz Upload Success - file size: " << file_info.st_size;
+        BOOST_LOG_TRIVIAL(info) << loghdr << "OpenMHz Upload Success - file size: " << file_info.st_size;
         ;
         return 0;
       }
     }
     std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\tOpenMHz Upload Error: " << response_buffer;
+    BOOST_LOG_TRIVIAL(error) << loghdr << "OpenMHz Upload Error: " << response_buffer;
     return 1;
   }
 

--- a/plugins/openmhz_uploader/openmhz_uploader.cc
+++ b/plugins/openmhz_uploader/openmhz_uploader.cc
@@ -291,13 +291,13 @@ public:
       if (res == CURLM_OK && response_code == 200) {
         struct stat file_info;
         stat(call_info.converted, &file_info);
-        std::string loghdr = log_header(call_info.short_name,call_info.call_num,talkgroup_display,call_info.freq);
+        std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
         BOOST_LOG_TRIVIAL(info) << loghdr << "\tOpenMHz Upload Success - file size: " << file_info.st_size;
         ;
         return 0;
       }
     }
-    std::string loghdr = log_header(call_info.short_name,call_info.call_num,talkgroup_display,call_info.freq);
+    std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
     BOOST_LOG_TRIVIAL(error) << loghdr << "\tOpenMHz Upload Error: " << response_buffer;
     return 1;
   }

--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -331,13 +331,13 @@ public:
         struct stat file_info;
         stat(compress_wav ? call_info.converted : call_info.filename, &file_info);
         std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\tRdio Scanner Upload Success - file size: " << file_info.st_size;
+        BOOST_LOG_TRIVIAL(info) << loghdr << "Rdio Scanner Upload Success - file size: " << file_info.st_size;
         ;
         return 0;
       }
     }
     std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\tRdio Scanner Upload Error: " << response_buffer;
+    BOOST_LOG_TRIVIAL(error) << loghdr << "Rdio Scanner Upload Error: " << response_buffer;
     return 1;
   }
 

--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -330,13 +330,13 @@ public:
       if (res == CURLM_OK && response_code == 200) {
         struct stat file_info;
         stat(compress_wav ? call_info.converted : call_info.filename, &file_info);
-        std::string loghdr = log_header(call_info.short_name,call_info.call_num,talkgroup_display,call_info.freq);
+        std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
         BOOST_LOG_TRIVIAL(info) << loghdr << "\tRdio Scanner Upload Success - file size: " << file_info.st_size;
         ;
         return 0;
       }
     }
-    std::string loghdr = log_header(call_info.short_name,call_info.call_num,talkgroup_display,call_info.freq);
+    std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
     BOOST_LOG_TRIVIAL(error) << loghdr << "\tRdio Scanner Upload Error: " << response_buffer;
     return 1;
   }

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -358,7 +358,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
     if (t.length < sys->get_min_tx_duration()) {
       if (!call_info.transmission_archive) {
         std::string loghdr = log_header( call_info.short_name, call_info.call_num, call_info.talkgroup_display , call_info.freq);
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\tRemoving transmission less than " << sys->get_min_tx_duration() << " seconds. Actual length: " << t.length << ".";
+        BOOST_LOG_TRIVIAL(info) << loghdr << "Removing transmission less than " << sys->get_min_tx_duration() << " seconds. Actual length: " << t.length << ".";
         call_info.min_transmissions_removed++;
 
         if (checkIfFile(t.filename)) {
@@ -378,7 +378,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
 
     std::stringstream transmission_info;
     std::string loghdr = log_header( call_info.short_name, call_info.call_num, call_info.talkgroup_display , call_info.freq);
-    transmission_info << loghdr << "\t- Transmission src: " << t.source << display_tag << " pos: " << format_time(total_length) << " length: " << format_time(t.length);
+    transmission_info << loghdr << "- Transmission src: " << t.source << display_tag << " pos: " << format_time(total_length) << " length: " << format_time(t.length);
 
     if (t.error_count < 1) {
       BOOST_LOG_TRIVIAL(info) << transmission_info.str();
@@ -415,21 +415,21 @@ void Call_Concluder::conclude_call(Call *call, System *sys, Config config) {
 
   std::string loghdr = log_header( call_info.short_name, call_info.call_num, call_info.talkgroup_display , call_info.freq);
   if(call->get_state() == MONITORING && call->get_monitoring_state() == SUPERSEDED){
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\tCall has been superseded. Removing files.";
+    BOOST_LOG_TRIVIAL(info) << loghdr << "Call has been superseded. Removing files.";
     remove_call_files(call_info);
     return;
   }
   else if (call_info.transmission_list.size()== 0 && call_info.min_transmissions_removed == 0) {
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\tNo Transmissions were recorded!";
+    BOOST_LOG_TRIVIAL(error) << loghdr << "No Transmissions were recorded!";
     return;
   }
   else if (call_info.transmission_list.size() == 0 && call_info.min_transmissions_removed > 0) {
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\tNo Transmissions were recorded! " << call_info.min_transmissions_removed << " tranmissions less than " << sys->get_min_tx_duration() << " seconds were removed.";
+    BOOST_LOG_TRIVIAL(info) << loghdr << "No Transmissions were recorded! " << call_info.min_transmissions_removed << " tranmissions less than " << sys->get_min_tx_duration() << " seconds were removed.";
     return;
   }
 
   if (call_info.length <= sys->get_min_duration()) {
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\t Call length: " << call_info.length << " is less than min duration: " << sys->get_min_duration();
+    BOOST_LOG_TRIVIAL(error) << loghdr << "Call length: " << call_info.length << " is less than min duration: " << sys->get_min_duration();
     remove_call_files(call_info);
     return;
   }
@@ -451,13 +451,13 @@ void Call_Concluder::manage_call_data_workers() {
 
         if (call_info.retry_attempt > Call_Concluder::MAX_RETRY) {
           remove_call_files(call_info);
-          BOOST_LOG_TRIVIAL(error) << loghdr << " Failed to conclude call - TG: " << call_info.talkgroup_display << "\t" << std::put_time(std::localtime(&start_time), "%c %Z");
+          BOOST_LOG_TRIVIAL(error) << loghdr << "Failed to conclude call - " << std::put_time(std::localtime(&start_time), "%c %Z");
         } else {
           long jitter = rand() % 10;
           long backoff = (2 ^ call_info.retry_attempt * 60) + jitter;
           call_info.process_call_time = time(0) + backoff;
           retry_call_list.push_back(call_info);
-          BOOST_LOG_TRIVIAL(error) << loghdr << " \tTG: " << call_info.talkgroup_display << "\t" << std::put_time(std::localtime(&start_time), "%c %Z") << " retry attempt " << call_info.retry_attempt << " in " << backoff << "s\t retry queue: " << retry_call_list.size() << " calls";
+          BOOST_LOG_TRIVIAL(error) << loghdr << std::put_time(std::localtime(&start_time), "%c %Z") << " retry attempt " << call_info.retry_attempt << " in " << backoff << "s\t retry queue: " << retry_call_list.size() << " calls";
         }
       }
       it = call_data_workers.erase(it);

--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -112,7 +112,7 @@ void Call_impl::stop_call() {
     // doing anything and can be stopped.
     if ((state == RECORDING) && this->get_recorder()->is_idle()) {
       std::string loghdr = log_header( sys->get_short_name(), this->get_call_num(), this->get_talkgroup_display(), this->get_freq());
-      BOOST_LOG_TRIVIAL(info) << loghdr << "\tStopping Recorded Call_impl - Last Update: " << this->since_last_update() << "s";
+      BOOST_LOG_TRIVIAL(info) << loghdr << "Stopping Recorded Call_impl - Last Update: " << this->since_last_update() << "s";
     }
   }
 }
@@ -142,14 +142,14 @@ void Call_impl::conclude_call() {
         this->set_signal(this->get_recorder()->get_pwr());
       }
         std::string loghdr = log_header( sys->get_short_name(), this->get_call_num(), this->get_talkgroup_display(), this->get_freq());
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[33mConcluding Recorded Call\u001b[0m - Last Update: " << this->since_last_update() << "s\tRecorder last write:" << recorder->since_last_write() << "\tCall Elapsed: " << this->elapsed() << "\t Signal: " << floor(this->get_signal()) << "dBm\t Noise: " << floor(this->get_noise()) << "dBm";
+        BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[33mConcluding Recorded Call\u001b[0m - Last Update: " << this->since_last_update() << "s\tRecorder last write:" << recorder->since_last_write() << "\tCall Elapsed: " << this->elapsed() << "\t Signal: " << floor(this->get_signal()) << "dBm\t Noise: " << floor(this->get_noise()) << "dBm";
     } else {
         std::string loghdr = log_header( sys->get_short_name(), this->get_call_num(), this->get_talkgroup_display(), this->get_freq());
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[33mConcluding Recorded Call\u001b[0m - Last Update: " << this->since_last_update() << "s\tRecorder last write:" << recorder->since_last_write() << "\tCall Elapsed: " << this->elapsed();
+        BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[33mConcluding Recorded Call\u001b[0m - Last Update: " << this->since_last_update() << "s\tRecorder last write:" << recorder->since_last_write() << "\tCall Elapsed: " << this->elapsed();
     }
     if (was_update) {
       std::string loghdr = log_header( sys->get_short_name(), this->get_call_num(), this->get_talkgroup_display(), this->get_freq());
-      BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[33mCall was UPDATE not GRANT\u001b[0m";
+      BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[33mCall was UPDATE not GRANT\u001b[0m";
     }
     freq_error = this->get_recorder()->get_freq_error();
     this->get_recorder()->stop();

--- a/trunk-recorder/formatter.cc
+++ b/trunk-recorder/formatter.cc
@@ -93,7 +93,7 @@ std::string format_state(State state, MonitoringState monitoringState) {
 
 std::string log_header(std::string short_name,long call_num, std::string talkgroup_display, double freq) {
   std::stringstream ss;
-  ss << "[" << short_name << "]\t\033[0;34m" << call_num << "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(freq) << "\033[0m";
+  ss << "[" << short_name << "]\t\033[0;34m" << call_num << "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(freq) << "\033[0m\t";
   std::string s = ss.str();
   return s;      
 }

--- a/trunk-recorder/formatter.cc
+++ b/trunk-recorder/formatter.cc
@@ -93,7 +93,7 @@ std::string format_state(State state, MonitoringState monitoringState) {
 
 std::string log_header(std::string short_name,long call_num, std::string talkgroup_display, double freq) {
   std::stringstream ss;
-  ss << "[" << short_name << "]\t\033[0;34m" << call_num << "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(freq) << "\t\u001b[36m";
+  ss << "[" << short_name << "]\t\033[0;34m" << call_num << "C\033[0m\tTG: " << talkgroup_display << "\tFreq: " << format_freq(freq) << "\033[0m";
   std::string s = ss.str();
   return s;      
 }

--- a/trunk-recorder/gr_blocks/transmission_sink.cc
+++ b/trunk-recorder/gr_blocks/transmission_sink.cc
@@ -141,7 +141,7 @@ bool transmission_sink::start_recording(Call *call) {
   state = IDLE;
   /* Should reset more variables here */
   std::string loghdr = log_header(d_current_call_short_name,d_current_call_num,d_current_call_talkgroup_display,d_current_call_freq);
-  BOOST_LOG_TRIVIAL(trace) << loghdr << "\tStarting wavfile sink SRC ID: " << curr_src_id << " Conventional: " << d_conventional;
+  BOOST_LOG_TRIVIAL(trace) << loghdr << "Starting wavfile sink SRC ID: " << curr_src_id << " Conventional: " << d_conventional;
 
   return true;
 }
@@ -205,14 +205,14 @@ void transmission_sink::set_source(long src) {
   std::string loghdr = log_header(d_current_call_short_name,d_current_call_num,d_current_call_talkgroup_display,d_current_call_freq);
   if (curr_src_id == -1) {
 
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\tUnit ID set via Control Channel, ext: " << src << "\tcurrent: " << curr_src_id << "\t samples: " << d_sample_count;
+    BOOST_LOG_TRIVIAL(info) << loghdr << "Unit ID set via Control Channel, ext: " << src << "\tcurrent: " << curr_src_id << "\t samples: " << d_sample_count;
 
     curr_src_id = src;
   }
   else if (d_conventional && (src != curr_src_id)) {
     if ((state == RECORDING) && (d_sample_count > 0)) {
         gr::thread::scoped_lock guard(d_mutex);
-        BOOST_LOG_TRIVIAL(error) << loghdr << "\tUnit ID externally set, ext: " << src << "\tcurrent: " << curr_src_id << "\t samples: " << d_sample_count;
+        BOOST_LOG_TRIVIAL(error) << loghdr << "Unit ID externally set, ext: " << src << "\tcurrent: " << curr_src_id << "\t samples: " << d_sample_count;
         end_transmission();
         state = IDLE;
         curr_src_id = src;
@@ -301,9 +301,9 @@ int transmission_sink::work(int noutput_items, gr_vector_const_void_star &input_
     // It is possible the P25 Frame Assembler passes a TDU after the call has timed out.
     // In this case, the termination tag will be transferred on a blank sample and can safely be ignored.
     if (noutput_items == 1) {
-      BOOST_LOG_TRIVIAL(trace) << loghdr << "\tDropping " << noutput_items << " samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
+      BOOST_LOG_TRIVIAL(trace) << loghdr << "Dropping " << noutput_items << " samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
     } else {
-      BOOST_LOG_TRIVIAL(error) << loghdr << "\tDropping " << noutput_items << " samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
+      BOOST_LOG_TRIVIAL(error) << loghdr << "Dropping " << noutput_items << " samples - current_call is null\t Rec State: " << format_state(this->state) << "\tSince close: " << its_been;
     }
 
     return noutput_items;
@@ -313,7 +313,7 @@ int transmission_sink::work(int noutput_items, gr_vector_const_void_star &input_
   if ((state == STOPPED) || (state == AVAILABLE)) {
     if (noutput_items > 1) {
 
-      BOOST_LOG_TRIVIAL(error) << loghdr << "\tDropping " << noutput_items << " samples - Recorder state is: " << format_state(this->state);
+      BOOST_LOG_TRIVIAL(error) << loghdr << "Dropping " << noutput_items << " samples - Recorder state is: " << format_state(this->state);
 
       // BOOST_LOG_TRIVIAL(info) << "WAV - state is: " << format_state(this->state) << "\t Dropping samples: " << noutput_items << " Since close: " << its_been << std::endl;
     }
@@ -341,14 +341,14 @@ int transmission_sink::work(int noutput_items, gr_vector_const_void_star &input_
       if ((state == RECORDING) || (state == IDLE)) {
         if (d_current_call_talkgroup_encoded != grp_id) {
           if (!d_conventional) {
-            BOOST_LOG_TRIVIAL(info) << loghdr << "\tGROUP MISMATCH -  Recorder TG: " << d_current_call_talkgroup_encoded << " Received TG: " << grp_id << " Recorder state: " << format_state(state) << " incoming: " << noutput_items;
+            BOOST_LOG_TRIVIAL(info) << loghdr << "GROUP MISMATCH -  Recorder TG: " << d_current_call_talkgroup_encoded << " Received TG: " << grp_id << " Recorder state: " << format_state(state) << " incoming: " << noutput_items;
             if (d_sample_count > 0) {
-              BOOST_LOG_TRIVIAL(info) << loghdr << "\tEnding Transmission and IGNORING Rest - count: " << d_sample_count;
+              BOOST_LOG_TRIVIAL(info) << loghdr << "Ending Transmission and IGNORING Rest - count: " << d_sample_count;
               end_transmission();
             }
             state = IGNORE;
           } else {
-            BOOST_LOG_TRIVIAL(debug) << loghdr << "\tGroup Mismatch - Recorder Received TG: " << grp_id << " Recorder state: " << format_state(state) << " incoming samples: " << noutput_items;
+            BOOST_LOG_TRIVIAL(debug) << loghdr << "Group Mismatch - Recorder Received TG: " << grp_id << " Recorder state: " << format_state(state) << " incoming samples: " << noutput_items;
           }
         }
       }
@@ -397,12 +397,12 @@ int transmission_sink::work(int noutput_items, gr_vector_const_void_star &input_
       if (pmt::eq(spike_count_key, tags[i].key)) {
         d_spike_count = pmt::to_long(tags[i].value);
 
-        BOOST_LOG_TRIVIAL(trace) << loghdr << "\tSpike Count: " << d_spike_count << " pos: " << pos << " offset: " << tags[i].offset;
+        BOOST_LOG_TRIVIAL(trace) << loghdr << "Spike Count: " << d_spike_count << " pos: " << pos << " offset: " << tags[i].offset;
       }
       if (pmt::eq(error_count_key, tags[i].key)) {
         d_error_count = pmt::to_long(tags[i].value);
 
-        BOOST_LOG_TRIVIAL(trace) << loghdr << "\tError Count: " << d_error_count << " pos: " << pos << " offset: " << tags[i].offset;
+        BOOST_LOG_TRIVIAL(trace) << loghdr << "Error Count: " << d_error_count << " pos: " << pos << " offset: " << tags[i].offset;
       }
     }
   }
@@ -463,7 +463,7 @@ int transmission_sink::dowork(int noutput_items, gr_vector_const_void_star &inpu
     }
 
     if (state == IGNORE) {
-      BOOST_LOG_TRIVIAL(trace) << loghdr << "\tResetting state from IGNORE to IDLE: " << noutput_items;
+      BOOST_LOG_TRIVIAL(trace) << loghdr << "Resetting state from IGNORE to IDLE: " << noutput_items;
       state = IDLE;
 
       return noutput_items;
@@ -471,26 +471,26 @@ int transmission_sink::dowork(int noutput_items, gr_vector_const_void_star &inpu
 
     // The TDU can come in with voice samples. Write the voice samples and then end the transmission.
     if (d_sample_count > 0 && noutput_items > 1) {
-      BOOST_LOG_TRIVIAL(trace) << loghdr << "\tTerminator received with items. Ending transmission after writing. Sample Count: " << d_sample_count << " Noutput Items: " << noutput_items;
+      BOOST_LOG_TRIVIAL(trace) << loghdr << "Terminator received with items. Ending transmission after writing. Sample Count: " << d_sample_count << " Noutput Items: " << noutput_items;
       terminate_after_write = true;
       // Handle the case of a terminator coming in without voice samples. End the transmission immediately.
     } else if (d_sample_count > 0) {
-      BOOST_LOG_TRIVIAL(trace) << loghdr << "\tTerminator received without items. Ending transmission immediately. " << d_sample_count << " Noutput Items: " << noutput_items;
+      BOOST_LOG_TRIVIAL(trace) << loghdr << "Terminator received without items. Ending transmission immediately. " << d_sample_count << " Noutput Items: " << noutput_items;
       end_transmission();
       return noutput_items;
     } else {
-      BOOST_LOG_TRIVIAL(trace) << loghdr << "\tTERM - skipped....   - count: " << d_sample_count;
+      BOOST_LOG_TRIVIAL(trace) << loghdr << "TERM - skipped....   - count: " << d_sample_count;
       return noutput_items;
     }
   }
 
   if (state == IGNORE) {
-    BOOST_LOG_TRIVIAL(trace) << loghdr << "\tIGNORE missing count: " << noutput_items;
+    BOOST_LOG_TRIVIAL(trace) << loghdr << "IGNORE missing count: " << noutput_items;
     return noutput_items;
   }
 
   if (state == IDLE) {
-    // BOOST_LOG_TRIVIAL(info) << loghdr << "\tIDLE but haven't seen Group ID yet, missing count: " << noutput_items;
+    // BOOST_LOG_TRIVIAL(info) << loghdr << "IDLE but haven't seen Group ID yet, missing count: " << noutput_items;
     // return noutput_items;
     if (d_fp) {
       // if we are already recording a file for this call, close it before starting a new one.
@@ -513,7 +513,7 @@ int transmission_sink::dowork(int noutput_items, gr_vector_const_void_star &inpu
       return noutput_items;
     }
 
-    BOOST_LOG_TRIVIAL(trace) << loghdr << "\tStarting new Transmission \tSrc ID:  " << curr_src_id;
+    BOOST_LOG_TRIVIAL(trace) << loghdr << "Starting new Transmission \tSrc ID:  " << curr_src_id;
 
     // curr_src_id = d_current_call->get_current_source_id();
     state = RECORDING;
@@ -552,9 +552,9 @@ int transmission_sink::dowork(int noutput_items, gr_vector_const_void_star &inpu
   d_last_write_time = std::chrono::steady_clock::now();
 
   if (nwritten < noutput_items) {
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\tFailed to Write! Wrote: " << nwritten << " of " << noutput_items;
+    BOOST_LOG_TRIVIAL(error) << loghdr << "Failed to Write! Wrote: " << nwritten << " of " << noutput_items;
   } else {
-    BOOST_LOG_TRIVIAL(trace) << loghdr << "\t Wrote: " << nwritten << " of " << noutput_items;
+    BOOST_LOG_TRIVIAL(trace) << loghdr << "Wrote: " << nwritten << " of " << noutput_items;
   }
   return noutput_items;
 }

--- a/trunk-recorder/monitor_systems.cc
+++ b/trunk-recorder/monitor_systems.cc
@@ -27,7 +27,7 @@ bool start_recorder(Call *call, TrunkMessage message, Config &config, System *sy
     call->set_monitoring_state(UNKNOWN_TG);
     if (sys->get_hideUnknown() == false) {
       std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-      BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[33mNot Recording: TG not in Talkgroup File\u001b[0m ";
+      BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[33mNot Recording: TG not in Talkgroup File\u001b[0m ";
     }
     return false;
   }
@@ -48,7 +48,7 @@ bool start_recorder(Call *call, TrunkMessage message, Config &config, System *sy
         tag = " (\033[0;34m" + tag + "\033[0m)";
       }
       std::string loghdr = log_header( sys->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-      BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[31mNot Recording: ENCRYPTED\u001b[0m - src: " << unit_id << tag;
+      BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[31mNot Recording: ENCRYPTED\u001b[0m - src: " << unit_id << tag;
     }
     return false;
   }
@@ -78,7 +78,7 @@ bool start_recorder(Call *call, TrunkMessage message, Config &config, System *sy
         }
       } else {
         std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\tTG not in Talkgroup File ";
+        BOOST_LOG_TRIVIAL(info) << loghdr << "TG not in Talkgroup File ";
 
         // A talkgroup was not found from the talkgroup file.
         // Use an analog recorder if this is a Type II trunk and defaultMode is analog.
@@ -148,7 +148,7 @@ bool start_recorder(Call *call, TrunkMessage message, Config &config, System *sy
     call->set_state(MONITORING);
     call->set_monitoring_state(NO_SOURCE);
     std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\t\u001b[36mNot Recording: no source covering Freq\u001b[0m";
+    BOOST_LOG_TRIVIAL(error) << loghdr << "\u001b[36mNot Recording: no source covering Freq\u001b[0m";
     return false;
   }
   return false;
@@ -162,13 +162,13 @@ void print_status(std::vector<Source *> &sources, std::vector<System *> &systems
     Recorder *recorder = call->get_recorder();
     std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
     if (call->get_state() == MONITORING) {
-      BOOST_LOG_TRIVIAL(info) << loghdr << " Elapsed: " << std::setw(4) << call->elapsed() << " State: " << format_state(call->get_state(), call->get_monitoring_state());
+      BOOST_LOG_TRIVIAL(info) << loghdr << "Elapsed: " << std::setw(4) << call->elapsed() << " State: " << format_state(call->get_state(), call->get_monitoring_state());
     } else {
       if (call->is_conventional() ) {
         bool is_enabled = call->get_recorder()->is_enabled();
-         BOOST_LOG_TRIVIAL(info) << loghdr << " Elapsed: " << std::setw(4) << call->elapsed() << " State: " << format_state(call->get_state()) << " Enabled: " << is_enabled;
+         BOOST_LOG_TRIVIAL(info) << loghdr << "Elapsed: " << std::setw(4) << call->elapsed() << " State: " << format_state(call->get_state()) << " Enabled: " << is_enabled;
       } else {
-        BOOST_LOG_TRIVIAL(info) << loghdr << " Elapsed: " << std::setw(4) << call->elapsed() << " State: " << format_state(call->get_state());
+        BOOST_LOG_TRIVIAL(info) << loghdr << "Elapsed: " << std::setw(4) << call->elapsed() << " State: " << format_state(call->get_state());
       }
     }
 
@@ -283,7 +283,7 @@ void manage_calls(Config &config, std::vector<Call *> &calls) {
 
       if ((recorder->since_last_write() > config.call_timeout) && (call->since_last_update() > config.call_timeout)) {
         std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-        BOOST_LOG_TRIVIAL(trace) << loghdr << "\t\u001b[36m Stopping Call because of Recorder \u001b[0m Rec last write: " << recorder->since_last_write() << " State: " << format_state(recorder->get_state());
+        BOOST_LOG_TRIVIAL(trace) << loghdr << "\u001b[36m Stopping Call because of Recorder \u001b[0m Rec last write: " << recorder->since_last_write() << " State: " << format_state(recorder->get_state());
         call->conclude_call();
         // The State of the Recorders has changed, so lets send an update
         ended_call = true;
@@ -297,7 +297,7 @@ void manage_calls(Config &config, std::vector<Call *> &calls) {
     } else if (call->since_last_update() > config.call_timeout) {
       Recorder *recorder = call->get_recorder();
       std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-      BOOST_LOG_TRIVIAL(trace) << loghdr << "\t\u001b[36m  Call UPDATEs has been inactive for more than " << config.call_timeout << " Sec \u001b[0m Rec last write: " << recorder->since_last_write() << " State: " << format_state(recorder->get_state());
+      BOOST_LOG_TRIVIAL(trace) << loghdr << "\u001b[36m  Call UPDATEs has been inactive for more than " << config.call_timeout << " Sec \u001b[0m Rec last write: " << recorder->since_last_write() << " State: " << format_state(recorder->get_state());
     }
     ++it;
   } // foreach loggers
@@ -454,7 +454,7 @@ void handle_call_grant(TrunkMessage message, System *sys, bool grant_message, Co
         recorder_state = format_state(recorder->get_state());
       }
       std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-      BOOST_LOG_TRIVIAL(trace) << loghdr << "\t\u001b[36mShould be Stopping RECORDING call, Recorder State: " << recorder_state << " RX overlapping TG message Freq, TG:" << message.talkgroup << "\u001b[0m";
+      BOOST_LOG_TRIVIAL(trace) << loghdr << "\u001b[36mShould be Stopping RECORDING call, Recorder State: " << recorder_state << " RX overlapping TG message Freq, TG:" << message.talkgroup << "\u001b[0m";
     }
 
     it++;
@@ -486,7 +486,7 @@ void handle_call_grant(TrunkMessage message, System *sys, bool grant_message, Co
     std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
     if (superseding_grant) {
       
-      BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[36mSuperseding Grant\u001b[0m - Stopping original call: " << original_call_data << "- Superseding call: " << grant_call_data;
+      BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[36mSuperseding Grant\u001b[0m - Stopping original call: " << original_call_data << "- Superseding call: " << grant_call_data;
       // Attempt to start a new call on the preferred NAC.
       recording_started = start_recorder(call, message, config, sys, sources);
 
@@ -497,16 +497,16 @@ void handle_call_grant(TrunkMessage message, System *sys, bool grant_message, Co
         original_call->conclude_call();
       } else {
         
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[36mCould not start Superseding recorder.\u001b[0m Continuing original call: " << original_call->get_call_num() << "C";
+        BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[36mCould not start Superseding recorder.\u001b[0m Continuing original call: " << original_call->get_call_num() << "C";
       }
     } else if (duplicate_grant) {
       call->set_state(MONITORING);
       call->set_monitoring_state(DUPLICATE);
-      BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[36mDuplicate Grant\u001b[0m - Not recording: " << grant_call_data << "- Original call: " << original_call_data;
+      BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[36mDuplicate Grant\u001b[0m - Not recording: " << grant_call_data << "- Original call: " << original_call_data;
     } else {
       recording_started = start_recorder(call, message, config, sys, sources);
       if (recording_started && !grant_message) {
-        BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[36mThis was an UPDATE\u001b[0m";
+        BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[36mThis was an UPDATE\u001b[0m";
       }
     }
     calls.push_back(call);

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -385,7 +385,7 @@ bool analog_recorder::start(Call *call) {
   }
   
   std::string loghdr = log_header(call->get_short_name(),call->get_call_num(),this->call->get_talkgroup_display(),chan_freq);
-  BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[32mStarting Analog Recorder Num [" << rec_num << "]\u001b[0m \tSquelch: " << squelch_db;
+  BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[32mStarting Analog Recorder Num [" << rec_num << "]\u001b[0m \tSquelch: " << squelch_db;
   prefilter->set_squelch_db(squelch_db);
   return true;
 }

--- a/trunk-recorder/recorders/dmr_recorder_impl.cc
+++ b/trunk-recorder/recorders/dmr_recorder_impl.cc
@@ -264,7 +264,7 @@ bool dmr_recorder_impl::start(Call *call) {
     chan_freq = call->get_freq();
     this->call = call;
     std::string loghdr = log_header(this->call->get_short_name(),this->call->get_call_num(),this->call->get_talkgroup_display(),chan_freq);
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[32mStarting DMR Recorder Num [" << rec_num << "]\u001b[0m\tTDMA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot();
+    BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[32mStarting DMR Recorder Num [" << rec_num << "]\u001b[0m\tTDMA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot();
 
     int offset_amount = (center_freq - chan_freq);
 

--- a/trunk-recorder/recorders/p25_recorder_impl.cc
+++ b/trunk-recorder/recorders/p25_recorder_impl.cc
@@ -263,7 +263,7 @@ void p25_recorder_impl::stop() {
     }
 
     std::string loghdr = log_header(this->call->get_short_name(),this->call->get_call_num(),this->call->get_talkgroup_display(),chan_freq);
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[33mStopping P25 Recorder Num [" << rec_num << "]\u001b[0m\tTDMA: " << d_phase2_tdma << "\tSlot: " << tdma_slot << "\tHz Error: " << this->get_freq_error();
+    BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[33mStopping P25 Recorder Num [" << rec_num << "]\u001b[0m\tTDMA: " << d_phase2_tdma << "\tSlot: " << tdma_slot << "\tHz Error: " << this->get_freq_error();
 
     state = INACTIVE;
     set_enabled(false);
@@ -319,7 +319,7 @@ bool p25_recorder_impl::start(Call *call) {
     this->call = call;
 
     std::string loghdr = log_header(this->call->get_short_name(),this->call->get_call_num(),this->call->get_talkgroup_display(),chan_freq);
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[32mStarting P25 Recorder Num [" << rec_num << "]\u001b[0m\tTDMA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot() << "\tQPSK: " << qpsk_mod;
+    BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[32mStarting P25 Recorder Num [" << rec_num << "]\u001b[0m\tTDMA: " << call->get_phase2_tdma() << "\tSlot: " << call->get_tdma_slot() << "\tQPSK: " << qpsk_mod;
 
     int offset_amount = (center_freq - chan_freq);
 

--- a/trunk-recorder/recorders/sigmf_recorder_impl.cc
+++ b/trunk-recorder/recorders/sigmf_recorder_impl.cc
@@ -119,7 +119,7 @@ State sigmf_recorder_impl::get_state() {
 void sigmf_recorder_impl::stop() {
   if (state == ACTIVE) {
     std::string loghdr = log_header(this->call->get_short_name(),this->call->get_call_num(),this->call->get_talkgroup_display(),freq);
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[32mStopping SigMF Recorder Num [" << rec_num << "]\u001b[0m";
+    BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[32mStopping SigMF Recorder Num [" << rec_num << "]\u001b[0m";
 
     state = INACTIVE;
     set_enabled(false);
@@ -145,7 +145,7 @@ bool sigmf_recorder_impl::start(Call *call) {
     
     //freq_xlat->set_center_freq(-offset_amount);
     std::string loghdr = log_header(this->call->get_short_name(),this->call->get_call_num(),this->call->get_talkgroup_display(),freq);
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\t\u001b[32mStarting SigMF Recorder Num [" << rec_num << "]\u001b[0m";
+    BOOST_LOG_TRIVIAL(info) << loghdr << "\u001b[32mStarting SigMF Recorder Num [" << rec_num << "]\u001b[0m";
 
     std::stringstream path_stream;
 

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -558,14 +558,14 @@ Recorder *Source::get_analog_recorder(Talkgroup *talkgroup, int priority, Call *
   if (talkgroup && (priority == -1)) {
     call->set_state(MONITORING);
     call->set_monitoring_state(IGNORED_TG);
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\tNot recording talkgroup. Priority is -1.";
+    BOOST_LOG_TRIVIAL(info) << loghdr << "Not recording talkgroup. Priority is -1.";
     return NULL;
   }
 
   if (talkgroup && priority > num_available_recorders) { // a high priority is bad. You need at least the number of availalbe recorders to your priority
     call->set_state(MONITORING);
     call->set_monitoring_state(NO_RECORDER);
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\tNot recording talkgroup. Priority is " << priority << " but only " << num_available_recorders << " recorders are available.";
+    BOOST_LOG_TRIVIAL(error) << loghdr << "Not recording talkgroup. Priority is " << priority << " but only " << num_available_recorders << " recorders are available.";
     return NULL;
   }
 
@@ -584,7 +584,7 @@ Recorder *Source::get_analog_recorder(Call *call) {
     }
   }
   std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-  BOOST_LOG_TRIVIAL(error) << loghdr << "\t[ " << device << " ] No Analog Recorders Available.";
+  BOOST_LOG_TRIVIAL(error) << loghdr << "[ " << device << " ] No Analog Recorders Available.";
   return NULL;
 }
 
@@ -595,14 +595,14 @@ Recorder *Source::get_digital_recorder(Talkgroup *talkgroup, int priority, Call 
   if (talkgroup && (priority == -1)) {
     call->set_state(MONITORING);
     call->set_monitoring_state(IGNORED_TG);
-    BOOST_LOG_TRIVIAL(info) << loghdr << "\tNot recording talkgroup. Priority is -1.";
+    BOOST_LOG_TRIVIAL(info) << loghdr << "Not recording talkgroup. Priority is -1.";
     return NULL;
   }
 
   if (talkgroup && priority > num_available_recorders) { // a high priority is bad. You need at least the number of availalbe recorders to your priority
     call->set_state(MONITORING);
     call->set_monitoring_state(NO_RECORDER);
-    BOOST_LOG_TRIVIAL(error) << loghdr << "\tNot recording talkgroup. Priority is " << priority << " but only " << num_available_recorders << " recorders are available.";
+    BOOST_LOG_TRIVIAL(error) << loghdr << "Not recording talkgroup. Priority is " << priority << " but only " << num_available_recorders << " recorders are available.";
     return NULL;
   }
 
@@ -621,7 +621,7 @@ Recorder *Source::get_digital_recorder(Call *call) {
     }
   }
   std::string loghdr = log_header( call->get_short_name(), call->get_call_num(), call->get_talkgroup_display(), call->get_freq());
-  BOOST_LOG_TRIVIAL(error) << loghdr << "\t[ " << device << " ] No Digital Recorders Available.";
+  BOOST_LOG_TRIVIAL(error) << loghdr << "[ " << device << " ] No Digital Recorders Available.";
 
   for (std::vector<p25_recorder_sptr>::iterator it = digital_recorders.begin();
        it != digital_recorders.end(); it++) {


### PR DESCRIPTION
The `log_header()` formatter currently ends with a cyan ANSI color code, and most uses of the returned string are being double-tabbed in the console output. 

This PR removes the stray cyan code, as well as extra `/t` or whitespace in the boost logging messages.  Additional whitespace adjustments after a formatted header should not be necessary under most circumstances, as it already terminates with a tab in the resulting string.

```
BOOST_LOG_TRIVIAL(info) << loghdr << "Example status message.";
```

The openmhz and broadcastify plugins have been also reverted to utilize the pre-formatted `call_info.talkgroup_display` string that displayed correctly in the logs prior to the update.