### PR TITLE
Motorola OTA Alias support for P25P1/P2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ list(APPEND trunk_recorder_sources
   trunk-recorder/talkgroups.cc
   trunk-recorder/unit_tag.cc
   trunk-recorder/unit_tags.cc
+  trunk-recorder/unit_tags_ota.cc
   trunk-recorder/plugin_manager/plugin_manager.cc
   trunk-recorder/call_concluder/call_concluder.cc
   trunk-recorder/autotune.cc

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -277,6 +277,9 @@ During the status display, each source will report the running average as well a
 | multiSite              |          | false         | **true** / **false** | Enables multiSite mode for this system                                            |
 | multiSiteSystemName    |          |               | string               | The name of the system that this site belongs to. **This is required for SmartNet in Multi-Site mode.** |
 | multiSiteSystemNumber  |          | 0             | number               | An arbitrary number used to identify this system for SmartNet in Multi-Site mode. |
+| monitorEncrypted       |          | false         | **true** / **false** | Monitor encrypted transmissions and generate call metadata **without recording audio**. Trunk Recorder can assign a recorder to monitor encrypted calls to capture talkgroup activity and associated metadata. |
+| unitTagsOTA            |          |               | string               | CSV file for storing over-the-air (OTA) radio aliases; if it doesn't exist yet, the file entered will be created automatically. Trunk Recorder will capture and log OTA aliases as `unitID,alias,source,timestamp,WACN,SYS,talkgroup_discovered`. This file is loaded at startup, and searched after the `unitTagsFile` unless otherwise configured. |
+| unitTagsMode           |          | "user"        | "user", "ota", "user_only", "none" | Set the search order for radio aliases. It may be useful to control which collection is searched first, use only manual aliases, or ignore all. |
 
 When enabled, Multi-Site mode attempts to avoid recording duplicate calls by detecting simulcasted transmissions for the same talkgroup across multiple sites at the same time.
 

--- a/lib/op25_repeater/lib/p25p1_fdma.h
+++ b/lib/op25_repeater/lib/p25p1_fdma.h
@@ -98,6 +98,8 @@ namespace gr {
                 double error_history[20];
                 long curr_src_id;
                 long curr_grp_id;
+                std::array<std::vector<uint8_t>, 10> alias_buffer;
+                
                 std::pair<bool,long> terminate_call;
                 const char *d_udp_host;
                 int  d_port;

--- a/lib/op25_repeater/lib/p25p2_tdma.h
+++ b/lib/op25_repeater/lib/p25p2_tdma.h
@@ -88,6 +88,7 @@ private:
 	std::pair<bool,long> terminate_call;
 	long src_id;
 	long grp_id;
+	std::array<std::vector<uint8_t>, 10> alias_buffer;
 	const op25_audio& op25audio;
     log_ts& logts;
     int d_nac;

--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -296,7 +296,10 @@ MonitoringState Call_impl::get_monitoring_state() {
 }
 
 void Call_impl::set_encrypted(bool m) {
-  encrypted = m;
+  if (encrypted != m) {
+    encrypted = m;
+    update_talkgroup_display();
+  }
 }
 
 bool Call_impl::get_encrypted() {
@@ -466,12 +469,13 @@ void Call_impl::update_talkgroup_display() {
   }
 
   char formattedTalkgroup[62];
+  int color = encrypted ? 31 : 35; // Red for encrypted, magenta for normal
   if (this->sys->get_talkgroup_display_format() == talkGroupDisplayFormat_id_tag) {
-    snprintf(formattedTalkgroup, 61, "%10ld (%c[%dm%23s%c[0m)", talkgroup, 0x1B, 35, talkgroup_tag.c_str(), 0x1B);
+    snprintf(formattedTalkgroup, 61, "%10ld (%c[%dm%23s%c[0m)", talkgroup, 0x1B, color, talkgroup_tag.c_str(), 0x1B);
   } else if (this->sys->get_talkgroup_display_format() == talkGroupDisplayFormat_tag_id) {
-    snprintf(formattedTalkgroup, 61, "%c[%dm%23s%c[0m (%10ld)", 0x1B, 35, talkgroup_tag.c_str(), 0x1B, talkgroup);
+    snprintf(formattedTalkgroup, 61, "%c[%dm%23s%c[0m (%10ld)", 0x1B, color, talkgroup_tag.c_str(), 0x1B, talkgroup);
   } else {
-    snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, 35, talkgroup, 0x1B);
+    snprintf(formattedTalkgroup, 61, "%c[%dm%10ld%c[0m", 0x1B, color, talkgroup, 0x1B);
   }
   talkgroup_display = boost::lexical_cast<std::string>(formattedTalkgroup);
 }

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -360,6 +360,10 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         BOOST_LOG_TRIVIAL(info) << "Transmission Archive: " << system->get_transmission_archive();
         system->set_unit_tags_file(element.value("unitTagsFile", ""));
         BOOST_LOG_TRIVIAL(info) << "Unit Tags File: " << system->get_unit_tags_file();
+        system->set_unit_tags_ota_file(element.value("unitTagsOTA", ""));
+        BOOST_LOG_TRIVIAL(info) << "Unit Tags OTA File: " << system->get_unit_tags_ota_file();
+        system->set_unit_tags_mode(element.value("unitTagsMode", "user"));
+        BOOST_LOG_TRIVIAL(info) << "Unit Tags Mode: " << system->get_unit_tags_mode();
         system->set_record_unknown(element.value("recordUnknown", true));
         BOOST_LOG_TRIVIAL(info) << "Record Unknown Talkgroups: " << system->get_record_unknown();
         system->set_mdc_enabled(element.value("decodeMDC", false));
@@ -409,6 +413,8 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
 
         system->set_hideEncrypted(element.value("hideEncrypted", system->get_hideEncrypted()));
         BOOST_LOG_TRIVIAL(info) << "Hide Encrypted Talkgroups: " << system->get_hideEncrypted();
+        system->set_monitorEncrypted(element.value("monitorEncrypted", system->get_monitorEncrypted()));
+        BOOST_LOG_TRIVIAL(info) << "Monitor Encrypted Calls: " << system->get_monitorEncrypted();
         system->set_hideUnknown(element.value("hideUnknownTalkgroups", system->get_hideUnknown()));
         BOOST_LOG_TRIVIAL(info) << "Hide Unknown Talkgroups: " << system->get_hideUnknown();
         system->set_min_duration(element.value("minDuration", 0.0));

--- a/trunk-recorder/recorders/p25_recorder.h
+++ b/trunk-recorder/recorders/p25_recorder.h
@@ -45,6 +45,7 @@ public:
   virtual void set_tdma_slot(int slot) = 0;
   virtual void set_source(long src) = 0;
   virtual double since_last_write() = 0;
+  virtual void process_message_queues() = 0;
   virtual double get_current_length() = 0;
   virtual void set_enabled(bool enabled) {};
   virtual bool is_enabled() { return false; };

--- a/trunk-recorder/recorders/p25_recorder_decode.h
+++ b/trunk-recorder/recorders/p25_recorder_decode.h
@@ -73,6 +73,9 @@ public:
   double get_output_sample_rate();
   State get_state();
   gr::op25_repeater::p25_frame_assembler::sptr get_transmission_sink();
+  void check_message_queue();
 
+private:
+  void handle_alias_message(const nlohmann::json& j);
 };
 #endif

