### PR TITLE
Update frequency table variable names and logging statements.

### DIFF
--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -3,23 +3,23 @@
 
 P25Parser::P25Parser() {}
 
-void P25Parser::add_channel(int chan_id, Channel temp_chan, int sys_num) {
+void P25Parser::add_freq_table(int freq_table_id, Freq_Table temp_table, int sys_num) {
   /*std::cout << "Add  - Channel id " << std::dec << chan_id << " freq " <<
-    temp_chan.frequency << " offset " << temp_chan.offset << " step " <<
-   temp_chan.step << " slots/carrier " << temp_chan.slots_per_carrier  << std::endl;
+    temp_table.frequency << " offset " << temp_table.offset << " step " <<
+   temp_table.step << " slots/carrier " << temp_table.slots_per_carrier  << std::endl;
 */
-  channels[sys_num][chan_id] = temp_chan;
+  freq_tables[sys_num][freq_table_id] = temp_table;
 }
 
 long P25Parser::get_tdma_slot(int chan_id, int sys_num) {
   long channel = chan_id & 0xfff;
 
-  it = channels[sys_num].find((chan_id >> 12) & 0xf);
+  it = freq_tables[sys_num].find((chan_id >> 12) & 0xf);
 
-  if (it != channels[sys_num].end()) {
-    Channel temp_chan = it->second;
+  if (it != freq_tables[sys_num].end()) {
+    Freq_Table temp_table = it->second;
 
-    if (temp_chan.phase2_tdma) {
+    if (temp_table.phase2_tdma) {
       return channel & 1;
     }
   }
@@ -28,11 +28,11 @@ long P25Parser::get_tdma_slot(int chan_id, int sys_num) {
 }
 
 double P25Parser::get_bandwidth(int chan_id, int sys_num) {
-  it = channels[sys_num].find((chan_id >> 12) & 0xf);
+  it = freq_tables[sys_num].find((chan_id >> 12) & 0xf);
 
-  if (it != channels[sys_num].end()) {
-    Channel temp_chan = it->second;
-    return temp_chan.bandwidth;
+  if (it != freq_tables[sys_num].end()) {
+    Freq_Table temp_table = it->second;
+    return temp_table.bandwidth;
   }
 
   return 0;
@@ -42,21 +42,21 @@ double P25Parser::channel_id_to_frequency(int chan_id, int sys_num) {
   // long id      = (chan_id >> 12) & 0xf;
   long channel = chan_id & 0xfff;
 
-  it = channels[sys_num].find((chan_id >> 12) & 0xf);
+  it = freq_tables[sys_num].find((chan_id >> 12) & 0xf);
 
-  if (it != channels[sys_num].end()) {
-    Channel temp_chan = it->second;
+  if (it != freq_tables[sys_num].end()) {
+    Freq_Table temp_table = it->second;
 
-    if (temp_chan.phase2_tdma) {
-      return temp_chan.frequency + temp_chan.step * int(channel / temp_chan.slots_per_carrier);
+    if (temp_table.phase2_tdma) {
+      return temp_table.frequency + temp_table.step * int(channel / temp_table.slots_per_carrier);
     } else {
-      return temp_chan.frequency + temp_chan.step * channel;
+      return temp_table.frequency + temp_table.step * channel;
     }
   }
   return 0;
 }
 
-std::string P25Parser::channel_id_to_string(int chan_id, int sys_num) {
+std::string P25Parser::channel_id_to_freq_string(int chan_id, int sys_num) {
   double f = channel_id_to_frequency(chan_id, sys_num);
 
   if (f == 0) {
@@ -66,6 +66,16 @@ std::string P25Parser::channel_id_to_string(int chan_id, int sys_num) {
     strs << f / 1000000.0;
     return strs.str();
   }
+}
+
+std::string P25Parser::channel_to_string(int chan, int sys_num) {
+
+  long bandplan = (chan >> 12) & 0xf;
+  long channel = chan & 0xfff;
+
+  std::ostringstream strs;
+  strs << std::setfill('0') << std::setw(2) << bandplan << "-" << std::setfill('0') << std::setw(4) << channel;
+  return strs.str();
 }
 
 unsigned long P25Parser::bitset_shift_mask(boost::dynamic_bitset<> &tsbk, int shift, unsigned long long mask) {
@@ -148,7 +158,7 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
       message.tdma_slot = 0;
     }
 
-    os << "mbt00\tChan Grant\tChannel 1 ID: " << std::setw(5) << ch1 << "\tFreq: " << format_freq(f1) <<  "\tChannel 2 ID: " << std::setw(5) << ch2 << "\tFreq: " << format_freq(f2) << "\tga " << std::setw(7) << ga << "\tTDMA " << get_tdma_slot(ch1, sys_num) << "\tsa " << sa << "\tEncrypt " << encrypted << "\tBandwidth: " << get_bandwidth(ch1, sys_num);
+    os << "mbt00\tChan Grant\tChannel 1 ID: " << channel_to_string(ch1, sys_num) << "\tFreq: " << format_freq(f1) <<  "\tChannel 2 ID: " << channel_to_string(ch2, sys_num) << "\tFreq: " << format_freq(f2) << "\tga " << std::setw(7) << ga << "\tTDMA " << get_tdma_slot(ch1, sys_num) << "\tsa " << sa << "\tEncrypt " << encrypted << "\tBandwidth: " << get_bandwidth(ch1, sys_num);
     message.meta = os.str();
     BOOST_LOG_TRIVIAL(debug) << os.str();
   } else if (opcode == 0x02) { // grp regroup voice channel grant
@@ -171,7 +181,7 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
         message.tdma_slot = 0;
       }
 
-      os << "mbt02\tmfid90_grg_cn_grant_exp\tChannel 1 ID: " << std::setw(5) << ch1 << "\tFreq: " << format_freq(f1) <<  "\tChannel 2 ID: " << std::setw(5) << ch2 << "\tFreq: " << format_freq(f2) << "\tsg " << std::setw(7) << sg << "\tTDMA " << get_tdma_slot(ch1, sys_num) << "\tBandwidth: " << get_bandwidth(ch1, sys_num);
+      os << "mbt02\tmfid90_grg_cn_grant_exp\tChannel 1 ID: " << channel_to_string(ch1, sys_num) << "\tFreq: " << format_freq(f1) <<  "\tChannel 2 ID: " << channel_to_string(ch2, sys_num) << "\tFreq: " << format_freq(f2) << "\tsg " << std::setw(7) << sg << "\tTDMA " << get_tdma_slot(ch1, sys_num) << "\tBandwidth: " << get_bandwidth(ch1, sys_num);
       message.meta = os.str();
       BOOST_LOG_TRIVIAL(debug) << os.str();
     }
@@ -200,7 +210,7 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
     message.sys_id = syid;
     message.sys_rfss = rfid;
     message.sys_site_id = stid;
-    os << "mbt3a rfss status: syid: " << syid << " rfid " << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1, sys_num) << ")";
+    os << "mbt3a rfss status: syid: " << syid << " rfid " << rfid << " stid " << stid << " ch1 " << channel_to_string(ch1, sys_num) << "(" << channel_id_to_freq_string(ch1, sys_num) << ")";
     message.meta = os.str();
     BOOST_LOG_TRIVIAL(debug) << os.str();
   } else if (opcode == 0x3b) { // network status
@@ -217,7 +227,7 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
       message.sys_id = syid;
       message.freq = f1;
     }
-    BOOST_LOG_TRIVIAL(debug) << "mbt3b net stat: wacn " << std::dec << wacn << " syid " << syid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1, sys_num) << ") ";
+    BOOST_LOG_TRIVIAL(debug) << "mbt3b net stat: wacn " << std::dec << wacn << " syid " << syid << " ch1 " << channel_to_string(ch1, sys_num) << "(" << channel_id_to_freq_string(ch1, sys_num) << ") ";
   } else if (opcode == 0x3c) { // adjacent status
     unsigned long syid = bitset_shift_mask(header, 48, 0xfff);
     unsigned long rfid = bitset_shift_mask(header, 24, 0xff);
@@ -418,12 +428,12 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
           message.tdma_slot = 0;
         }
 
-        os << "tsbk02\tGrant Update 2nd\tChannel ID: " << std::setw(5) << ch2 << "\tFreq: " << format_freq(f2) << "\tga " << std::setw(7) << ga2 << "\tTDMA " << get_tdma_slot(ch2, sys_num) << " | ";
+        os << "tsbk02\tGrant Update 2nd\tChannel ID: " << channel_to_string(ch2, sys_num) << "\tFreq: " << format_freq(f2) << "\tga " << std::setw(7) << ga2 << "\tTDMA " << get_tdma_slot(ch2, sys_num) << " | ";
 
         message.meta = os.str();
         
       }
-      os << "tsbk02\tGrant Update\tChannel ID: " << std::setw(5) << ch1 << "\tFreq: " << format_freq(f1) << "\tga " << std::setw(7) << ga1 << "\tTDMA " << get_tdma_slot(ch1, sys_num);
+      os << "tsbk02\tGrant Update\tChannel ID: " << channel_to_string(ch1, sys_num) << "\tFreq: " << format_freq(f1) << "\tga " << std::setw(7) << ga1 << "\tTDMA " << get_tdma_slot(ch1, sys_num);
       message.meta = os.str();
       BOOST_LOG_TRIVIAL(debug) << os.str();
     }
@@ -464,11 +474,11 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
           message.phase2_tdma = false;
           message.tdma_slot = 0;
         }
-        os << "MOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT_UPDATE(0x03): \tChannel ID: " << std::setw(5) << ch2 << "\tFreq: " << format_freq(f2) << "\tsg " << std::setw(7) << sg2 << "\tTDMA " << get_tdma_slot(ch2, sys_num);
+        os << "MOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT_UPDATE(0x03): \tChannel ID: " << channel_to_string(ch2, sys_num) << "\tFreq: " << format_freq(f2) << "\tsg " << std::setw(7) << sg2 << "\tTDMA " << get_tdma_slot(ch2, sys_num);
         message.meta = os.str();
         BOOST_LOG_TRIVIAL(debug) << os.str();
       }
