### PR TITLE
fmt 11 compile fix

### DIFF
--- a/lib/op25_repeater/lib/iqfile_source_impl.cc
+++ b/lib/op25_repeater/lib/iqfile_source_impl.cc
@@ -185,14 +185,14 @@ void iqfile_source_impl::open(const char* filename,
     }
 
     if ((d_new_fp = fopen(filename, "rb")) == NULL) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        GR_LOG_ERROR(d_logger, (boost::format("%s: %s") % filename % strerror(errno)).str());
         throw std::runtime_error("can't open file");
     }
 
     struct GR_STAT st;
 
     if (GR_FSTAT(GR_FILENO(d_new_fp), &st)) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        GR_LOG_ERROR(d_logger, (boost::format("%s: %s") % filename % strerror(errno)).str());
         throw std::runtime_error("can't fstat file");
     }
     if (S_ISREG(st.st_mode)) {


### PR DESCRIPTION
Trunk Recorder may fail to compile as distributions start including newer versions of the fmt library.  So far, this has been observed on MacOS (homebrew), and in Arch (#976).  It is likely that other distributions will notice this issue as they are updated similarly.

All that is needed is for these two `GR_LOG_ERROR()` functions to be provided a string instead of a `boost::format` object.

This change should not impact older versions of fmt, as gnuradio logging functions were already handling these messages as strings.