### PR TITLE
prevent failure on cmake 4

### DIFF
--- a/lib/op25_repeater/lib/imbe_vocoder/CMakeLists.txt
+++ b/lib/op25_repeater/lib/imbe_vocoder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.12)
 
 SET( MORE_FLAGS "-fPIC")
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${MORE_FLAGS}" )


### PR DESCRIPTION
https://gitlab.kitware.com/cmake/cmake/-/issues/26698
CMake 4 has dropped support for cmake < 3.5, minimum version must be raised.
I raised it to match the main CMakeFile.txt