### PR TITLE
Update frequency table variable names and logging statements.

### DIFF
--- a/trunk-recorder/systems/p25_parser.h
+++ b/trunk-recorder/systems/p25_parser.h
@@ -12,7 +12,7 @@
 #include <map>
 #include <vector>
 
-struct Channel {
+struct Freq_Table {
   unsigned long id;
   long offset;
   unsigned long step;
@@ -23,8 +23,8 @@ struct Channel {
 };
 
 class P25Parser : public TrunkParser {
-  std::map<int, std::map<int, Channel>> channels;
-  std::map<int, Channel>::iterator it;
+  std::map<int, std::map<int, Freq_Table>> freq_tables;
+  std::map<int, Freq_Table>::iterator it;
 
 public:
   P25Parser();
@@ -34,10 +34,11 @@ public:
   std::vector<TrunkMessage> decode_tsbk(boost::dynamic_bitset<> &tsbk, unsigned long nac, int sys_num);
   unsigned long bitset_shift_mask(boost::dynamic_bitset<> &tsbk, int shift, unsigned long long mask);
   unsigned long bitset_shift_left_mask(boost::dynamic_bitset<> &tsbk, int shift, unsigned long long mask);
-  std::string channel_id_to_string(int chan_id, int sys_num);
+  std::string channel_id_to_freq_string(int chan_id, int sys_num);
   void print_bitset(boost::dynamic_bitset<> &tsbk);
-  void add_channel(int chan_id, Channel chan, int sys_num);
+  void add_freq_table(int freq_table_id, Freq_Table table, int sys_num);
   double channel_id_to_frequency(int chan_id, int sys_num);
+  std::string channel_to_string(int chan, int sys_num);
   std::vector<TrunkMessage> parse_message(gr::message::sptr msg, System *system);
 };
 


### PR DESCRIPTION
Resubmitting against the master branch.

This helps clean up some of the P25 frequency table (Bandplan) information variable names and logging statements.

1. Renames Channels to Freq_Tables to align with OP25. https://github.com/boatbod/op25/blob/883c569c040cdfade78fda245929e2e9eba6df2a/op25/gr-op25_repeater/apps/tk_p25.py#L355-L373
2. Renames `channel_id_to_string` function to `channel_id_to_freq_string` to help clarify what is being returned.
3. Adds a `channel_to_string` function that prints out the channels in the format of `<XX>-<YYYY>` where XX is the bandplan ID and YYYY is the channel ID.

Following this PR, I plan to add a second PR to expand and add the ability to input custom frequency tables for systems that aren't correctly sending them over the control channel.