### PR TITLE
Broadcastify uploader fixes - 5.0

### DIFF
--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -143,10 +143,6 @@ public:
     curl_mime_name(part, "metadata");
 
     part = curl_mime_addpart(mime);
-    curl_mime_data(part, call_info.converted, CURL_ZERO_TERMINATED);
-    curl_mime_name(part, "filename");
-
-    part = curl_mime_addpart(mime);
     curl_mime_data(part, std::to_string(call_info.length).c_str(), CURL_ZERO_TERMINATED);
     curl_mime_name(part, "callDuration");
 

--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -258,14 +258,16 @@ public:
       long response_code;
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
 
+      std::string loghdr = log_header(call_info.short_name,call_info.call_num,call_info.talkgroup_display,call_info.freq);
+
       if (res != CURLM_OK || response_code != 200) {
-        BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Metadata Upload Error: " << response_buffer;
+        BOOST_LOG_TRIVIAL(error) << loghdr << "Broadcastify Metadata Upload Error: " << response_buffer;
         return 1;
       }
 
       std::size_t spacepos = response_buffer.find(' ');
       if (spacepos < 1) {
-        BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Metadata Upload Error: " << response_buffer;
+        BOOST_LOG_TRIVIAL(error) << loghdr << response_buffer;
         return 1;
       }
 
@@ -273,30 +275,31 @@ public:
       std::string message = response_buffer.substr(spacepos + 1);
 
       if (code == "1" && (message.rfind("SKIPPED", 0) == 0)) {
-        BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Upload Skipped: " << message;
+        BOOST_LOG_TRIVIAL(info) << loghdr << "Broadcastify Upload Skipped: " << message;
         return 0;
       }
+      
       if (code == "1" && (message.rfind("REJECTED", 0) == 0)) {
-        BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Upload REJECTED: " << message;
+        BOOST_LOG_TRIVIAL(error) << loghdr << "Broadcastify Upload REJECTED: " << message;
         return 0;
       }
 
       if (code != "0") {
-        BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Metadata Upload Error: " << message;
+        BOOST_LOG_TRIVIAL(error) << loghdr << "Broadcastify Metadata Upload Error: " << message;
         return 1;
       }
 
       CURLcode audio_error = this->upload_audio_file(call_info.converted, message);
 
       if (audio_error) {
-        BOOST_LOG_TRIVIAL(error) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Audio Upload Error: " << curl_easy_strerror(audio_error);
+        BOOST_LOG_TRIVIAL(error) << loghdr << "Broadcastify Audio Upload Error: " << curl_easy_strerror(audio_error);
         return 1;
       }
 
       struct stat file_info;
       stat(call_info.converted, &file_info);
 
-      BOOST_LOG_TRIVIAL(info) << "[" << call_info.short_name << "]\t\033[0;34m" << call_info.call_num << "C\033[0m\tTG: " << call_info.talkgroup_display << "\tFreq: " << format_freq(call_info.freq) << "\tBroadcastify Upload Success - file size: " << file_info.st_size;
+      BOOST_LOG_TRIVIAL(info) << loghdr << "Broadcastify Upload Success - file size: " << file_info.st_size;
       return 0;
     } else {
       return 1;

--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -137,7 +137,8 @@ public:
     mime = curl_mime_init(curl);
 
     part = curl_mime_addpart(mime);
-    curl_mime_filedata(part, call_info.status_filename);
+    curl_mime_data(part, call_info.call_json.dump().c_str(), CURL_ZERO_TERMINATED);
+    curl_mime_filename(part, "call_meta.json");
     curl_mime_type(part, "application/json");
     curl_mime_name(part, "metadata");
 


### PR DESCRIPTION
Three relatively minor edits for the broadcastify plugin in rc/5.0

1. The Broadcastify plugin currently re-reads the call json from disk as part of the initial upload stage.  As of [#927], this disk read is no longer necessary and potentially undesirable now that the json can be directly dumped from from the `Call_Data_t` object into the curl object.  The dumped json is also stripped of whitespace and should be smaller than the formatted file Trunk Recorder generates for human review.
2. The `filename` field does not appear to be in use with the current Broadcastify API.  Additionally, `call_info.converted` provides an _absolute_ filename for the audio, and such uploads may unintentionally transmit details about the host system and/or home directories/usernames that are not required.  Broadcastify appears to ignore this field, and automatically generates filenames for audio as `[SystemId]/[startTime]-[talkgroup].m4a` using details provided during the upload.
3. The plugin does not presently use the `log_header()` formatting function to simplify logging statements.  These have been added where useful.