### PR TITLE
Hostname resolution cache for upload plugins

### DIFF
--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -21,10 +21,14 @@ struct Broadcastify_Uploader_Data {
   bool ssl_verify_disable;
 };
 
+boost::mutex curl_share_mutex;
+
 class Broadcastify_Uploader : public Plugin_Api {
   // float aggr_;
   // my_plugin_aggregator() : aggr_(0) {}
   Broadcastify_Uploader_Data data;
+  CURLSH *curl_share;
+  long curl_dns_ttl;
 
 public:
   std::string get_api_key(std::string short_name) {
@@ -101,6 +105,9 @@ public:
 
       curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
+      curl_easy_setopt(curl, CURLOPT_SHARE, curl_share); 
+      curl_easy_setopt(curl, CURLOPT_DNS_CACHE_TIMEOUT, curl_dns_ttl);
+
       /* Perform the request, res will get the return code */
       res = curl_easy_perform(curl);
 
@@ -168,6 +175,9 @@ public:
 
       curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_buffer);
+
+      curl_easy_setopt(curl, CURLOPT_SHARE, curl_share); 
+      curl_easy_setopt(curl, CURLOPT_DNS_CACHE_TIMEOUT, curl_dns_ttl);
 
       // broadcastify seems to make a habit out of letting their ssl certs expire
       if (this->data.ssl_verify_disable) {
@@ -356,7 +366,23 @@ public:
       return 1;
     }
 
+    // Initialize shared curl cache to reduce DNS lookups (5 min TTL)
+    curl_share = curl_share_init();
+    curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+    curl_share_setopt(curl_share, CURLSHOPT_LOCKFUNC, curl_lock_cb);
+    curl_share_setopt(curl_share, CURLSHOPT_UNLOCKFUNC, curl_unlock_cb);
+    curl_dns_ttl = 300;
+
     return 0;
+  }
+
+  // curl callbacks
+  static void curl_lock_cb(CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr) {
+    curl_share_mutex.lock();
+  }
+
+  static void curl_unlock_cb(CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr) {
+    curl_share_mutex.unlock();
   }
 
   /*

--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -25,8 +25,12 @@ struct Rdio_Scanner_Uploader_Data {
   std::string server;
 };
 
+boost::mutex curl_share_mutex;
+
 class Rdio_Scanner_Uploader : public Plugin_Api {
   Rdio_Scanner_Uploader_Data data;
+  CURLSH *curl_share;
+  long curl_dns_ttl;
 
 public:
   Rdio_Scanner_System *get_system(std::string short_name) {
@@ -244,6 +248,9 @@ public:
       curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_buffer);
 
+      curl_easy_setopt(curl, CURLOPT_SHARE, curl_share); 
+      curl_easy_setopt(curl, CURLOPT_DNS_CACHE_TIMEOUT, curl_dns_ttl);
+
       curl_multi_add_handle(multi_handle, curl);
 
       curl_multi_perform(multi_handle, &still_running);
@@ -395,7 +402,23 @@ public:
       return 1;
     }
 
+    // Initialize shared curl cache to reduce DNS lookups (5 min TTL)
+    curl_share = curl_share_init();
+    curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+    curl_share_setopt(curl_share, CURLSHOPT_LOCKFUNC, curl_lock_cb);
+    curl_share_setopt(curl_share, CURLSHOPT_UNLOCKFUNC, curl_unlock_cb);
+    curl_dns_ttl = 300;
+
     return 0;
+  }
+
+  // curl callbacks
+  static void curl_lock_cb(CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr) {
+    curl_share_mutex.lock();
+  }
+
+  static void curl_unlock_cb(CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr) {
+    curl_share_mutex.unlock();
   }
 
   /*


### PR DESCRIPTION
The curl library does not utilize the host's DNS cache, and relies on [an internal mechanism](https://curl.se/libcurl/c/CURLOPT_DNS_CACHE_TIMEOUT.html) to determine when to resolve a hostname query.

However, the curl _easy handles_ and _multi handles_ found in uploader plugins are not reused, nor do they exist long enough to benefit from this internal mechanism.  Every curl-based upload currently must start with a DNS lookup, no matter how recently the last one occurred.  Trunk Recorder users with a home DNS server likely noticed that the top domains may be `api.openmhz.com` or `api.broadcastify.com` by _**several orders of magnitude**_.

This patch implements a [shared curl cache](https://curl.se/libcurl/c/CURLSHOPT_SHARE.html) within each of the three main uploaders (OpenMHz, Broadcastify, Rdio Scanner).  These resolved hostnames will persist between uploads, and use a standard 300 second TTL to determine when to refresh the address.

The result of implementing this could reduce *millions* of unnecessary DNS lookups, and speed up uploads ~100 ms by maintaining a per-plugin hostname cache.