--- a/trunk-recorder/recorders/p25_recorder_impl.cc
+++ b/trunk-recorder/recorders/p25_recorder_impl.cc
@@ -164,6 +164,14 @@ double p25_recorder_impl::since_last_write() {
   }
 }
 
+void p25_recorder_impl::process_message_queues() {
+  if (qpsk_mod) {
+    qpsk_p25_decode->check_message_queue();
+  } else {
+    fsk4_p25_decode->check_message_queue();
+  }
+}
+
 State p25_recorder_impl::get_state() {
   if (qpsk_mod) {
     return qpsk_p25_decode->get_state();

--- a/trunk-recorder/recorders/p25_recorder_impl.h
+++ b/trunk-recorder/recorders/p25_recorder_impl.h
@@ -97,6 +97,7 @@ public:
   void set_tdma_slot(int slot);
   void set_source(long src);
   double since_last_write();
+  void process_message_queues();
   double get_current_length();
   void set_enabled(bool enabled);
   bool is_enabled();

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -123,6 +123,10 @@ public:
   virtual void set_channel_file(std::string channel_file) = 0;
   virtual bool has_channel_file() = 0;
   virtual void set_unit_tags_file(std::string) = 0;
+  virtual void set_unit_tags_ota_file(std::string) = 0;
+  virtual std::string get_unit_tags_ota_file() = 0;
+  virtual void set_unit_tags_mode(std::string mode) = 0;
+  virtual std::string get_unit_tags_mode() = 0;
   virtual void set_custom_freq_table_file(std::string custom_freq_table_file) = 0;
   virtual std::string get_custom_freq_table_file() = 0;
   virtual bool has_custom_freq_table_file() = 0;
@@ -164,6 +168,8 @@ public:
 
   virtual bool get_hideEncrypted() = 0;
   virtual void set_hideEncrypted(bool hideEncrypted) = 0;
+  virtual bool get_monitorEncrypted() = 0;
+  virtual void set_monitorEncrypted(bool monitorEncrypted) = 0;
 
   virtual bool get_hideUnknown() = 0;
   virtual void set_hideUnknown(bool hideUnknown) = 0;

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -93,6 +93,7 @@ System_impl::System_impl(int sys_num) {
   unit_tags = new UnitTags();
   talkgroup_patches = {};
   d_hideEncrypted = false;
+  d_monitorEncrypted = false;
   d_hideUnknown = false;
   d_mdc_enabled = false;
   d_fsync_enabled = false;
@@ -331,6 +332,32 @@ void System_impl::set_unit_tags_file(std::string unit_tags_file) {
   this->unit_tags->load_unit_tags(unit_tags_file);
 }
 
+void System_impl::set_unit_tags_ota_file(std::string unit_tags_ota_file) {
+  this->unit_tags_ota_file = unit_tags_ota_file;
+  this->unit_tags->load_unit_tags_ota(unit_tags_ota_file);
+}
+
+std::string System_impl::get_unit_tags_ota_file() {
+  return this->unit_tags_ota_file;
+}
+
+void System_impl::set_unit_tags_mode(std::string mode) {
+  this->unit_tags_mode = mode;
+  if (mode == "ota" || mode == "OTA") {
+    this->unit_tags->set_mode(TAG_OTA_FIRST);
+  } else if (mode == "user_only") {
+    this->unit_tags->set_mode(TAG_USER_ONLY);
+  } else if (mode == "none") {
+    this->unit_tags->set_mode(TAG_NONE);
+  } else {
+    this->unit_tags->set_mode(TAG_USER_FIRST);
+  }
+}
+
+std::string System_impl::get_unit_tags_mode() {
+  return this->unit_tags_mode;
+}
+
 void System_impl::set_custom_freq_table_file(std::string custom_freq_table_file) {
   this->custom_freq_table_file = custom_freq_table_file;
 }
@@ -533,6 +560,12 @@ bool System_impl::get_hideEncrypted() {
 }
 void System_impl::set_hideEncrypted(bool hideEncrypted) {
   d_hideEncrypted = hideEncrypted;
+}
+bool System_impl::get_monitorEncrypted() {
+  return d_monitorEncrypted;
+}
+void System_impl::set_monitorEncrypted(bool monitorEncrypted) {
+  d_monitorEncrypted = monitorEncrypted;
 }
 
 bool System_impl::get_hideUnknown() {

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -59,6 +59,8 @@ public:
   std::string talkgroups_file;
   std::string channel_file;
   std::string unit_tags_file;
+  std::string unit_tags_ota_file;
+  std::string unit_tags_mode;
   std::string custom_freq_table_file;
   std::string short_name;
   std::string api_key;
@@ -185,6 +187,10 @@ public:
   void set_channel_file(std::string channel_file) override;
   bool has_channel_file() override;
   void set_unit_tags_file(std::string) override;
+  void set_unit_tags_ota_file(std::string) override;
+  std::string get_unit_tags_ota_file() override;
+  void set_unit_tags_mode(std::string mode) override;
+  std::string get_unit_tags_mode() override;
   void set_custom_freq_table_file(std::string custom_freq_table_file) override;
   std::string get_custom_freq_table_file() override;
   bool has_custom_freq_table_file() override;
@@ -228,6 +234,8 @@ public:
 
   bool get_hideEncrypted() override;
   void set_hideEncrypted(bool hideEncrypted) override;
+  bool get_monitorEncrypted() override;
+  void set_monitorEncrypted(bool monitorEncrypted) override;
 
   bool get_hideUnknown() override;
   void set_hideUnknown(bool hideUnknown) override;
@@ -257,6 +265,7 @@ public:
 private:
   TalkgroupDisplayFormat talkgroup_display_format;
   bool d_hideEncrypted;
+  bool d_monitorEncrypted;
   bool d_hideUnknown;
   bool d_multiSite;
   std::string d_multiSiteSystemName;

--- a/trunk-recorder/unit_tag.cc
+++ b/trunk-recorder/unit_tag.cc
@@ -5,3 +5,13 @@ UnitTag::UnitTag(std::string p, std::string t) {
   pattern = p;
   tag = t;
 }
+
+UnitTagOTA::UnitTagOTA(long id, std::string a, std::string src, std::string w, std::string s, long tg, time_t ts) {
+  unit_id = id;
+  alias = a;
+  source = src;
+  wacn = w;
+  sys = s;
+  talkgroup_id = tg;
+  timestamp = ts;
+}

--- a/trunk-recorder/unit_tag.h
+++ b/trunk-recorder/unit_tag.h
@@ -6,12 +6,27 @@
 #include <string>
 #include <boost/regex.hpp>
 
+// User defined tag structure with regex pattern matching
 class UnitTag {
 public:
   boost::regex pattern;
   std::string tag;
 
   UnitTag(std::string p, std::string t);
+};
+
+// Long int OTA tag structure for fast number-to-alias lookups
+class UnitTagOTA {
+public:
+  long unit_id;
+  std::string alias;
+  std::string source;
+  std::string wacn;
+  std::string sys;
+  long talkgroup_id;
+  time_t timestamp;
+
+  UnitTagOTA(long id, std::string a, std::string src, std::string w, std::string s, long tg, time_t ts);
 };
 
 #endif // UNIT_TAG_H

--- a/trunk-recorder/unit_tags.cc
+++ b/trunk-recorder/unit_tags.cc
@@ -7,89 +7,240 @@
 #include <boost/tokenizer.hpp>
 #include <boost/regex.hpp>
 
-#include "csv_helper.h"
+#include <csv-parser/csv.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <map>
 
-UnitTags::UnitTags() {}
+using namespace csv;
 
 void UnitTags::load_unit_tags(std::string filename) {
   if (filename == "") {
     return;
   }
 
-  std::ifstream in(filename.c_str());
+  CSVFormat format;
+  format.trim({' ', '\t'});
+  format.header_row(-1);  // No header row expected
+  format.column_names({"unit_id", "tag"});
+  
+  try {
+    CSVReader reader(filename, format);
+    
+    int lines_loaded = 0;
+    for (CSVRow &row : reader) {
+      if (row.size() < 2) {
+        continue;
+      }
+      
+      std::string pattern = row["unit_id"].get<>();
+      std::string tag = row["tag"].get<>();
+      
+      add(pattern, tag);
+      lines_loaded++;
+    }
+    
+    BOOST_LOG_TRIVIAL(info) << "Read " << lines_loaded << " unit tags.";
+  } catch (std::exception &e) {
+    BOOST_LOG_TRIVIAL(error) << "Error reading Unit Tag File: " << filename << " - " << e.what();
+  }
+}
 
-  if (!in.is_open()) {
-    BOOST_LOG_TRIVIAL(error) << "Error Opening Unit Tag File: " << filename << std::endl;
+void UnitTags::load_unit_tags_ota(std::string filename) {
+  ota_filename = filename;
+  
+  if (filename == "") {
     return;
   }
 
-  boost::escaped_list_separator<char> sep("\\", ",\t", "\"");
-  typedef boost::tokenizer<boost::escaped_list_separator<char>> t_tokenizer;
-
-  std::vector<std::string> vec;
-  std::string line;
-
-  int lines_read = 0;
-  int lines_pushed = 0;
-
-  while (!safeGetline(in, line).eof()) // this works with \r, \n, or \r\n
-  {
-    if (line.size() && (line[line.size() - 1] == '\r')) {
-      line = line.substr(0, line.size() - 1);
-    }
-
-    lines_read++;
-
-    if (line == "")
-      continue;
-
-    t_tokenizer tok(line, sep);
-
-    // Unit Tag configuration columns:
-    //
-    // [0] - talkgroup number
-    // [1] - tag
-
-    vec.assign(tok.begin(), tok.end());
-
-    if (vec.size() < 2) {
-      BOOST_LOG_TRIVIAL(error) << "Malformed talkgroup entry at line " << lines_read << ".";
-      continue;
-    }
-
-    add(vec[0].c_str(), vec[1].c_str());
-
-    lines_pushed++;
+  if (mode == TAG_NONE) {
+    return;
   }
 
-  if (lines_pushed != lines_read) {
-    // The parser above is pretty brittle. This will help with debugging it, for
-    // now.
-    BOOST_LOG_TRIVIAL(error) << "Warning: skipped " << lines_read - lines_pushed << " of " << lines_read << " unit tag entries! Invalid format?";
-    BOOST_LOG_TRIVIAL(error) << "The format is very particular. See  https://github.com/robotastic/trunk-recorder for example input.";
-  } else {
-    BOOST_LOG_TRIVIAL(info) << "Read " << lines_pushed << " unit tags.";
+  std::ifstream test(filename);
+  if (!test.good()) {
+    return;  // File doesn't exist yet, that's ok!
+  }
+  test.close();
+
+  CSVFormat format;
+  format.trim({' ', '\t'});
+  format.header_row(-1);  // No header row
+  format.column_names({"unit_id", "tag", "source", "timestamp", "wacn", "sys", "talkgroup_id"});
+  
+  try {
+    CSVReader reader(filename, format);
+    
+    int lines_loaded = 0;
+    int lines_needing_update = 0;
+    for (CSVRow &row : reader) {
+      if (row.size() < 2) {
+        continue;
+      }
+
+      // Mandatory fields
+      long unit_id = std::stol(row["unit_id"].get<>());
+      std::string tag = row["tag"].get<>();
+      
+      // Optional fields with defaults
+      std::string source = (row.size() >= 3) ? row["source"].get<>() : "";
+      time_t ts = (row.size() >= 4) ? std::stol(row["timestamp"].get<>()) : 0;
+      std::string wacn = (row.size() >= 7) ? row["wacn"].get<>() : "";
+      std::string sys = (row.size() >= 7) ? row["sys"].get<>() : "";
+      std::string tg_str = (row.size() >= 7) ? row["talkgroup_id"].get<>() : "";
+      long tg = tg_str.empty() ? -1 : std::stol(tg_str);
+      
+      if (wacn.empty()) {
+        lines_needing_update++;
+      }
+      
+      UnitTagOTA *ota_tag = new UnitTagOTA(unit_id, tag, source, wacn, sys, tg, ts);
+      unit_tags_ota.push_back(ota_tag);
+      lines_loaded++;
+    }
+    
+    if (lines_loaded > 0) {
+      BOOST_LOG_TRIVIAL(info) << "Loaded " << lines_loaded << " OTA unit tags.";
+      
+      // Check if data is already sorted by unit_id
+      bool is_sorted = true;
+      for (size_t i = 1; i < unit_tags_ota.size(); i++) {
+        if (unit_tags_ota[i-1]->unit_id > unit_tags_ota[i]->unit_id) {
+          is_sorted = false;
+          break;
+        }
+      }
+      
+      // Deduplicate: keep newest entry per unit_id
+      std::map<long, UnitTagOTA*> unique_tags;
+      int duplicates_removed = 0;
+      
+      for (auto ota_tag : unit_tags_ota) {
+        auto result = unique_tags.insert(std::make_pair(ota_tag->unit_id, ota_tag));
+        
+        if (!result.second) {
+          // Duplicate found - compare timestamps and metadata completeness
+          UnitTagOTA *current = result.first->second;
+          bool replace = false;
+          if (ota_tag->timestamp > current->timestamp) {
+            replace = true;
+          } else if (ota_tag->timestamp == current->timestamp && !ota_tag->wacn.empty() && current->wacn.empty()) {
+            replace = true;
+          }
+          
+          if (replace) {
+            delete current;
+            result.first->second = ota_tag;
+          } else {
+            delete ota_tag;
+          }
+          duplicates_removed++;
+        }
+      }
+      
+      if (duplicates_removed > 0 || !is_sorted || lines_needing_update > 0) {
+        if (duplicates_removed > 0) {
+          BOOST_LOG_TRIVIAL(info) << " Found " << duplicates_removed << " duplicate OTA entries";
+        }
+        if (!is_sorted) {
+          BOOST_LOG_TRIVIAL(info) << " OTA CSV is unsorted, reorganizing by unit ID";
+        }
+        if (lines_needing_update > 0) {
+          BOOST_LOG_TRIVIAL(info) << " " << lines_needing_update << " OTA tags with incomplete metadata, will update as discovered";
+        }
+        
+        unit_tags_ota.clear();
+        for (auto &pair : unique_tags) {
+          unit_tags_ota.push_back(pair.second);
+        }
+        
+        // Atomic rewrite: temp file + rename
+        try {
+          std::string temp_file = filename + ".tmp";
+          std::ofstream out(temp_file, std::ios::trunc);
+          if (out.is_open()) {
+            CSVWriter<std::ofstream> writer(out);
+            for (UnitTagOTA *ota_tag : unit_tags_ota) {
+              writer << std::vector<std::string>{
+                std::to_string(ota_tag->unit_id),
+                ota_tag->alias,
+                ota_tag->source,
+                std::to_string(ota_tag->timestamp),
+                ota_tag->wacn,
+                ota_tag->sys,
+                (ota_tag->talkgroup_id == -1) ? "" : std::to_string(ota_tag->talkgroup_id)
+              };
+            }
+            out.close();
+            
+            if (std::rename(temp_file.c_str(), filename.c_str()) == 0) {
+              BOOST_LOG_TRIVIAL(info) << "OTA CSV cleaned and sorted successfully (" << unique_tags.size() << " entries)";
+            } else {
+              BOOST_LOG_TRIVIAL(error) << "Failed to rename cleaned CSV";
+            }
+          }
+        } catch (std::exception &e) {
+          BOOST_LOG_TRIVIAL(error) << "Error rewriting CSV: " << e.what();
+        }
+      }
+    }
+  } catch (std::exception &e) {
+    BOOST_LOG_TRIVIAL(error) << "Error reading OTA Unit Tag File: " << filename << " - " << e.what();
   }
 }
 
 std::string UnitTags::find_unit_tag(long tg_number) {
-  std::string tg_num_str = std::to_string(tg_number);
-  std::string tag = "";
-
-  for (std::vector<UnitTag *>::iterator it = unit_tags.begin(); it != unit_tags.end(); ++it) {
-    UnitTag *tg = (UnitTag *)*it;
-
-    if (regex_match(tg_num_str, tg->pattern)) {
-      tag = regex_replace(tg_num_str, tg->pattern, tg->tag, boost::regex_constants::format_no_copy | boost::regex_constants::format_all);
-      break;
-    }
+  // TAG_NONE: Don't search any tags
+  if (mode == TAG_NONE) {
+    return "";
   }
 
-  return tag;
+  std::string tg_num_str = std::to_string(tg_number);
+  
+  // Helper lambda: Search user tags
+  auto search_user_tags = [&]() -> std::string {
+    for (std::vector<UnitTag *>::iterator it = unit_tags.begin(); it != unit_tags.end(); ++it) {
+      UnitTag *tg = (UnitTag *)*it;
+      if (regex_match(tg_num_str, tg->pattern)) {
+        return regex_replace(tg_num_str, tg->pattern, tg->tag, boost::regex_constants::format_no_copy | boost::regex_constants::format_all);
+      }
+    }
+    return "";
+  };
+  
+  // Helper lambda: Search OTA tags
+  auto search_ota_tags = [&]() -> std::string {
+    for (auto it = unit_tags_ota.rbegin(); it != unit_tags_ota.rend(); ++it) {
+      UnitTagOTA *ota_tag = *it;
+      if (ota_tag->unit_id == tg_number) {
+        return ota_tag->alias;
+      }
+    }
+    return "";
+  };
+  
+  // TAG_USER_FIRST: Search user tags first, then OTA
+  if (mode == TAG_USER_FIRST) {
+    std::string tag = search_user_tags();
+    if (!tag.empty()) return tag;
+    return search_ota_tags();
+  }
+  
+  // TAG_OTA_FIRST: Search OTA tags first, then user tags
+  if (mode == TAG_OTA_FIRST) {
+    std::string tag = search_ota_tags();
+    if (!tag.empty()) return tag;
+    return search_user_tags();
+  }
+
+  // TAG_USER_ONLY: Only search user tags
+  if (mode == TAG_USER_ONLY) {
+    return search_user_tags();
+  }
+
+  return "";
 }
 
 void UnitTags::add(std::string pattern, std::string tag) {
@@ -103,4 +254,93 @@ void UnitTags::add(std::string pattern, std::string tag) {
   }
   UnitTag *unit_tag = new UnitTag(pattern, tag);
   unit_tags.push_back(unit_tag);
+}
+
+bool UnitTags::add_ota(const OTAAlias& ota_alias) {
+  if (!ota_alias.success) {
+    return false;
+  }
+  
+  // If mode is TAG_NONE, don't process or write OTA tags
+  if (mode == TAG_NONE) {
+    return false;
+  }
+  
+  // Check if this unit already has an OTA tag (search OTA list only)
+  UnitTagOTA *existing_ota = nullptr;
+  for (auto it = unit_tags_ota.rbegin(); it != unit_tags_ota.rend(); ++it) {
+    UnitTagOTA *ota_tag = *it;
+    if (ota_tag->unit_id == ota_alias.radio_id) {
+      existing_ota = ota_tag;
+      break;
+    }
+  }
+  
+  if (existing_ota) {
+    if (existing_ota->alias == ota_alias.alias) {
+      // check if decode metadata is missing
+      bool needs_enrichment = (existing_ota->wacn.empty() && !ota_alias.wacn.empty()) ||
+                              (existing_ota->sys.empty() && !ota_alias.sys.empty()) ||
+                              (existing_ota->talkgroup_id == -1 && ota_alias.talkgroup_id != -1);
+      
+      if (needs_enrichment) {
+        BOOST_LOG_TRIVIAL(debug) << "Unit " << ota_alias.radio_id << " (" << ota_alias.alias << "): enriching with metadata (WACN: " << ota_alias.wacn << ", SYS: " << ota_alias.sys << ", TG: " << ota_alias.talkgroup_id << ")";
+        
+        if (!ota_alias.source.empty()) existing_ota->source = ota_alias.source;
+        if (!ota_alias.wacn.empty()) existing_ota->wacn = ota_alias.wacn;
+        if (!ota_alias.sys.empty()) existing_ota->sys = ota_alias.sys;
+        if (ota_alias.talkgroup_id != -1) existing_ota->talkgroup_id = ota_alias.talkgroup_id;
+        existing_ota->timestamp = std::time(nullptr);
+        
+        // Append enriched entry to CSV
+        if (!ota_filename.empty()) {
+          try {
+            std::ofstream out(ota_filename, std::ios::app);
+            if (out.is_open()) {
+              CSVWriter<std::ofstream> writer(out);
+              writer << std::vector<std::string>{std::to_string(ota_alias.radio_id), ota_alias.alias, ota_alias.source, std::to_string(existing_ota->timestamp), ota_alias.wacn, ota_alias.sys, (ota_alias.talkgroup_id == -1) ? "" : std::to_string(ota_alias.talkgroup_id)};
+              out.close();
+            } else {
+              BOOST_LOG_TRIVIAL(error) << "Failed to open " << ota_filename << " for appending enriched entry";
+            }
+          } catch (std::exception &e) {
+            BOOST_LOG_TRIVIAL(error) << "Error appending enriched OTA entry: " << e.what();
+          }
+        }
+        return false;
+      }
+      BOOST_LOG_TRIVIAL(debug) << "Unit " << ota_alias.radio_id << " has existing OTA alias: '" << ota_alias.alias << "', skipping";
+      return false;
+    }
+    BOOST_LOG_TRIVIAL(info) << "Unit " << ota_alias.radio_id << " OTA alias updated: '" << existing_ota->alias << "' -> '" << ota_alias.alias << "'";
+  }
+  
+  UnitTagOTA *ota_tag = new UnitTagOTA(ota_alias.radio_id, ota_alias.alias, ota_alias.source, ota_alias.wacn, ota_alias.sys, ota_alias.talkgroup_id, std::time(nullptr));
+  unit_tags_ota.push_back(ota_tag);
+
+  // Write to OTA file if configured
+  if (!ota_filename.empty()) {
+    try {
+      std::ofstream out(ota_filename, std::ios::app);
+      if (out.is_open()) {
+        CSVWriter<std::ofstream> writer(out);
+        writer << std::vector<std::string>{std::to_string(ota_alias.radio_id), ota_alias.alias, ota_alias.source, std::to_string(ota_tag->timestamp), ota_alias.wacn, ota_alias.sys, (ota_alias.talkgroup_id == -1) ? "" : std::to_string(ota_alias.talkgroup_id)};
+        out.close();
+      } else {
+        BOOST_LOG_TRIVIAL(error) << "Failed to open " << ota_filename << " for writing OTA alias.";
+      }
+    } catch (std::exception &e) {
+      BOOST_LOG_TRIVIAL(error) << "Error writing to OTA file " << ota_filename << ": " << e.what();
+    }
+  }
+  
+  return true;
+}
+
+void UnitTags::set_mode(UnitTagMode mode) {
+  this->mode = mode;
+}
+
+UnitTagMode UnitTags::get_mode() {
+  return this->mode;
 }

--- a/trunk-recorder/unit_tags.h
+++ b/trunk-recorder/unit_tags.h
@@ -2,17 +2,31 @@
 #define UNIT_TAGS_H
 
 #include "unit_tag.h"
+#include "unit_tags_ota.h"
 
 #include <string>
 #include <vector>
 
+enum UnitTagMode {
+  TAG_USER_FIRST = 0, // Search user tags first, then OTA
+  TAG_OTA_FIRST = 1,  // Search OTA tags first, then user
+  TAG_USER_ONLY = 3,  // Only search user tags, ignore OTA (still write OTA to disk if configured)
+  TAG_NONE = -1       // Don't search any tags
+};
+
 class UnitTags {
-  std::vector<UnitTag *> unit_tags;
+  std::vector<UnitTag *> unit_tags;                  // Manual tags from unitTagsFile (regex patterns)
+  std::vector<UnitTagOTA *> unit_tags_ota;           // OTA tags: simple (unitID, alias) pairs
+  std::string ota_filename;
+  UnitTagMode mode = TAG_USER_FIRST;                 // Default to user tags first
 
 public:
-  UnitTags();
   void load_unit_tags(std::string filename);
+  void load_unit_tags_ota(std::string filename);
   std::string find_unit_tag(long unitID);
   void add(std::string pattern, std::string tag);
+  bool add_ota(const OTAAlias& ota_alias);
+  void set_mode(UnitTagMode mode);
+  UnitTagMode get_mode();
 };
 #endif // UNIT_TAGS_H

--- a/trunk-recorder/unit_tags_ota.cc
+++ b/trunk-recorder/unit_tags_ota.cc
@@ -1,0 +1,378 @@
+// Handling for OTA (Over-The-Air) unit tags
+// Motorola Alias Algorithm decode_mot_alias() - Copyright 2024 Ilya Smirnov / @ilyacodes. All rights reserved.
+
+#include "unit_tags_ota.h"
+
+#include <boost/log/trivial.hpp>
+#include <sstream>
+#include <iomanip>
+#include <map>
+#include <array>
+
+// OTA Motorola alias handling tools
+
+OTAAlias UnitTagsOTA::decode_motorola_alias(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages) {
+  // Validate input
+  if (messages <= 0 || messages >= (int)alias_buffer.size()) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: invalid message count " << messages;
+    return OTAAlias();
+  }
+
+  // Assemble the payload from all message fragments
+  std::string payload_hex = assemble_payload(alias_buffer, messages);
+  if (payload_hex.length() < 32) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: assembled payload too short (" << payload_hex.length() << " chars)";
+    return OTAAlias();
+  }
+
+  // Extract components
+  std::string tg = payload_hex.substr(0, 4);           // Talkgroup ID
+  std::string msg_count = payload_hex.substr(4, 2);    // # of Data blocks
+  std::string unknown_4 = payload_hex.substr(6, 4);    // [unknown] - format?
+  std::string sequence_id = payload_hex.substr(10, 1); // Sequence ID char
+  std::string unknown_3 = payload_hex.substr(11, 3);   // [unknown] - checksum?
+  std::string wacn = payload_hex.substr(14, 5);        // WACN 
+  std::string sys = payload_hex.substr(19, 3);         // System ID
+  std::string radio = payload_hex.substr(22, 6);       // Radio ID
+  std::string length_code = payload_hex.substr(28, 2); // Alias length code (first 2 chars of alias)
+  
+  static const std::map<std::string, int> length_lookup = {
+    {"94", 1}, {"32", 2}, {"95", 3}, {"9d", 4}, {"1b", 5}, {"77", 6}, {"b5", 7},
+    {"6e", 8}, {"24", 9}, {"61", 10}, {"2d", 11}, {"7d", 12}, {"83", 13}, {"29", 14}
+  };
+
+  auto it = length_lookup.find(length_code);
+  int alias_len = (it != length_lookup.end()) ? it->second : 0;
+
+  if (alias_len == 0) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: unknown alias length code: " << length_code;
+    return OTAAlias();
+  }
+
+  size_t required_len = 28 + alias_len * 4 + 4;
+  if (payload_hex.length() < required_len) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: payload too short for alias length " << alias_len;
+    return OTAAlias();
+  }
+
+  std::string alias_code = payload_hex.substr(28, alias_len * 4);
+  std::string checksum = payload_hex.substr(28 + alias_len * 4, 4);
+
+  // Convert radio ID to decimal
+  unsigned long radio_decimal = std::stoul(radio, nullptr, 16);
+  unsigned long tg_decimal = std::stoul(tg, nullptr, 16);
+
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: WACN: " << wacn << ", SYS: " << sys << ", Radio: " << radio_decimal << " (0x" << radio << ")" << ", TG: " << tg_decimal << " (0x" << tg << ")";
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: Alias Length: " << alias_len << ", Code: " << alias_code << ", Checksum: " << checksum;
+
+  // Validate CRC
+  std::string crc_payload = wacn + sys + radio + alias_code;
+  if (!validate_crc(crc_payload, checksum)) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: CRC-16/GSM check failed";
+    return OTAAlias();
+  }
+
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: CRC-16/GSM check passed";
+
+  // Convert hex string to bytes
+  std::vector<uint8_t> payload_bytes = hex_string_to_uint8_vector(crc_payload);
+  if (payload_bytes.empty()) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: failed to parse hex payload";
+    return OTAAlias();
+  }
+
+  // Need at least 8 bytes (7 byte offset + 1 byte minimum encoded data)
+  if (payload_bytes.size() < 8) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: payload too short for decoding (" << payload_bytes.size() << " bytes)";
+    return OTAAlias();
+  }
+
+  // Extract encoded portion (skip first 7 bytes)
+  std::vector<int8_t> encoded(payload_bytes.begin() + 7, payload_bytes.end());
+
+  std::string alias = decode_mot_alias(encoded);
+
+  if (!alias.empty()) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: Decoded alias: '" << alias << "' for radio " << radio_decimal << " (0x" << radio << ")" << ", TG: " << tg_decimal << " (0x" << tg << ")";
+    return OTAAlias(radio_decimal, alias, "MotoP25_FDMA", wacn, sys, tg_decimal);
+  }
+
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: Decrypt returned empty alias";
+  return OTAAlias();
+}
+
+// Phase 1 FDMA: assemble payload hex string from message buffer
+std::string UnitTagsOTA::assemble_payload(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages) {
+  std::stringstream ss;
+
+  if (alias_buffer[0].size() < 9) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: header too small";
+    return "";
+  }
+
+  // Header block - extract bytes 2-8 (7 bytes) - discarding opcode/mfr (bytes 0-1)
+  std::vector<uint8_t> header_slice(alias_buffer[0].begin() + 2, alias_buffer[0].begin() + 9);
+  ss << uint8_vector_to_hex_string(header_slice);
+
+  for (int i = 1; i <= messages; i++) {
+    if (alias_buffer[i].size() < 9) {
+      BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: alias_buffer[" << i << "] too small";
+      return "";
+    }
+
+    // Bytes 3-8: extract all, then skip first char (upper nibble of byte 3)
+    std::vector<uint8_t> data_slice(alias_buffer[i].begin() + 3, alias_buffer[i].begin() + 9);
+    ss << uint8_vector_to_hex_string(data_slice).substr(1);
+  }
+
+  return ss.str();
+}
+
+// Phase 2 TDMA: Assemble payload from 17-byte MAC PDU messages
+std::string UnitTagsOTA::assemble_payload_p2(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages) {
+  std::stringstream ss;
+
+  if (alias_buffer[0].size() < 17) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: header too small (" << alias_buffer[0].size() << " bytes)";
+    return "";
+  }
+
+  // Header block - extract bytes 3-16 (14 bytes)
+  std::vector<uint8_t> header_slice(alias_buffer[0].begin() + 3, alias_buffer[0].begin() + 17);
+  ss << uint8_vector_to_hex_string(header_slice);
+
+  // Data blocks - extract bytes 4-16 (13 bytes each)
+  for (int i = 1; i <= messages; i++) {
+    if (alias_buffer[i].size() < 17) {
+      BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: alias_buffer[" << i << "] too small (" << alias_buffer[i].size() << " bytes)";
+      return "";
+    }
+    // Bytes 4-16: extract all, then skip first char (sequence ID upper nibble)
+    std::vector<uint8_t> data_slice(alias_buffer[i].begin() + 4, alias_buffer[i].begin() + 17);
+    ss << uint8_vector_to_hex_string(data_slice).substr(1);
+  }
+
+  return ss.str();
+}
+
+// Phase 2 TDMA alias decode entry point
+OTAAlias UnitTagsOTA::decode_motorola_alias_p2(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages) {
+  // Validate input
+  if (messages <= 0 || messages >= (int)alias_buffer.size()) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: invalid message count " << messages;
+    return OTAAlias();
+  }
+
+  // Assemble the payload from all message fragments using P2 format
+  std::string payload_hex = assemble_payload_p2(alias_buffer, messages);
+  if (payload_hex.length() < 30) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: assembled payload too short (" << payload_hex.length() << " chars)";
+    return OTAAlias();
+  }
+
+  // Extract components
+  std::string tg = payload_hex.substr(0, 4);           // Talkgroup ID
+  std::string msg_count = payload_hex.substr(4, 2);    // # of Data blocks
+  std::string unknown_4 = payload_hex.substr(6, 4);    // [unknown] - format?
+  std::string sequence_id = payload_hex.substr(10, 1); // Sequence ID char
+  std::string unknown_1 = payload_hex.substr(11, 1);   // [unknown] - check digit?
+  std::string wacn = payload_hex.substr(12, 5);        // WACN
+  std::string sys = payload_hex.substr(17, 3);         // System ID
+  std::string radio = payload_hex.substr(20, 6);       // Radio ID
+  std::string length_code = payload_hex.substr(26, 2); // Alias length code (first 2 chars of alias)
+
+  static const std::map<std::string, int> length_lookup = {
+    {"94", 1}, {"32", 2}, {"95", 3}, {"9d", 4}, {"1b", 5}, {"77", 6}, {"b5", 7},
+    {"6e", 8}, {"24", 9}, {"61", 10}, {"2d", 11}, {"7d", 12}, {"83", 13}, {"29", 14}
+  };
+
+  auto it = length_lookup.find(length_code);
+  int alias_len = (it != length_lookup.end()) ? it->second : 0;
+
+  if (alias_len == 0) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: unknown alias length code: " << length_code;
+    return OTAAlias();
+  }
+
+  size_t required_len = 26 + alias_len * 4 + 4;
+  if (payload_hex.length() < required_len) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: payload too short for alias length " << alias_len;
+    return OTAAlias();
+  }
+
+  std::string alias_code = payload_hex.substr(26, alias_len * 4);
+  std::string checksum = payload_hex.substr(26 + alias_len * 4, 4);
+
+  unsigned long radio_decimal = std::stoul(radio, nullptr, 16);
+  unsigned long tg_decimal = std::stoul(tg, nullptr, 16);
+
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: WACN: " << wacn << ", SYS: " << sys << ", Radio: " << radio_decimal << " (0x" << radio << ")" << ", TG: " << tg_decimal << " (0x" << tg << ")";
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: Alias Length: " << alias_len << ", Code: " << alias_code << ", Checksum: " << checksum;
+
+  // Validate CRC
+  std::string crc_payload = wacn + sys + radio + alias_code;
+  if (!validate_crc(crc_payload, checksum)) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: CRC-16/GSM check failed for " << crc_payload;
+    return OTAAlias();
+  }
+
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: CRC-16/GSM check passed";
+
+  // Convert hex string to bytes
+  std::vector<uint8_t> payload_bytes = hex_string_to_uint8_vector(crc_payload);
+  if (payload_bytes.empty()) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: failed to parse hex payload";
+    return OTAAlias();
+  }
+
+  // Need at least 8 bytes (7 byte offset + 1 byte minimum encoded data)
+  if (payload_bytes.size() < 8) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: payload too short for decoding (" << payload_bytes.size() << " bytes)";
+    return OTAAlias();
+  }
+
+  // Extract encoded portion (skip first 7 bytes)
+  std::vector<int8_t> encoded(payload_bytes.begin() + 7, payload_bytes.end());
+
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: Encoded data size: " << encoded.size() << " bytes";
+
+  std::string alias = decode_mot_alias(encoded);
+
+  if (!alias.empty()) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: Decoded alias: '" << alias << "' for radio " << radio_decimal << " (0x" << radio << ")" << ", TG: " << tg_decimal << " (0x" << tg << ")";
+    return OTAAlias(radio_decimal, alias, "MotoP25_TDMA", wacn, sys, tg_decimal);
+  }
+
+  BOOST_LOG_TRIVIAL(debug) << "MOTOROLA P2: Decrypt returned empty alias";
+  return OTAAlias();
+}
+
+// Validate CRC-16/GSM checksum
+bool UnitTagsOTA::validate_crc(const std::string& payload_hex, const std::string& checksum_hex) {
+  // Convert hex string to bytes
+  std::vector<uint8_t> payload_bytes = hex_string_to_uint8_vector(payload_hex);
+  if (payload_bytes.empty()) return false;
+
+  // Calculate CRC-16/GSM
+  uint16_t crc = 0x0000;
+  for (size_t j = 0; j < payload_bytes.size(); ++j) {
+    uint8_t byte = static_cast<uint8_t>(payload_bytes[j]);
+    crc ^= byte << 8;
+
+    for (int i = 0; i < 8; i++) {
+      if (crc & 0x8000) {
+        crc = (crc << 1) ^ 0x1021;
+      } else {
+        crc <<= 1;
+      }
+    }
+  }
+  uint16_t crc_calc = ~crc & 0xFFFF;
+
+  // Parse expected checksum
+  uint16_t expected_crc = 0;
+  try {
+    expected_crc = std::stoi(checksum_hex, nullptr, 16);
+  } catch (const std::exception& e) {
+    BOOST_LOG_TRIVIAL(debug) << "MOTOROLA: invalid checksum format: " << checksum_hex;
+    return false;
+  }
+
+  return (crc_calc == expected_crc);
+}
+
+// De-obfuscate Motorola alias using custom algorithm
+std::string UnitTagsOTA::decode_mot_alias(const std::vector<int8_t>& encoded) {
+
+  static const uint8_t SUBSTITUTION_TABLE[256] = {
+    0xd2, 0xf6, 0xd4, 0x2b, 0x63, 0x49, 0x94, 0x5e, 0xa7, 0x5c, 0x70, 0x69, 0xf7, 0x08, 0xb1, 0x7d,
+    0x38, 0xcf, 0xcc, 0xd8, 0x51, 0x8f, 0xd5, 0x93, 0x6a, 0xf3, 0xef, 0x7e, 0xfb, 0x64, 0xf4, 0x35,
+    0x27, 0x07, 0x31, 0x14, 0x87, 0x98, 0x76, 0x34, 0xca, 0x92, 0x33, 0x1b, 0x4f, 0x8c, 0x09, 0x40,
+    0x32, 0x36, 0x77, 0x12, 0xd3, 0xc3, 0x01, 0xab, 0x72, 0x81, 0x95, 0xc9, 0xc0, 0xe9, 0x65, 0x52,
+    0x24, 0x30, 0x1c, 0xdb, 0x88, 0xe8, 0x97, 0x9d, 0x58, 0x26, 0x04, 0x39, 0xac, 0x2a, 0x9e, 0xaa,
+    0x25, 0xd7, 0xce, 0xeb, 0x96, 0xf5, 0x0e, 0x8d, 0xdc, 0xa9, 0x2f, 0xdd, 0x1f, 0xea, 0x91, 0xb7,
+    0xd6, 0x89, 0x8b, 0xd1, 0xb0, 0x99, 0x13, 0x7a, 0xe7, 0x9a, 0xb5, 0x86, 0xff, 0x46, 0x85, 0xb2,
+    0x73, 0xda, 0xbf, 0xd0, 0x71, 0xcb, 0x4d, 0x80, 0x15, 0x67, 0x16, 0x1a, 0x20, 0x8e, 0x45, 0x3e,
+    0xf2, 0x2e, 0x66, 0x90, 0x74, 0x8a, 0x6f, 0x78, 0xbb, 0x53, 0x03, 0x11, 0x68, 0xcd, 0x44, 0x17,
+    0x28, 0x5f, 0x1e, 0x84, 0x75, 0x79, 0x6e, 0x9b, 0x2c, 0xbe, 0x62, 0x2d, 0xf1, 0x7c, 0xb8, 0x83,
+    0xd9, 0x4e, 0x6d, 0x02, 0x61, 0x3d, 0xa8, 0x06, 0xb9, 0xf8, 0x9c, 0x37, 0x3a, 0x23, 0xc1, 0x50,
+    0xed, 0x9f, 0xaf, 0x3b, 0xbd, 0x82, 0xba, 0xa0, 0xdf, 0xc2, 0x47, 0x22, 0xf0, 0xee, 0xa1, 0xfe,
+    0xa2, 0x10, 0x5b, 0x48, 0x57, 0xa3, 0x05, 0x60, 0x7b, 0x0d, 0xf9, 0x6c, 0xb3, 0x56, 0x4c, 0xbc,
+    0x29, 0xa4, 0x0f, 0xec, 0xb6, 0xa5, 0xa6, 0x3c, 0x7f, 0x6b, 0xb4, 0x21, 0xad, 0xae, 0xc4, 0xc8,
+    0xc5, 0x5d, 0xde, 0xe0, 0x1d, 0x19, 0x4b, 0xc6, 0x0c, 0x3f, 0x5a, 0xc7, 0xe1, 0x59, 0x55, 0x54,
+    0x4a, 0x43, 0x42, 0xe2, 0xe3, 0xfa, 0x00, 0xe4, 0xe5, 0x18, 0x41, 0x0b, 0x0a, 0xe6, 0xfc, 0xfd,
+  };
+
+  // Precomputed inverses to avoid runtime calculation for each byte
+  static const uint8_t MODULAR_INVERSE_ODD[128] = {
+    0x01, 0xab, 0xcd, 0xb7, 0x39, 0xa3, 0xc5, 0xef, 0xf1, 0x1b, 0x3d, 0xa7, 0x29, 0x13, 0x35, 0xdf,
+    0xe1, 0x8b, 0xad, 0x97, 0x19, 0x83, 0xa5, 0xcf, 0xd1, 0xfb, 0x1d, 0x87, 0x09, 0xf3, 0x15, 0xbf,
+    0xc1, 0x6b, 0x8d, 0x77, 0xf9, 0x63, 0x85, 0xaf, 0xb1, 0xdb, 0xfd, 0x67, 0xe9, 0xd3, 0xf5, 0x9f,
+    0xa1, 0x4b, 0x6d, 0x57, 0xd9, 0x43, 0x65, 0x8f, 0x91, 0xbb, 0xdd, 0x47, 0xc9, 0xb3, 0xd5, 0x7f,
+    0x81, 0x2b, 0x4d, 0x37, 0xb9, 0x23, 0x45, 0x6f, 0x71, 0x9b, 0xbd, 0x27, 0xa9, 0x93, 0xb5, 0x5f,
+    0x61, 0x0b, 0x2d, 0x17, 0x99, 0x03, 0x25, 0x4f, 0x51, 0x7b, 0x9d, 0x07, 0x89, 0x73, 0x95, 0x3f,
+    0x41, 0xeb, 0x0d, 0xf7, 0x79, 0xe3, 0x05, 0x2f, 0x31, 0x5b, 0x7d, 0xe7, 0x69, 0x53, 0x75, 0x1f,
+    0x21, 0xcb, 0xed, 0xd7, 0x59, 0xc3, 0xe5, 0x0f, 0x11, 0x3b, 0x5d, 0xc7, 0x49, 0x33, 0x55, 0xff,
+  };
+
+  std::vector<uint8_t> decoded(encoded.size(), 0);
+
+  uint16_t accumulator = static_cast<uint16_t>(decoded.size());
+
+  for (size_t i = 0; i < decoded.size(); ++i) {
+    uint8_t encoded_byte = static_cast<uint8_t>(encoded[i]);
+    
+    uint16_t lcg_value = accumulator * 293 + 0x72E9;
+    uint8_t substituted = SUBSTITUTION_TABLE[encoded_byte];
+    uint8_t intermediate = substituted - static_cast<uint8_t>(lcg_value >> 8);
+
+    uint8_t modulus = static_cast<uint8_t>(lcg_value | 0x1);
+    uint8_t inverse = MODULAR_INVERSE_ODD[modulus >> 1];
+    
+    decoded[i] = intermediate * inverse;
+
+    accumulator += encoded_byte + 1;
+  }
+
+  std::string alias;
+  alias.reserve(decoded.size() / 2);
+  
+  for (size_t i = 0; i + 1 < decoded.size(); i += 2) {
+    uint16_t codepoint = (static_cast<uint16_t>(decoded[i]) << 8) | decoded[i + 1];
+    
+    if (codepoint > 31 && codepoint < 128) {
+      alias += static_cast<char>(codepoint);
+    }
+  }
+
+  return alias;
+}
+
+// Convert vector of uint8_t to hex string
+std::string UnitTagsOTA::uint8_vector_to_hex_string(const std::vector<uint8_t>& v)
+{
+    std::string result;
+    result.reserve(v.size() * 2);
+
+    static constexpr char hex[] = "0123456789abcdef";
+
+    for (uint8_t c : v)
+    {
+        result.push_back(hex[c / 16]);
+        result.push_back(hex[c % 16]);
+    }
+
+    return result;
+}
+
+// Convert hex string to vector of int8_t
+std::vector<uint8_t> UnitTagsOTA::hex_string_to_uint8_vector(const std::string& hex_str) {
+    std::vector<uint8_t> result;
+    result.reserve(hex_str.length() / 2);
+    for (size_t i = 0; i + 1 < hex_str.length(); i += 2) {
+        int hi = (hex_str[i] <= '9') ? hex_str[i] - '0' : (hex_str[i] & 0xF) + 9;
+        int lo = (hex_str[i+1] <= '9') ? hex_str[i+1] - '0' : (hex_str[i+1] & 0xF) + 9;
+        result.push_back(static_cast<uint8_t>((hi << 4) | lo));
+    }
+    return result;
+}

