### PR TITLE
Configurable de-emphasis time constant for analog recorders

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -253,6 +253,7 @@ There is a list of available Plugins [here](./Plugins.md).
 | decodeFSync            |          | false                      | **true** / **false**                                                         | *Conventional systems only* enable the Fleet Sync signaling decoder. |
 | decodeStar             |          | false                      | **true** / **false**                                                         | *Conventional systems only* enable the Star signaling decoder. |
 | decodeTPS              |          | false                      | **true** / **false**                                                         | *Conventional systems only* enable the Motorola Tactical Public Safety (aka FDNY Fireground) signaling decoder. |
+| deemphasisTau              |          | 0.000750                      | number                                                        | *Conventional systems only* configure the de-emphasis time constant. 750µs for NFM (default), 75µs for WFM North America, 50µs for WFM most other regions.   |
 | enabled                |          | true                       | **true** / **false**                                                         | control whether a configured system is enabled or disabled                 |
 
 ***

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -303,7 +303,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         double digital_levels = element.value("digitalLevels", 1.0);
         double analog_levels = element.value("analogLevels", 8.0);
         double squelch_db = element.value("squelch", -160.0);
-        float tau = element.value("deemphasisTau", 0.000075);  // Default to 75us if not specified
+        float tau = element.value("deemphasisTau", 0.000750);  // Default to 750us if not specified
         int max_dev = element.value("maxDev", 5000);
         double filter_width = element.value("filterWidth", 1.0);
         bool conversation_mode = element.value("conversationMode", true);

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -303,6 +303,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         double digital_levels = element.value("digitalLevels", 1.0);
         double analog_levels = element.value("analogLevels", 8.0);
         double squelch_db = element.value("squelch", -160.0);
+        float tau = element.value("deemphasisTau", 0.000075);  // Default to 75us if not specified
         int max_dev = element.value("maxDev", 5000);
         double filter_width = element.value("filterWidth", 1.0);
         bool conversation_mode = element.value("conversationMode", true);
@@ -325,7 +326,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
           BOOST_LOG_TRIVIAL(info) << "Modulation: qpsk";
           qpsk_mod = true;
         }
-
+        system->set_tau(tau);
         system->set_squelch_db(squelch_db);
         system->set_analog_levels(analog_levels);
         system->set_digital_levels(digital_levels);
@@ -337,6 +338,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         BOOST_LOG_TRIVIAL(info) << "Analog Recorder Maximum Deviation: " << element.value("maxDev", 4000);
         BOOST_LOG_TRIVIAL(info) << "Filter Width: " << filter_width;
         BOOST_LOG_TRIVIAL(info) << "Squelch: " << element.value("squelch", -160);
+        BOOST_LOG_TRIVIAL(info) << "De-emphasis Tau: " << tau;
         system->set_api_key(element.value("apiKey", ""));
         BOOST_LOG_TRIVIAL(info) << "API Key: " << system->get_api_key();
         system->set_bcfy_api_key(element.value("broadcastifyApiKey", ""));

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -38,11 +38,11 @@ std::vector<float> design_filter(double interpolation, double deci) {
 }
 
 analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type) {
-  return gnuradio::get_initial_sptr(new analog_recorder(src, system, type, -1));
+  return gnuradio::get_initial_sptr(new analog_recorder(src, static_cast<System*>(nullptr), type, -1));
 }
 
 analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq) {
-  return gnuradio::get_initial_sptr(new analog_recorder(src, system, type, tone_freq));
+  return gnuradio::get_initial_sptr(new analog_recorder(src, static_cast<System*>(nullptr), type, tone_freq));
 }
 
 void analog_recorder::set_tau(float tau) {

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -37,12 +37,12 @@ std::vector<float> design_filter(double interpolation, double deci) {
   return result;
 }
 
-analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type) {
-  return gnuradio::get_initial_sptr(new analog_recorder(src, type, -1));
+analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type) {
+  return gnuradio::get_initial_sptr(new analog_recorder(src, system, type, -1));
 }
 
-analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq) {
-  return gnuradio::get_initial_sptr(new analog_recorder(src, type, tone_freq));
+analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq) {
+  return gnuradio::get_initial_sptr(new analog_recorder(src, system, type, tone_freq));
 }
 
 void analog_recorder::set_tau(float tau) {
@@ -91,7 +91,7 @@ analog_recorder::analog_recorder(Source *src, System *system, Recorder_Type type
   // int nchars;
 
   source = src;
-  this.system = system;
+  this->system = system;
   chan_freq = source->get_center();
   center_freq = source->get_center();
   config = source->get_config();

--- a/trunk-recorder/recorders/analog_recorder.cc
+++ b/trunk-recorder/recorders/analog_recorder.cc
@@ -37,11 +37,11 @@ std::vector<float> design_filter(double interpolation, double deci) {
   return result;
 }
 
-analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type) {
+analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type) {
   return gnuradio::get_initial_sptr(new analog_recorder(src, system, type, -1));
 }
 
-analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq) {
+analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq) {
   return gnuradio::get_initial_sptr(new analog_recorder(src, system, type, tone_freq));
 }
 
@@ -154,7 +154,7 @@ analog_recorder::analog_recorder(Source *src, System *system, Recorder_Type type
   converter = gr::blocks::float_to_short::make(1, 32767);
 
   /* de-emphasis */
-  d_tau = system->get_tau(); //updated to pull from config
+  d_tau = (system != nullptr) ? system->get_tau() : 0.000075f;  // Default to 75us if system is not provided
   d_fftaps.resize(2);
   d_fbtaps.resize(2);
   calculate_iir_taps(d_tau);

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -68,11 +68,11 @@ int plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalTy
 analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
 analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq);
 class analog_recorder : public gr::hier_block2, public Recorder {
-  friend analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
-  friend analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq);
+  friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type);
+  friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);
 
 protected:
-  analog_recorder(Source *src, Recorder_Type type, float tone_freq);
+  analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);
 
 public:
   ~analog_recorder();
@@ -105,6 +105,8 @@ public:
   void plugin_callback_handler(int16_t *samples, int sampleCount);
   double get_output_sample_rate();
   double since_last_write();
+  void set_tau(float tau);
+  float get_tau() const;
 
 private:
   double center_freq, chan_freq;
@@ -130,12 +132,13 @@ private:
   /* De-emph IIR filter taps */
   std::vector<double> d_fftaps; /*! Feed forward taps. */
   std::vector<double> d_fbtaps; /*! Feed back taps. */
-  double d_tau;                 /*! De-emphasis time constant. */
+  float d_tau;                 /*! De-emphasis time constant. */
 
   Call *call;
   Config *config;
   Source *source;
-  void calculate_iir_taps(double tau);
+  System *system;
+  void calculate_iir_taps(float tau);
 
   /* GR blocks */
   // channelizer::sptr prefilter;

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -68,8 +68,8 @@ int plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalTy
 analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
 analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq);
 class analog_recorder : public gr::hier_block2, public Recorder {
-  friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type);
-  friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);
+  friend analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
+  friend analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq);
 
 protected:
   analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -65,8 +65,8 @@ typedef std::shared_ptr<analog_recorder> analog_recorder_sptr;
 
 int plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
 
-analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type);
-analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);
+analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
+analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq);
 class analog_recorder : public gr::hier_block2, public Recorder {
   friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type);
   friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);

--- a/trunk-recorder/recorders/analog_recorder.h
+++ b/trunk-recorder/recorders/analog_recorder.h
@@ -65,8 +65,8 @@ typedef std::shared_ptr<analog_recorder> analog_recorder_sptr;
 
 int plugman_signal(long unitId, const char *signaling_type, gr::blocks::SignalType sig_type, Call *call, System *system, Recorder *recorder);
 
-analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type);
-analog_recorder_sptr make_analog_recorder(Source *src, Recorder_Type type, float tone_freq);
+analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type);
+analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);
 class analog_recorder : public gr::hier_block2, public Recorder {
   friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type);
   friend analog_recorder_sptr make_analog_recorder(Source *src, System *system, Recorder_Type type, float tone_freq);

--- a/trunk-recorder/setup_systems.cc
+++ b/trunk-recorder/setup_systems.cc
@@ -42,6 +42,7 @@ bool setup_conventional_channel(System *system, double frequency, long channel_i
           rec = source->create_conventional_recorder(tb);
         }
         rec->start(call);
+        rec->set_tau(system->get_tau()); //set the tau value for the recorder from the system config
         call->set_is_analog(true);
         call->set_recorder((Recorder *)rec.get());
         call->set_state(RECORDING);

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -93,8 +93,8 @@ public:
   virtual bool get_qpsk_mod() = 0;
   virtual void set_squelch_db(double s) = 0;
   virtual double get_squelch_db() = 0;
-  virtual void set_tau(float t) = 0;
-  virtual float get_tau() = 0;
+  virtual void set_tau(float tau) = 0;
+  virtual float get_tau() const = 0;
   virtual void set_max_dev(int max_dev) = 0;
   virtual int get_max_dev() = 0;
   virtual void set_filter_width(double f) = 0;

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -93,6 +93,8 @@ public:
   virtual bool get_qpsk_mod() = 0;
   virtual void set_squelch_db(double s) = 0;
   virtual double get_squelch_db() = 0;
+  virtual void set_tau(float t) = 0;
+  virtual float get_tau() = 0;
   virtual void set_max_dev(int max_dev) = 0;
   virtual int get_max_dev() = 0;
   virtual void set_filter_width(double f) = 0;

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -204,6 +204,14 @@ double System_impl::get_squelch_db() {
   return squelch_db;
 }
 
+void System_impl::set_tau(float t){
+  d_tau = t;
+}
+
+float System_impl::get_tau(){
+  return d_tau;
+}
+
 void System_impl::set_filter_width(double filter_width) {
   this->filter_width = filter_width;
 }

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -205,11 +205,11 @@ double System_impl::get_squelch_db() {
 }
 
 void System_impl::set_tau(float t){
-  d_tau = t;
+  tau = t;
 }
 
-float System_impl::get_tau(){
-  return d_tau;
+float System_impl::get_tau() const{
+  return tau;
 }
 
 void System_impl::set_filter_width(double filter_width) {

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -86,6 +86,7 @@ public:
   bool conversation_mode;
   bool qpsk_mod;
   double squelch_db;
+  float tau;
   double analog_levels;
   double digital_levels;
 
@@ -154,6 +155,8 @@ public:
   bool get_qpsk_mod();
   void set_squelch_db(double s);
   double get_squelch_db();
+  void set_tau(float tau);
+  float get_tau() const;
   void set_max_dev(int max_dev);
   int get_max_dev();
   void set_filter_width(double f);

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -155,8 +155,8 @@ public:
   bool get_qpsk_mod();
   void set_squelch_db(double s);
   double get_squelch_db();
-  void set_tau(float tau);
-  float get_tau() const;
+  void set_tau(float tau) override;
+  float get_tau() const override;
   void set_max_dev(int max_dev);
   int get_max_dev();
   void set_filter_width(double f);


### PR DESCRIPTION
Related to #187 #511 

As mentioned in the above issues, many analog VHF low-band public safety frequencies use a higher de-emphasis time constant. After much confusion trying to set up a 42 MHz highway patrol stream and consistently getting distorted audio, I eventually found the value in the analog_reocorder set to 75µs. Adjusting it fixed the distortion, and the stream sounded as I had originally expected.

Looks like #511 was forgotten about, but it seems like a sensible addition as most broadcasters running into this problem are never going to find that file and rebuild. Would have saved me a boatload of time as a first-time user.

Example config.json:
```
"systems": [
        {
            "type": "conventional",
            "channels": [],
            "squelch": -60,
            "deemphasisTau": 0.000530
        }
]
```