### PR TITLE
Add optional whitelist/blacklist for talkgroups on RDIO upload plugin…

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -45,30 +45,34 @@ This plugin makes it easy to connect Trunk Recorder with [Rdio Scanner](https://
 
 *Rdio Scanner System Object:*
 
-| Key              | Required | Default Value | Type   | Description                                                                                                                                                                                                 |
-| ---------------- | :------: | ------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| systemId         |    ✓     |               | number | System ID for Rdio Scanner.                                                                                                                                                                                 |
-| apiKey           |    ✓     |               | string | System-specific API key for uploading calls to Rdio Scanner. See the ApiKey section in the Rdio Scanner administrative dashboard for the value it should be.                                                |
-| shortName        |    ✓     |               | string | This should match the shortName of a system that is defined in the main section of the config file.                                                                                                         |
-| talkgroupWhitelist |        | []            | array  | Optional allow-list of talkgroups to upload for this system. If set (non-empty), the talkgroup **must** match at least one pattern to be uploaded. Patterns are glob-style (supports `*` and `?`).        |
-| talkgroupBlacklist |        | []            | array  | Optional deny-list of talkgroups to block upload for this system. If set (non-empty), any matching talkgroup will be skipped. Patterns are glob-style (supports `*` and `?`).                             |
+| Key             | Required | Default Value | Type  | Description                                                                                                                                                                                                 |
+| --------------- | :------: | ------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| systemId        |    ✓     |               | number | System ID for Rdio Scanner.                                                                                                                                                                                |
+| apiKey          |    ✓     |               | string | System-specific API key for uploading calls to Rdio Scanner. See the ApiKey section in the Rdio Scanner administrative dashboard for the value it should be.                                                |
+| shortName       |    ✓     |               | string | This should match the shortName of a system that is defined in the main section of the config file.                                                                                                         |
+| talkgroupAllow  |          | []            | array  | Optional allow-list of talkgroups to upload for this system. If set (non-empty), the talkgroup **must** match at least one pattern to be uploaded. Patterns are glob-style (supports `*` and `?`).        |
+| talkgroupDeny   |          | []            | array  | Optional deny-list of talkgroups to block upload for this system. If set (non-empty), any matching talkgroup will be skipped. Patterns are glob-style (supports `*` and `?`).                              |
 
 **Talkgroup filter rules (per-system):**
 - Talkgroup comparisons are done against the numeric talkgroup ID as a string (e.g. `50712`).
 - Patterns are glob-style:
-    - `*` matches any number of characters
-    - `?` matches a single character
-- If `talkgroupWhitelist` is provided and non-empty, the talkgroup must match at least one whitelist pattern (otherwise it is skipped).
-- If `talkgroupBlacklist` is provided and non-empty, the talkgroup must **not** match any blacklist pattern (otherwise it is skipped).
-- If both are provided, the whitelist check is applied first, then the blacklist check.
+  - `*` matches any number of characters
+  - `?` matches a single character
+- If `talkgroupAllow` is provided and non-empty, the talkgroup must match at least one allow pattern (otherwise it is skipped).
+- If `talkgroupDeny` is provided and non-empty, the talkgroup must **not** match any deny pattern (otherwise it is skipped).
+- If both are provided, the allow check is applied first, then the deny check.
 
 **Examples:**
 - Allow only talkgroups starting with `507`:
-    - `talkgroupWhitelist: ["507*"]`
+  - `talkgroupAllow: ["507*"]`
+- Allow only 5-digit talkgroups starting with `12` (uses `?`):
+  - `talkgroupAllow: ["12???"]`
 - Block a specific talkgroup:
-    - `talkgroupBlacklist: ["12345"]`
-- Block a range/prefix while allowing others:
-    - `talkgroupBlacklist: ["99*"]`
+  - `talkgroupDeny: ["12345"]`
+- Block a prefix/range while allowing others:
+  - `talkgroupDeny: ["99*"]`
+- Block a specific “slot” pattern using `?`:
+  - `talkgroupDeny: ["507?9"]`
 
 ##### Example Plugin Object:
 
@@ -81,10 +85,9 @@ This plugin makes it easy to connect Trunk Recorder with [Rdio Scanner](https://
     {
       "shortName": "test", 
       "apiKey": "fakekey", 
-      "systemId": 411,
-
-      "talkgroupWhitelist": ["507*"],
-      "talkgroupBlacklist": ["507999", "12345"]
+      "systemId": 411, 
+      "talkgroupAllow": ["507*", "12???"], 
+      "talkgroupDeny": ["507?9", "12345"]
     }
   ]
 }