--- a/trunk-recorder/unit_tags_ota.h
+++ b/trunk-recorder/unit_tags_ota.h
@@ -1,0 +1,41 @@
+#ifndef UNIT_TAGS_OTA_H
+#define UNIT_TAGS_OTA_H
+
+#include <string>
+#include <vector>
+#include <array>
+#include <cstdint>
+
+// Result structure for OTA alias decode containing radio ID, alias text, and source
+struct OTAAlias {
+  bool success;           // Whether decode was successful
+  long radio_id;          // Radio ID from the alias payload
+  std::string alias;      // Decoded alias text
+  std::string source;     // Decoder source (e.g. "MotoP25_TDMA", "MotoP25_FDMA", etc..)
+  std::string wacn;       // WACN
+  std::string sys;        // System ID
+  long talkgroup_id;      // Talkgroup ID where alias was broadcast
+  
+  OTAAlias() : success(false), radio_id(0), alias(""), source(""), wacn(""), sys(""), talkgroup_id(0) {}
+  OTAAlias(long id, const std::string& text, const std::string& src = "", 
+           const std::string& w = "", const std::string& s = "", long tg = 0) 
+    : success(true), radio_id(id), alias(text), source(src), wacn(w), sys(s), talkgroup_id(tg) {}
+};
+
+class UnitTagsOTA {
+public:
+  // Motorola OTA (Over-The-Air) alias decoding
+  static OTAAlias decode_motorola_alias(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages);
+  static OTAAlias decode_motorola_alias_p2(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages);
+
+private:
+  // Helper functions for Motorola alias decoding
+  static std::string assemble_payload(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages);
+  static std::string assemble_payload_p2(const std::array<std::vector<uint8_t>, 10>& alias_buffer, int messages);
+  static bool validate_crc(const std::string& payload_hex, const std::string& checksum_hex);
+  static std::string decode_mot_alias(const std::vector<int8_t>& encoded_data);
+  static std::string uint8_vector_to_hex_string(const std::vector<uint8_t>& v);
+  static std::vector<uint8_t> hex_string_to_uint8_vector(const std::string& hex_str);
+};
+
+#endif // UNIT_TAGS_OTA_H