-      os << "MOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT_UPDATE(0x03): \tChannel ID: " << std::setw(5) << ch1 << "\tFreq: " << format_freq(f1) << "\tsg " << std::setw(7) << sg1 << "\tTDMA " << get_tdma_slot(ch1, sys_num);
+      os << "MOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT_UPDATE(0x03): \tChannel ID: " << channel_to_string(ch1, sys_num) << "\tFreq: " << format_freq(f1) << "\tsg " << std::setw(7) << sg1 << "\tTDMA " << get_tdma_slot(ch1, sys_num);
       message.meta = os.str();
       BOOST_LOG_TRIVIAL(debug) << os.str();
     } else {
@@ -497,7 +507,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
         message.tdma_slot = 0;
       }
 
-      os << "tsbk03\tExplicit Grant Update\tTX Channel ID: " << std::setw(5) << ch1 << "\tFreq: " << format_freq(f1) << "\tFNE TX Channel ID: " << std::setw(5) << ch1 << "\tFreq: " << format_freq(f1) << "\tga " << std::setw(7) << ga1 << "\tTDMA " << get_tdma_slot(ch1, sys_num);
+      os << "tsbk03\tExplicit Grant Update\tTX Channel ID: " << channel_to_string(ch1, sys_num) << "\tFreq: " << format_freq(f1) << "\tFNE TX Channel ID: " << channel_to_string(ch1, sys_num) << "\tFreq: " << format_freq(f1) << "\tga " << std::setw(7) << ga1 << "\tTDMA " << get_tdma_slot(ch1, sys_num);
       message.meta = os.str();
       BOOST_LOG_TRIVIAL(debug) << os.str();
     }
