### PR TITLE
Min Duration to Info instead of error

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -434,7 +434,7 @@ void Call_Concluder::conclude_call(Call *call, System *sys, Config config) {
   }
 
   if (call_info.length <= sys->get_min_duration()) {
-    BOOST_LOG_TRIVIAL(error) << loghdr << "Call length: " << call_info.length << " is less than min duration: " << sys->get_min_duration();
+    BOOST_LOG_TRIVIAL(info) << loghdr << "Call length: " << call_info.length << " is less than min duration: " << sys->get_min_duration();
     remove_call_files(call_info);
     return;
   }


### PR DESCRIPTION
super minor update to log-level for one line. 

Brought this up on discord. I initially felt this should be a warning but others in discord stated the program is doing exactly what we told it to do and it should be info instead. Either way I feel like it shouldn't be an error. 