### PR TITLE
Avoid loading unused internal plugins

### DIFF
--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -613,10 +613,23 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
     }
 
     BOOST_LOG_TRIVIAL(info) << "\n\n-------------------------------------\nPLUGINS\n-------------------------------------\n";
-    add_internal_plugin("openmhz_uploader", "libopenmhz_uploader.so", data);
-    add_internal_plugin("broadcastify_uploader", "libbroadcastify_uploader.so", data);
-    add_internal_plugin("unit_script", "libunit_script.so", data);
-    add_internal_plugin("stat_socket", "libstat_socket.so", data);
+    // add internal plugins only if mandatory config keys exist in the config file
+    if (config.upload_server != "")
+      add_internal_plugin("openmhz_uploader", "libopenmhz_uploader.so", data);
+    
+    if (config.bcfy_calls_server != "")
+      add_internal_plugin("broadcastify_uploader", "libbroadcastify_uploader.so", data);
+    
+    if (config.status_server != "")
+      add_internal_plugin("stat_socket", "libstat_socket.so", data);
+
+    for (const auto& system : data["systems"]) {
+      if (system.find("unitScript") != system.end()) {
+        add_internal_plugin("unit_script", "libunit_script.so", data);
+        break;
+      }
+    }
+  
     initialize_plugins(data, &config, sources, systems);
   } catch (std::exception const &e) {
     BOOST_LOG_TRIVIAL(error) << "Failed parsing Config: " << e.what();


### PR DESCRIPTION
The four "internal" plugins [`openmhz_uploader`, `broadcastify_uploader`, `stat_socket`, `unit_script`] are always loaded, whether or not the user intends to use them in their trunk-recorder installation.

After the configuration file is parsed, this PR checks if any of the mandatory configuration keys for the above plugins are present before adding them to the load list.  This will reduce unnecessary API calls, and avoid the overhead of loading a plugin in duplicate should the user consolidate the configuration into the "plugins" section as shown in the example below:

```json
    "plugins": [
        {
            "name": "Broadcastify",
            "library": "libbroadcastify_uploader.so",
            "enabled": true,
            "broadcastifyCallsServer": "https://api.broadcastify.com/call-upload",
            "broadcastifySslVerifyDisable": false,
            "systems": [
                {
                    "shortName": "sys1",
                    "broadcastifySystemId": 1234,
                    "broadcastifyApiKey": "api-key-vrry-secret"
                },
                {
                    "shortName": "sys2",
                    "broadcastifySystemId": 1235,
                    "broadcastifyApiKey": "api-key-vrry-secret"
                }
            ]
        }
    ]
```

"Internal" plugins (other than stat_socket) can be loaded in "plugin" section if desired.  Aside from the convenience of managing a plugin's configuration in a single part of the config file, this also allows the user to toggle the `enabled` key to easily enable/disable a plugin as needed.