### PR TITLE
Docker Build: Only build librtlsdr 1x, install 2x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,21 +45,8 @@ RUN cd /tmp && \
   make install && \
   # We need to install both in / and /newroot to use in this image
   # and to copy over to the final image
-  make DESTDIR=/newroot install && \
-  ldconfig && \
-  cd /tmp && \
-  rm -rf librtlsdr
-
-# Compile librtlsdr-dev 2.0 for SDR-Blog v4 support and other updates
-# Ubuntu 22.04 LTS has librtlsdr 0.6.0
-RUN cd /tmp && \
-  git clone https://github.com/steve-m/librtlsdr.git && \
-  cd librtlsdr && \
-  mkdir build && \
-  cd build && \
-  cmake .. && \
-  make -j$(nproc) && \
   make install && \
+  make DESTDIR=/newroot install && \
   ldconfig && \
   cd /tmp && \
   rm -rf librtlsdr


### PR DESCRIPTION
Improve Docker build - only build librtlsdr 1x, install 2x

Addresses issue: https://github.com/robotastic/trunk-recorder/issues/985