### PR TITLE
P25 P2 - Use MAC_HANGTIME to End Transmissions.

### DIFF
--- a/lib/op25_repeater/lib/p25p2_tdma.cc
+++ b/lib/op25_repeater/lib/p25p2_tdma.cc
@@ -364,6 +364,12 @@ void p25p2_tdma::decode_mac_msg(const uint8_t byte_buf[], const unsigned int len
         op   = (b1b2 << 6) + mco;
 		mfid = 0;
 
+		// Variables need to be defined outside of the Switch.
+		uint16_t grpaddr;
+		uint32_t srcaddr;
+		uint32_t wacn;
+		uint32_t sysid;
+
 		// Find message length using opcode handlers or lookup table
 		switch (op) {
 			case 0x00: // Null Information


### PR DESCRIPTION
Updated transmission termination logic to end transmissions when MAC_HANGTIME is received rather than when MAC_END_PTT is received.

After reviewing the P25 standards, MAC_HANGTIME is sent each time an individual transmission ends, while MAC_END_PTT is only transmitted when the entire channel is being torn down. Multiple MAC_PTT messages from different sources can occur before a single MAC_END_PTT.