### PR TITLE
Update Docs: multisite should be boolean, not string

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -278,14 +278,14 @@ By default, Trunk Recorder will record the call from the first site to receive t
         {
             "type": "P25",
             ...
-            "multiSite": "true",
+            "multiSite": true,
             "multiSiteSystemName": "somesharedname",
             "multiSiteSystemNumber": 1
         },
         {
             "type": "P25",
             ...
-            "multiSite": "true",
+            "multiSite": true,
             "multiSiteSystemName": "somesharedname",
             "multiSiteSystemNumber": 2
         }


### PR DESCRIPTION
Update CONFIGURE.md to properly reflect that the multisite parameter should be boolean, not a string.