@@ -663,7 +673,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
 
       // message.sys_id = syid;
     }
-    os << "tsbk29 secondary cc: rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1, sys_num) << ") ch2 " << ch2 << "(" << channel_id_to_string(ch2, sys_num) << ") ";
+    os << "tsbk29 secondary cc: rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_freq_string(ch1, sys_num) << ") ch2 " << channel_to_string(ch2, sys_num) << "(" << channel_id_to_freq_string(ch2, sys_num) << ") ";
 
     message.meta = os.str();
     BOOST_LOG_TRIVIAL(debug) << os.str();
@@ -786,7 +796,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       } else {
         chan_tdma = false;
       }
-      Channel temp_chan = {
+      Freq_Table temp_table = {
           iden,              // id;
           toff * spac * 125, // offset;
           spac * 125,        // step;
@@ -794,8 +804,8 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
           chan_tdma,
           slots_per_carrier[channel_type], // tdma;
           6.25};
-      add_channel(iden, temp_chan, sys_num);
-      BOOST_LOG_TRIVIAL(debug) << "tsbk33 iden up tdma id " << std::dec << iden << " f " << temp_chan.frequency << " offset " << temp_chan.offset << " spacing " << temp_chan.step << " slots/carrier " << temp_chan.slots_per_carrier;
+      add_freq_table(iden, temp_table, sys_num);
+      BOOST_LOG_TRIVIAL(debug) << "tsbk33 iden up tdma id " << std::dec << iden << " f " << temp_table.frequency << " offset " << temp_table.offset << " spacing " << temp_table.step << " slots/carrier " << temp_table.slots_per_carrier;
     }
   } else if (opcode == 0x34) { // iden_up vhf uhf
     unsigned long iden = bitset_shift_mask(tsbk, 76, 0xf);
@@ -817,7 +827,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       toff = 0 - toff;
     }
     std::string txt[] = {"mob Tx-", "mob Tx+"};
