### PR TITLE
Control Channel Retune Handling

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -727,6 +727,16 @@ void handle_message(std::vector<TrunkMessage> messages, System *sys) {
       unit_answer_request(sys, message.source, message.talkgroup);
       break;
 
+    case TDU:
+    {
+      //Control Channel may have retuned to an active data channel. Do not count the message.
+      int msg_count = sys->get_message_count();
+      if(msg_count > 1){
+        sys->set_message_count(msg_count - 1);
+      }
+    }
+    break;
+
     case UNKNOWN:
       break;
     }

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -649,6 +649,86 @@ void handle_call_update(TrunkMessage message, System *sys) {
   }
 }
 
+System *find_system(int sys_num) {
+  System *sys_match = NULL;
+
+  for (std::vector<System *>::iterator it = systems.begin(); it != systems.end(); ++it) {
+    System *sys = (System *)*it;
+
+    if (sys->get_sys_num() == sys_num) {
+      sys_match = sys;
+      break;
+    }
+  }
+
+  if (sys_match == NULL) {
+    BOOST_LOG_TRIVIAL(info) << "Sys is null";
+  }
+  return sys_match;
+}
+
+void retune_system(System *sys) {
+  System_impl *system = (System_impl *)sys;
+  bool source_found = false;
+  Source *current_source = system->get_source();
+  double control_channel_freq = system->get_next_control_channel();
+
+  BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "] Retuning to Control Channel: " << format_freq(control_channel_freq);
+
+  if ((current_source->get_min_hz() <= control_channel_freq) &&
+      (current_source->get_max_hz() >= control_channel_freq)) {
+    source_found = true;
+    BOOST_LOG_TRIVIAL(info) << "\t - System Source " << current_source->get_num() << " - Min Freq: " << format_freq(current_source->get_min_hz()) << " Max Freq: " << format_freq(current_source->get_max_hz());
+    // The source can cover the System's control channel, break out of the
+    // For Loop
+    if (system->get_system_type() == "smartnet") {
+      system->smartnet_trunking->tune_freq(control_channel_freq);
+      system->smartnet_trunking->reset();
+    } else if (system->get_system_type() == "p25") {
+      system->p25_trunking->tune_freq(control_channel_freq);
+    } else {
+      BOOST_LOG_TRIVIAL(error) << "\t - Unknown system type for Retune";
+    }
+  } else {
+    for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
+      Source *source = *src_it;
+
+      if ((source->get_min_hz() <= control_channel_freq) &&
+          (source->get_max_hz() >= control_channel_freq)) {
+        source_found = true;
+        BOOST_LOG_TRIVIAL(info) << "\t - System Source " << source->get_num() << " - Min Freq: " << format_freq(source->get_min_hz()) << " Max Freq: " << format_freq(source->get_max_hz());
+
+        if (system->get_system_type() == "smartnet") {
+          system->set_source(source);
+          // We must lock the flow graph in order to disconnect and reconnect blocks
+          tb->lock();
+          tb->disconnect(current_source->get_src_block(), 0, system->smartnet_trunking, 0);
+          system->smartnet_trunking = make_smartnet_trunking(control_channel_freq, source->get_center(), source->get_rate(), system->get_msg_queue(), system->get_sys_num());
+          tb->connect(source->get_src_block(), 0, system->smartnet_trunking, 0);
+          tb->unlock();
+          system->smartnet_trunking->reset();
+        } else if (system->get_system_type() == "p25") {
+          system->set_source(source);
+          // We must lock the flow graph in order to disconnect and reconnect blocks
+          tb->lock();
+          tb->disconnect(current_source->get_src_block(), 0, system->p25_trunking, 0);
+          system->p25_trunking = make_p25_trunking(control_channel_freq, source->get_center(), source->get_rate(), system->get_msg_queue(), system->get_qpsk_mod(), system->get_sys_num());
+          tb->connect(source->get_src_block(), 0, system->p25_trunking, 0);
+          tb->unlock();
+        } else {
+          BOOST_LOG_TRIVIAL(error) << "\t - Unkown system type for Retune";
+        }
+
+        // break out of the For Loop
+        break;
+      }
+    }
+  }
+  if (!source_found) {
+    BOOST_LOG_TRIVIAL(error) << "\t - Unable to retune System control channel, freq not covered by any source.";
+  }
+}
+
 void handle_message(std::vector<TrunkMessage> messages, System *sys) {
   for (std::vector<TrunkMessage>::iterator it = messages.begin(); it != messages.end(); it++) {
     TrunkMessage message = *it;
@@ -728,98 +808,22 @@ void handle_message(std::vector<TrunkMessage> messages, System *sys) {
       break;
 
     case INVALID_CC_MESSAGE:
-    {
-      //Do not count messages that aren't valid TSBK or MBTs.
-      int msg_count = sys->get_message_count();
-      if(msg_count > 1){
-        sys->set_message_count(msg_count - 1);
+      {
+        //Do not count messages that aren't valid TSBK or MBTs.
+        int msg_count = sys->get_message_count();
+        if(msg_count > 1){
+          sys->set_message_count(msg_count - 1);
+        }
       }
-    }
-    break;
+      break;
+
+    case TDULC:
+      retune_system(sys);
+      break;
 
     case UNKNOWN:
       break;
     }
-  }
-}
-
-System *find_system(int sys_num) {
-  System *sys_match = NULL;
-
-  for (std::vector<System *>::iterator it = systems.begin(); it != systems.end(); ++it) {
-    System *sys = (System *)*it;
-
-    if (sys->get_sys_num() == sys_num) {
-      sys_match = sys;
-      break;
-    }
-  }
-
-  if (sys_match == NULL) {
-    BOOST_LOG_TRIVIAL(info) << "Sys is null";
-  }
-  return sys_match;
-}
-
-void retune_system(System *sys) {
-  System_impl *system = (System_impl *)sys;
-  bool source_found = false;
-  Source *current_source = system->get_source();
-  double control_channel_freq = system->get_next_control_channel();
-
-  BOOST_LOG_TRIVIAL(error) << "[" << system->get_short_name() << "] Retuning to Control Channel: " << format_freq(control_channel_freq);
-
-  if ((current_source->get_min_hz() <= control_channel_freq) &&
-      (current_source->get_max_hz() >= control_channel_freq)) {
-    source_found = true;
-    BOOST_LOG_TRIVIAL(info) << "\t - System Source " << current_source->get_num() << " - Min Freq: " << format_freq(current_source->get_min_hz()) << " Max Freq: " << format_freq(current_source->get_max_hz());
-    // The source can cover the System's control channel, break out of the
-    // For Loop
-    if (system->get_system_type() == "smartnet") {
-      system->smartnet_trunking->tune_freq(control_channel_freq);
-      system->smartnet_trunking->reset();
-    } else if (system->get_system_type() == "p25") {
-      system->p25_trunking->tune_freq(control_channel_freq);
-    } else {
-      BOOST_LOG_TRIVIAL(error) << "\t - Unknown system type for Retune";
-    }
-  } else {
-    for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
-      Source *source = *src_it;
-
-      if ((source->get_min_hz() <= control_channel_freq) &&
-          (source->get_max_hz() >= control_channel_freq)) {
-        source_found = true;
-        BOOST_LOG_TRIVIAL(info) << "\t - System Source " << source->get_num() << " - Min Freq: " << format_freq(source->get_min_hz()) << " Max Freq: " << format_freq(source->get_max_hz());
-
-        if (system->get_system_type() == "smartnet") {
-          system->set_source(source);
-          // We must lock the flow graph in order to disconnect and reconnect blocks
-          tb->lock();
-          tb->disconnect(current_source->get_src_block(), 0, system->smartnet_trunking, 0);
-          system->smartnet_trunking = make_smartnet_trunking(control_channel_freq, source->get_center(), source->get_rate(), system->get_msg_queue(), system->get_sys_num());
-          tb->connect(source->get_src_block(), 0, system->smartnet_trunking, 0);
-          tb->unlock();
-          system->smartnet_trunking->reset();
-        } else if (system->get_system_type() == "p25") {
-          system->set_source(source);
-          // We must lock the flow graph in order to disconnect and reconnect blocks
-          tb->lock();
-          tb->disconnect(current_source->get_src_block(), 0, system->p25_trunking, 0);
-          system->p25_trunking = make_p25_trunking(control_channel_freq, source->get_center(), source->get_rate(), system->get_msg_queue(), system->get_qpsk_mod(), system->get_sys_num());
-          tb->connect(source->get_src_block(), 0, system->p25_trunking, 0);
-          tb->unlock();
-        } else {
-          BOOST_LOG_TRIVIAL(error) << "\t - Unkown system type for Retune";
-        }
-
-        // break out of the For Loop
-        break;
-      }
-    }
-  }
-  if (!source_found) {
-    BOOST_LOG_TRIVIAL(error) << "\t - Unable to retune System control channel, freq not covered by any source.";
   }
 }
 

