### PR TITLE
Improve Control Channel Retune Handling

### DIFF
--- a/trunk-recorder/monitor_systems.h
+++ b/trunk-recorder/monitor_systems.h
@@ -15,4 +15,5 @@
 #include <gnuradio/top_block.h>
 
 int monitor_messages(Config &config, gr::top_block_sptr &tb, std::vector<Source *> &sources, std::vector<System *> &systems, std::vector<Call *> &calls);
+void retune_system(System *sys, gr::top_block_sptr &tb, std::vector<Source *> &sources);
 #endif

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -972,6 +972,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
     return messages;
   } else if (type < 0) {
     BOOST_LOG_TRIVIAL(debug) << "unknown message type " << type;
+    message.message_type = INVALID_CC_MESSAGE;
     messages.push_back(message);
     return messages;
   }
@@ -980,7 +981,8 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
 
  if (s.length() < 2) {
     BOOST_LOG_TRIVIAL(error) << "P25 Parse error, s: " << s << " Len: " << s.length();
-    //messages.push_back(message);
+    message.message_type = INVALID_CC_MESSAGE;
+    messages.push_back(message);
     return messages;
   }
 
@@ -1005,7 +1007,7 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
   // //" at %f state %d len %d" %(nac, type, time.time(), self.state, len(s))
   if ((type != 7) && (type != 12)) // and nac not in self.trunked_systems:
   {
-    BOOST_LOG_TRIVIAL(debug) << std::hex << "NON TBSK: nac " << nac << std::dec << " type " << type << " size " << msg->to_string().length() << " mesg len: " << msg->length();
+    BOOST_LOG_TRIVIAL(debug) << std::hex << "NON TSBK: nac " << nac << std::dec << " type " << type << " size " << msg->to_string().length() << " mesg len: " << msg->length();
   
     /*
        if not self.configs:
@@ -1081,6 +1083,11 @@ std::vector<TrunkMessage> P25Parser::parse_message(gr::message::sptr msg, System
     return decode_mbt_data(opcode, header, mbt_data, link_id, nac, sys_num);
     // self.trunked_systems[nac].decode_mbt_data(opcode, header << 16, mbt_data
     // << 32)
+  } else if (type == 15)
+  {
+    //TDU with Link Contol. Link Control words should not be seen on an active Control Channel.
+    BOOST_LOG_TRIVIAL(debug) << "P25 Parser: TDULC on control channel. Retuning to next control channel.";
+    message.message_type = TDULC;
   }
   messages.push_back(message);
   return messages;

--- a/trunk-recorder/systems/parser.h
+++ b/trunk-recorder/systems/parser.h
@@ -20,6 +20,8 @@ enum MessageType {
   UU_ANS_REQ = 13,
   UU_V_GRANT = 14,
   UU_V_UPDATE = 15,
+  INVALID_CC_MESSAGE = 16,
+  TDULC = 17,
   UNKNOWN = 99
 };
 


### PR DESCRIPTION
Resubmitting this against v5.0

This should help address the issue of the control channel trying to retune to an active traffic channel.

- Adds an INVALID_CC_MESSAGE message type for messages that are not correctly parsed and does not count them for control channel msgs/sec. Note that UNKNOWN messages are still counted in cases of correctly parsed messages with an unknown opcode.

- Adds a TDULC message type when the parser receives a TDU with Link Control on a channel it believes should be a control channel. The specs indicate there should not be Link Control messages on an active control channel, so this immediately causes a retune to the next available control channel.