-    Channel temp_chan = {
+    Freq_Table temp_table = {
         iden,              // id;
         toff * spac * 125, // offset;
         spac * 125,        // step;
@@ -825,7 +835,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
         false,             // tdma;
         0,                 // slots
         bandwidth};
-    add_channel(iden, temp_chan, sys_num);
+    add_freq_table(iden, temp_table, sys_num);
 
     BOOST_LOG_TRIVIAL(debug) << "tsbk34 iden vhf/uhf id " << std::dec << iden << " toff " << toff * spac * 0.125 * 1e-3 << " spac " << spac * 0.125 << " freq " << freq * 0.000005 << " [ " << txt[toff_sign] << "]";
   } else if (opcode == 0x35) { // Time and Date Announcement
@@ -855,7 +865,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
 
       // message.sys_id = syid;
     }
-    os << "tsbk39 secondary cc: rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1, sys_num) << ") ch2 " << ch2 << "(" << channel_id_to_string(ch2, sys_num) << ") ";
+    os << "tsbk39 secondary cc: rfid " << std::dec << rfid << " stid " << stid << " ch1 " << channel_to_string(ch1, sys_num) << "(" << channel_id_to_freq_string(ch1, sys_num) << ") ch2 " << channel_to_string(ch2, sys_num) << "(" << channel_id_to_freq_string(ch2, sys_num) << ") ";
     message.meta = os.str();
     BOOST_LOG_TRIVIAL(debug) << os.str();
   } else if (opcode == 0x3a) { // rfss status
@@ -867,7 +877,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
     message.sys_id = syid;
     message.sys_rfss = rfid;
     message.sys_site_id = stid;
-    os << "tsbk3a rfss status: syid: " << syid << " rfid " << rfid << " stid " << stid << " ch1 " << chan << "(" << channel_id_to_string(chan, sys_num) << ")";
+    os << "tsbk3a rfss status: syid: " << syid << " rfid " << rfid << " stid " << stid << " ch1 " << channel_to_string(chan, sys_num) << "(" << channel_id_to_freq_string(chan, sys_num) << ")";
     message.meta = os.str();
     BOOST_LOG_TRIVIAL(debug) << os.str();
   } else if (opcode == 0x3b) { // network status
@@ -882,24 +892,24 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       message.sys_id = syid;
       message.freq = f1;
     }
