### PR TITLE
Save Config Location on Startup

### DIFF
--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -95,6 +95,8 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
   int sys_count = 0;
   int source_count = 0;
 
+  config.config_file = config_file;
+
   try {
     std::ifstream f(config_file);
     data = json::parse(f);

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -23,6 +23,7 @@ struct Transmission {
 };
 
 struct Config {
+  std::string config_file;
   std::string upload_script;
   std::string upload_server;
   std::string bcfy_calls_server;


### PR DESCRIPTION
After reading the config, trunk recorder does not retain the filename of the json loaded.  Should there be interest in an interactive config editor in the future, it will be important to know what file was used to perform read/write operations on it.

While there are ways to extract parameters used during process execution, it is far easier to just save the filename itself instead of maintaining various OS-specific workarounds.

The PR simply adds a new `config_file` string to the global Config struct, and populates it on startup.