### PR TITLE
Fixed Raspberry Pi Docker Install Typo

### DIFF
--- a/docs/Install/INSTALL-DOCKER.md
+++ b/docs/Install/INSTALL-DOCKER.md
@@ -10,7 +10,7 @@ To get started, create a directory and place your **config.json** file there and
 
 ```bash
 docker run -it \
-  --devices "/dev/bus/usb:/dev/bus/usb:rwm" -e TZ=$(cat /etc/timezone) --user "$(id -u):$(id -g)" \
+  --device "/dev/bus/usb:/dev/bus/usb:rwm" -e TZ=$(cat /etc/timezone) --user "$(id -u):$(id -g)" \
   -v $(pwd):/app \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket \


### PR DESCRIPTION
### Summary
The documentation incorrectly listed ``--devices`` as an argument, which is not recognized by Docker. The correct argument is ``--device``, and this fix resolves that discrepancy.

### Why This Change Matters
The incorrect flag caused confusion and delays in usage, as ``--devices`` is not valid. By correcting this, we ensure the documentation is accurate and users can follow it without encountering errors.

### Personal Note
I spent more time than I’d like to admit figuring this out, so I hope this fix saves others from the same frustration.