-    BOOST_LOG_TRIVIAL(debug) << "tsbk3b net stat: wacn " << std::dec << wacn << " syid " << syid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1, sys_num) << ") ";
+    BOOST_LOG_TRIVIAL(debug) << "tsbk3b net stat: wacn " << std::dec << wacn << " syid " << syid << " ch1 " << channel_to_string(ch1, sys_num) << "(" << channel_id_to_freq_string(ch1, sys_num) << ") ";
   } else if (opcode == 0x3c) { // adjacent status
     unsigned long rfid = bitset_shift_mask(tsbk, 48, 0xff);
     unsigned long stid = bitset_shift_mask(tsbk, 40, 0xff);
     unsigned long ch1 = bitset_shift_mask(tsbk, 24, 0xffff);
     unsigned long f1 = channel_id_to_frequency(ch1, sys_num);
-    BOOST_LOG_TRIVIAL(debug) << "tsbk3c\tAdjacent Status\t rfid " << std::dec << rfid << " stid " << stid << " ch1 " << ch1 << "(" << channel_id_to_string(ch1, sys_num) << ") ";
+    BOOST_LOG_TRIVIAL(debug) << "tsbk3c\tAdjacent Status\t rfid " << std::dec << rfid << " stid " << stid << " ch1 " << channel_to_string(ch1, sys_num) << "(" << channel_id_to_freq_string(ch1, sys_num) << ") ";
 
     if (f1) {
-      it = channels[stid].find((ch1 >> 12) & 0xf);
+      it = freq_tables[stid].find((ch1 >> 12) & 0xf);
 
-      if (it != channels[stid].end()) {
-        Channel temp_chan = it->second;
+      if (it != freq_tables[stid].end()) {
+        Freq_Table temp_table = it->second;
 
         //			self.adjacent[f1] = 'rfid: %d stid:%d uplink:%f
         // tbl:%d' % (rfid, stid, (f1 + self.freq_table[table]['offset']) /
         // 1000000.0, table)
-        BOOST_LOG_TRIVIAL(debug) << "\ttsbk3c Chan " << temp_chan.frequency << "  " << temp_chan.step;
+        BOOST_LOG_TRIVIAL(debug) << "\ttsbk3c Chan " << temp_table.frequency << "  " << temp_table.step;
       }
     }
   } else if (opcode == 0x3d) { // iden_up
@@ -915,7 +925,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       toff = 0 - toff;
     }
 
-    Channel temp_chan = {
+    Freq_Table temp_table = {
         iden,          // id;
         toff * 250000, // offset;
         spac * 125,    // step;
@@ -923,7 +933,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
         false,         // tdma;
         1,             // slots
         bw * .125};
-    add_channel(iden, temp_chan, sys_num);
+    add_freq_table(iden, temp_table, sys_num);
     BOOST_LOG_TRIVIAL(debug) << "tsbk3d iden id " << std::dec << iden << " toff " << toff * 0.25 << " spac " << spac * 0.125 << " freq " << freq * 0.000005;
   } else {
     BOOST_LOG_TRIVIAL(debug) << "tsbk other " << std::hex << opcode;

--- a/trunk-recorder/systems/p25_parser.cc
+++ b/trunk-recorder/systems/p25_parser.cc
@@ -265,7 +265,7 @@ std::vector<TrunkMessage> P25Parser::decode_mbt_data(unsigned long opcode, boost
       message.tdma_slot = 0;
     }
 
-    BOOST_LOG_TRIVIAL(debug) << "mbt04\tUnit to Unit Chan Grant\tChannel ID: " << std::setw(5) << ch << "\tFreq: " << format_freq(f) << "\tTarget ID: " << std::setw(7) << ta << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tSource ID: " << sa;
+    BOOST_LOG_TRIVIAL(debug) << "mbt04\tUnit to Unit Chan Grant\tChannel ID: " << channel_to_string(ch, sys_num) << "\tFreq: " << format_freq(f) << "\tTarget ID: " << std::setw(7) << ta << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tSource ID: " << sa;
   } else {
     BOOST_LOG_TRIVIAL(debug) << "mbt other: " << opcode;
     return messages;
@@ -351,7 +351,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
         message.phase2_tdma = false;
         message.tdma_slot = 0;
       }
-      os << "tsbk00\tChan Grant\tChannel ID: " << std::setw(5) << ch << "\tFreq: " << format_freq(f1) << "\tga " << std::setw(7) << ga << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tsa " << sa << "\tEncrypt " << encrypted << "\tBandwidth: " << get_bandwidth(ch, sys_num);
+      os << "tsbk00\tChan Grant\tChannel ID: " << channel_to_string(ch, sys_num) << "\tFreq: " << format_freq(f1) << "\tga " << std::setw(7) << ga << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tsa " << sa << "\tEncrypt " << encrypted << "\tBandwidth: " << get_bandwidth(ch, sys_num);
       message.meta = os.str();
       BOOST_LOG_TRIVIAL(debug) << os.str();
     }
@@ -392,7 +392,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
         message.tdma_slot = 0;
       }
 
-      os << "tsbk02\tMOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT\tChannel ID: " << std::setw(5) << ch << "\tFreq: " << format_freq(f) << "\tsg " << std::setw(7) << sg << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tsa " << sa;
+      os << "tsbk02\tMOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT\tChannel ID: " << channel_to_string(ch, sys_num) << "\tFreq: " << format_freq(f) << "\tsg " << std::setw(7) << sg << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tsa " << sa;
       message.meta = os.str();
       BOOST_LOG_TRIVIAL(debug) << os.str();
     } else {
@@ -541,7 +541,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       message.tdma_slot = 0;
     }
 