### PR DESCRIPTION
This (finally) adds support for Motorola OTA aliases on P25 systems.  These aliases are broadcast on the voice channel and visible to units in the talkgroup.  If used in the system, they can supplement the current `unitTags` metadata about participants in a call.

To this effect, the following changes are proposed:
- P25 TDMA/FDMA decoders to parse relevant opcodes, and send data into a separate message queue for processing downstream
- A c++ implementation of @ilyacodes decoder algorithm, with a pre-computed inverse lookup table for added efficiency
- Configuration settings to retain aliases between sessions (`unitTagsOTA`), and toggle whether OTA or user-defined aliases take precedence (`unitTagsMode`)
- Rewrite of `unit_tags.cc` to use the improved csv handler and support the `unitTagsOTA` cache

General operation is as follows:
- TDMA/FDMA decoder detects an alias, it is turned into plain text and provided to the parent `shortName`
- If it is a new alias, it is added to an internal list, and appended to the `unitTagsOTA` file if configured
- Calls including that radio ID will have the alias text added to the call metadata
- On each restart, trunk-recorder will clean up the alias cache, sorting entries and trimming duplicates
- If a `unitTagsOTA` entry has incomplete metadata (i.e. started as a simple [unit, alias] list), records will be enriched with additional information as it is discovered

While this PR does not handle other types of aliases, enabling the message queue will allow further analysis and development of information present on the voice channel.