### PR TITLE
assertion error fixes

### DIFF
--- a/lib/op25_repeater/lib/p25p1_fdma.cc
+++ b/lib/op25_repeater/lib/p25p1_fdma.cc
@@ -584,7 +584,7 @@ namespace gr {
                 blks = deinterleave_buf[0][6] & 0x7f;
 
                 if ((sap == 61) && ((fmt == 0x17) || (fmt == 0x15))) { // Multi Block Trunking messages
-                    if (blks > deinterleave_buf.size())
+                    if ((blks > deinterleave_buf.size()) || (deinterleave_buf.size() == 1))
                         return; // insufficient blocks available
 
                     uint32_t crc1 = crc32(deinterleave_buf[1].data(), ((blks * 12) - 4) * 8);

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -109,6 +109,10 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
   message.tdma_slot = 0;
   message.freq = 0;
   message.opcode = opcode;
+  message.patch_data.sg = -1;
+  message.patch_data.ga1 = -1;
+  message.patch_data.ga2 = -1;
+  message.patch_data.ga3 = -1; 
 
   BOOST_LOG_TRIVIAL(debug) << "decode_mbt_data: $" << opcode;
   if (opcode == 0x0) { // grp voice channel grant
@@ -285,6 +289,10 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
   message.tdma_slot = 0;
   message.freq = 0;
   message.opcode = opcode;
+  message.patch_data.sg = -1;
+  message.patch_data.ga1 = -1;
+  message.patch_data.ga2 = -1;
+  message.patch_data.ga3 = -1; 
 
   BOOST_LOG_TRIVIAL(trace) << "TSBK: opcode: $" << std::hex << opcode;
   if (opcode == 0x00) { // group voice chan grant
@@ -471,7 +479,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       // int priority = bitset_shift_mask(tsbk, 72, 0x07);
 
       unsigned long ch1 = bitset_shift_mask(tsbk, 48, 0xffff);
-      unsigned long ch2 = bitset_shift_mask(tsbk, 32, 0xffff);
+      // unsigned long ch2 = bitset_shift_mask(tsbk, 32, 0xffff);
       unsigned long ga1 = bitset_shift_mask(tsbk, 16, 0xffff);
       unsigned long f1 = channel_id_to_frequency(ch1, sys_num);
       // unsigned long f2 = channel_id_to_frequency(ch2, sys_num);
@@ -483,7 +491,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       message.encrypted = encrypted;
       if (get_tdma_slot(ch1, sys_num) >= 0) {
         message.phase2_tdma = true;
-        message.tdma_slot = get_tdma_slot(ch2, sys_num);
+        message.tdma_slot = get_tdma_slot(ch1, sys_num);
       } else {
         message.phase2_tdma = false;
         message.tdma_slot = 0;

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -109,10 +109,10 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
   message.tdma_slot = 0;
   message.freq = 0;
   message.opcode = opcode;
-  message.patch_data.sg = -1;
-  message.patch_data.ga1 = -1;
-  message.patch_data.ga2 = -1;
-  message.patch_data.ga3 = -1; 
+  message.patch_data.sg = 0;
+  message.patch_data.ga1 = 0;
+  message.patch_data.ga2 = 0;
+  message.patch_data.ga3 = 0; 
 
   BOOST_LOG_TRIVIAL(debug) << "decode_mbt_data: $" << opcode;
   if (opcode == 0x0) { // grp voice channel grant
@@ -289,10 +289,10 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
   message.tdma_slot = 0;
   message.freq = 0;
   message.opcode = opcode;
-  message.patch_data.sg = -1;
-  message.patch_data.ga1 = -1;
-  message.patch_data.ga2 = -1;
-  message.patch_data.ga3 = -1; 
+  message.patch_data.sg = 0;
+  message.patch_data.ga1 = 0;
+  message.patch_data.ga2 = 0;
+  message.patch_data.ga3 = 0; 
 
   BOOST_LOG_TRIVIAL(trace) << "TSBK: opcode: $" << std::hex << opcode;
   if (opcode == 0x00) { // group voice chan grant


### PR DESCRIPTION
1. Minor edit to `p25p1_fdma.cc` to address an issue seen in #950 where a MBT header may have been received without any following blocks.  Previously, this was handled when non-existent data in `deinterleave_buf[1]` did not pass the CRC check, but accessing the second item in a one-item array will trigger an assertion error in the development build.

2. Revert a previous edit in `p25_parser.cc` for `tsbk03` "Explicit Grant Update".  As seen in the [boatbod OP25](https://github.com/boatbod/op25/blob/88498ccf54ff6a3b4885a3420ae58ac8172b3b45/op25/gr-op25_repeater/apps/tk_p25.py#L721) fork, `ch1` should be used.  `ch2` will return a slot id of `-1`, and cause an assertion error when [p25p2_tdma.cc](https://github.com/robotastic/trunk-recorder/blob/346dcff4bf7bc82c7bab3fdbc6c012dce67a04b6/lib/op25_repeater/lib/p25p2_tdma.cc#L133-L137) encounters it later.

3. Also noted in the core dump for the above item, `patch_data` is included in all messages passed by the decoder, but only contains initialized variables when it encounters a patch-related opcode. As those opcodes may not be very frequent, the TrunkMessage.PatchData struct will generally carry random data as the message passes through trunk-recorder.  e.g.:
`patch_data = {sg = 140720929611216, ga1 = 140720929611056, ga2 = 97692074541337, ga3 = 97692100480080}`