-    BOOST_LOG_TRIVIAL(debug) << "tsbk04\tUnit to Unit Chan Grant\tChannel ID: " << std::setw(5) << ch << "\tFreq: " << format_freq(f) << "\tTarget ID: " << std::setw(7) << ta << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tSource ID: " << sa;
+    BOOST_LOG_TRIVIAL(debug) << "tsbk04\tUnit to Unit Chan Grant\tChannel ID: " << channel_to_string(ch, sys_num) << "\tFreq: " << format_freq(f) << "\tTarget ID: " << std::setw(7) << ta << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tSource ID: " << sa;
   } else if (opcode == 0x05) { // Unit To Unit Answer Request
     bool emergency = (bool)bitset_shift_mask(tsbk, 72, 0x80);
     bool encrypted = (bool)bitset_shift_mask(tsbk, 72, 0x40);
@@ -583,7 +583,7 @@ std::vector<TrunkMessage> P25Parser::decode_tsbk(boost::dynamic_bitset<> &tsbk, 
       message.tdma_slot = 0;
     }
 
-    BOOST_LOG_TRIVIAL(debug) << "tsbk06\tUnit to Unit Chan Update\tChannel ID: " << std::setw(5) << ch << "\tFreq: " << format_freq(f) << "\tTarget ID: " << std::setw(7) << ta << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tSource ID: " << sa;
+    BOOST_LOG_TRIVIAL(debug) << "tsbk06\tUnit to Unit Chan Update\tChannel ID: " << channel_to_string(ch, sys_num) << "\tFreq: " << format_freq(f) << "\tTarget ID: " << std::setw(7) << ta << "\tTDMA " << get_tdma_slot(ch, sys_num) << "\tSource ID: " << sa;
   } else if (opcode == 0x08) {
     BOOST_LOG_TRIVIAL(debug) << "tsbk08: Telephone Interconnect Voice Channel Grant";
   } else if (opcode == 0x09) {

--- a/trunk-recorder/systems/p25_parser.h
+++ b/trunk-recorder/systems/p25_parser.h
@@ -12,7 +12,7 @@
 #include <map>
 #include <vector>
 
-struct Channel {
+struct Freq_Table {
   unsigned long id;
   long offset;
   unsigned long step;
@@ -23,8 +23,8 @@ struct Channel {
 };
 
 class P25Parser : public TrunkParser {
-  std::map<int, std::map<int, Channel>> channels;
-  std::map<int, Channel>::iterator it;
+  std::map<int, std::map<int, Freq_Table>> freq_tables;
+  std::map<int, Freq_Table>::iterator it;
 
 public:
   P25Parser();
@@ -34,10 +34,11 @@ public:
   std::vector<TrunkMessage> decode_tsbk(boost::dynamic_bitset<> &tsbk, unsigned long nac, int sys_num);
   unsigned long bitset_shift_mask(boost::dynamic_bitset<> &tsbk, int shift, unsigned long long mask);
   unsigned long bitset_shift_left_mask(boost::dynamic_bitset<> &tsbk, int shift, unsigned long long mask);
-  std::string channel_id_to_string(int chan_id, int sys_num);
+  std::string channel_id_to_freq_string(int chan_id, int sys_num);
   void print_bitset(boost::dynamic_bitset<> &tsbk);
-  void add_channel(int chan_id, Channel chan, int sys_num);
+  void add_freq_table(int freq_table_id, Freq_Table table, int sys_num);
   double channel_id_to_frequency(int chan_id, int sys_num);
+  std::string channel_to_string(int chan, int sys_num);
   std::vector<TrunkMessage> parse_message(gr::message::sptr msg, System *system);
 };
 


### PR DESCRIPTION
This helps clean up some of the P25 frequency table (Bandplan) information variable names and logging statements.

1. Renames `Channels` to `Freq_Tables` to align with OP25. https://github.com/boatbod/op25/blob/883c569c040cdfade78fda245929e2e9eba6df2a/op25/gr-op25_repeater/apps/tk_p25.py#L355-L373
2. Renames `channel_id_to_string` function to `channel_id_to_freq_string` to help clarify what is being returned.
3. Adds a `channel_to_string` function that prints out the channels in the format of `<XX>-<YYYY>` where XX is the bandplan ID and YYYY is the channel ID. 

Following this PR, I plan to add a second PR to expand and add the ability to input custom frequency tables for systems that aren't correctly sending them over the control channel. 