--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -727,9 +727,9 @@ void handle_message(std::vector<TrunkMessage> messages, System *sys) {
       unit_answer_request(sys, message.source, message.talkgroup);
       break;
 
-    case TDU:
+    case INVALID_CC_MESSAGE:
     {
-      //Control Channel may have retuned to an active data channel. Do not count the message.
+      //Do not count messages that aren't valid TSBK or MBTs.
       int msg_count = sys->get_message_count();
       if(msg_count > 1){
         sys->set_message_count(msg_count - 1);

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -1006,6 +1006,11 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
      */
   }
 
+  if (type == 3 || type == 15)
+  {
+    message.message_type = TDU;
+  }
+
   if (type == 7) { // # trunk: TSBK
     boost::dynamic_bitset<> b((s.length() + 2) * 8);
 

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -964,6 +964,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
     return messages;
   } else if (type < 0) {
     BOOST_LOG_TRIVIAL(debug) << "unknown message type " << type;
+    message.message_type = INVALID_CC_MESSAGE;
     messages.push_back(message);
     return messages;
   }
@@ -979,6 +980,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
 
   if (s.length() < 2) {
     BOOST_LOG_TRIVIAL(error) << "P25 Parse error, s: " << s << " s0: " << static_cast<int>(s0) << " s1: " << static_cast<int>(s1) << " shift: " << shift << " nac: " << nac << " type: " << type << " Len: " << s.length();
+    message.message_type = INVALID_CC_MESSAGE;
     messages.push_back(message);
     return messages;
   }
@@ -996,7 +998,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
   if ((type != 7) && (type != 12)) // and nac not in self.trunked_systems:
   {
     BOOST_LOG_TRIVIAL(debug) << std::hex << "NON TBSK: nac " << nac << std::dec << " type " << type << " size " << msg->to_string().length() << " mesg len: " << msg->length();
-  
+    message.message_type = INVALID_CC_MESSAGE;
     /*
        if not self.configs:
      # TODO: allow whitelist/blacklist rather than blind automatic-add
@@ -1004,11 +1006,6 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
        else:
         return
      */
-  }
-
-  if (type == 3 || type == 15)
-  {
-    message.message_type = TDU;
   }
 
   if (type == 7) { // # trunk: TSBK

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -997,8 +997,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
   // //" at %f state %d len %d" %(nac, type, time.time(), self.state, len(s))
   if ((type != 7) && (type != 12)) // and nac not in self.trunked_systems:
   {
-    BOOST_LOG_TRIVIAL(debug) << std::hex << "NON TBSK: nac " << nac << std::dec << " type " << type << " size " << msg->to_string().length() << " mesg len: " << msg->length();
-    message.message_type = INVALID_CC_MESSAGE;
+    BOOST_LOG_TRIVIAL(debug) << std::hex << "NON TSBK: nac " << nac << std::dec << " type " << type << " size " << msg->to_string().length() << " mesg len: " << msg->length();
     /*
        if not self.configs:
      # TODO: allow whitelist/blacklist rather than blind automatic-add
@@ -1073,7 +1072,13 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
     return decode_mbt_data(opcode, header, mbt_data, link_id, nac, sys_num);
     // self.trunked_systems[nac].decode_mbt_data(opcode, header << 16, mbt_data
     // << 32)
+  } else if (type == 15)
+  {
+    //TDU with Link Contol. Link Control words should not be seen on an active Control Channel.
+    BOOST_LOG_TRIVIAL(debug) << "P25 Parser: TDULC on control channel. Retuning to next control channel.";
+    message.message_type = TDULC;
   }
+
   messages.push_back(message);
   return messages;
 }

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -21,6 +21,7 @@ enum MessageType {
   UU_V_GRANT = 14,
   UU_V_UPDATE = 15,
   INVALID_CC_MESSAGE = 16,
+  TDULC = 17,
   UNKNOWN = 99
 };
 

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -20,7 +20,7 @@ enum MessageType {
   UU_ANS_REQ = 13,
   UU_V_GRANT = 14,
   UU_V_UPDATE = 15,
-  TDU = 16,
+  INVALID_CC_MESSAGE = 16,
   UNKNOWN = 99
 };
 

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -20,6 +20,7 @@ enum MessageType {
   UU_ANS_REQ = 13,
   UU_V_GRANT = 14,
   UU_V_UPDATE = 15,
+  TDU = 16,
   UNKNOWN = 99
 };
 


### PR DESCRIPTION
This should help address the issue of the control channel trying to retune to an active traffic channel.

- Adds an INVALID_CC_MESSAGE message type for messages that are not correctly parsed and does not count them for control channel msgs/sec. Note that UNKNOWN messages are still counted in cases of correctly parsed messages with an unknown opcode.

- Adds a TDULC message type when the parser receives a TDU with Link Control on a channel it believes should be a control channel. The specs indicate there should not be Link Control messages on an active control channel, so this immediately causes a retune to the next available control channel.