--- a/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
+++ b/plugins/rdioscanner_uploader/rdioscanner_uploader.cc
@@ -21,10 +21,10 @@ struct Rdio_Scanner_System {
   bool compress_wav;
 
   // Talkgroup filters (compiled patterns)
-  std::vector<boost::regex> tg_whitelist;
-  std::vector<boost::regex> tg_blacklist;
-  std::vector<std::string> tg_whitelist_raw; // for logging/debug
-  std::vector<std::string> tg_blacklist_raw; // for logging/debug
+  std::vector<boost::regex> tg_allow;
+  std::vector<boost::regex> tg_deny;
+  std::vector<std::string> tg_allow_raw; // for logging/debug
+  std::vector<std::string> tg_deny_raw;  // for logging/debug
 };
 
 struct Rdio_Scanner_Uploader_Data {
@@ -80,13 +80,13 @@ private:
       if (!sys) return true; // no system config => don't filter here
       const std::string tg = std::to_string(talkgroup);
 
-      // If whitelist is set, MUST match it
-      if (!sys->tg_whitelist.empty() && !match_any(tg, sys->tg_whitelist)) {
+      // If allow is set, MUST match it
+      if (!sys->tg_allow.empty() && !match_any(tg, sys->tg_allow)) {
         return false;
       }
 
-      // If blacklist is set, MUST NOT match it
-      if (!sys->tg_blacklist.empty() && match_any(tg, sys->tg_blacklist)) {
+      // If deny is set, MUST NOT match it
+      if (!sys->tg_deny.empty() && match_any(tg, sys->tg_deny)) {
         return false;
       }
 
@@ -596,20 +596,20 @@ public:
 
         // Talkgroup filters per system (Optional)
         compile_patterns_from_json(
-          element, "talkgroupWhitelist",
-          sys.tg_whitelist, sys.tg_whitelist_raw,
+          element, "talkgroupAllow",
+          sys.tg_allow, sys.tg_allow_raw,
           log_prefix, sys.short_name
         );
         compile_patterns_from_json(
-          element, "talkgroupBlacklist",
-          sys.tg_blacklist, sys.tg_blacklist_raw,
+          element, "talkgroupDeny",
+          sys.tg_deny, sys.tg_deny_raw,
           log_prefix, sys.short_name
         );
 
-        if (!sys.tg_whitelist_raw.empty() || !sys.tg_blacklist_raw.empty()) {
+        if (!sys.tg_allow_raw.empty() || !sys.tg_deny_raw.empty()) {
           BOOST_LOG_TRIVIAL(info) << log_prefix << "Talkgroup filters for " << sys.short_name
-                                  << " whitelist=" << sys.tg_whitelist_raw.size()
-                                  << " blacklist=" << sys.tg_blacklist_raw.size();
+                                  << " allow=" << sys.tg_allow_raw.size()
+                                  << " deny=" << sys.tg_deny_raw.size();
         }
 
         regex_match(sys.api_key.c_str(), what, api_regex);


### PR DESCRIPTION
This PR updates the Rdio Scanner uploader plugin with (1) per-system talkgroup
allow/deny filtering using glob-style patterns, and (2) targeted libcurl
robustness + observability fixes (timeouts, better error reporting, and more
correct status/result handling). Existing configs continue to work unchanged.

### Rdio Scanner Plugin (rdioscanner_uploader) — Changes in this PR
===============================================================================

1) Per-system talkgroup filtering (new allow/deny keys + glob patterns)
----------------------------------------------------------------------
Added two optional keys on each Rdio “system” object:

- talkgroupAllow (array)
  If provided and non-empty, the talkgroup MUST match at least one pattern
  to upload. If it doesn’t match, the call is skipped.

- talkgroupDeny (array)
  If provided and non-empty, any matching talkgroup is skipped.

Patterns are glob-style and compiled to fully-anchored regex (^...$):
- * matches any number of characters
- ? matches exactly one character

Filter evaluation order:
1) allow check (if present)
2) deny check (if present)

Additional notes:
- Matching is performed against the numeric talkgroup ID coerced to a string
  (e.g., 50712), so pattern lists can contain strings or numbers.
- When a call is skipped due to filters, we log an info message that includes
  the talkgroup ID for easy debugging.

2) libcurl robustness / observability / correctness improvements
---------------------------------------------------------------
The upload path now includes these changes:

Observability:
- Adds CURLOPT_ERRORBUFFER and includes curl_err=... in error logs when present.
- Error logs now include HTTP status code in the message context.

Thread-safety / stability:
- Sets CURLOPT_NOSIGNAL=1 to avoid signal-related issues in threaded usage.

Timeouts:
- Sets CURLOPT_CONNECTTIMEOUT_MS (e.g., 15000ms).
- Sets CURLOPT_TIMEOUT_MS (e.g., 120000ms).

Correctness fixes in multi + HTTP handling:
- Extracts the per-transfer CURLcode from curl_multi_info_read() so we can tell
  whether the transfer itself failed vs. a non-2xx HTTP response.
- Captures CURLINFO_RESPONSE_CODE BEFORE cleaning up the easy handle
  (the old flow attempted to read it after cleanup).

Success criteria expanded:
- Treats any successful HTTP status as success via is_success_http_status(...),
  and explicitly supports 202 Accepted (logs “Accepted (202) - stub cached” vs.
  “Success” for other success statuses).

Safer lifetime for mime string inputs:
- Uses explicit std::string variables for fields passed into curl_mime_data()
  (audioType/dateTime/system/talkgroup/etc.) so the backing memory is guaranteed
  to remain valid until after the request completes.

Net effect
----------
- Adds per-system talkgroup allow/deny filtering with glob patterns.
- Makes uploads more reliable (timeouts + NOSIGNAL), fixes status handling, and
  improves diagnostics (curl error buffer + clearer error/success logging).
