### PR TITLE
Round freqList and srcList 'pos' values to 2 decimal places.

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -2,6 +2,7 @@
 #include "../plugin_manager/plugin_manager.h"
 #include <boost/filesystem.hpp>
 #include <filesystem>
+#include <cmath>
 namespace fs = std::filesystem;
 
 const int Call_Concluder::MAX_RETRY = 2;
@@ -96,7 +97,7 @@ int create_call_json(Call_Data_t& call_info) {
     json_data["freqList"] += {
         {"freq", int(call_info.freq)},
         {"time", call_info.transmission_error_list[i].time},
-        {"pos", call_info.transmission_error_list[i].position},
+        {"pos", round(call_info.transmission_error_list[i].position * 100.0) / 100.0},  // round to 2 decimal places
         {"len", call_info.transmission_error_list[i].total_len},
         {"error_count", int(call_info.transmission_error_list[i].error_count)},
         {"spike_count", int(call_info.transmission_error_list[i].spike_count)}};
@@ -106,7 +107,7 @@ int create_call_json(Call_Data_t& call_info) {
     json_data["srcList"] += {
         {"src", int(call_info.transmission_source_list[i].source)},
         {"time", call_info.transmission_source_list[i].time},
-        {"pos", call_info.transmission_source_list[i].position},
+        {"pos", round(call_info.transmission_error_list[i].position * 100.0) / 100.0},  // round to 2 decimal places
         {"emergency", int(call_info.transmission_source_list[i].emergency)},
         {"signal_system", call_info.transmission_source_list[i].signal_system},
         {"tag", call_info.transmission_source_list[i].tag}};


### PR DESCRIPTION
Occasionally, the `"pos"` keys' values in the `"freqList"` and `"srcList"` stanzas of the call metadata JSON file are presented to many decimal places.
This can occur when the binary representation of a floating point number is serialized.  In this case, `pos` in T-R is a double; which has an approximate precision of 15 decimal places.
This change rounds the `pos` value to 2 decimal places, similar to what the OpenMHz uploader plugin does.

Example fragment from call metadata JSON:
```
...
  "freqList": [
    {
      "freq": 852550000,
      "time": 1769708284,
      "pos": 0.0,
      "len": 1.52,
      "error_count": 0,
      "spike_count": 0
    },
    {
      "freq": 852550000,
      "time": 1769708286,
      "pos": 1.52,
      "len": 9.52,
      "error_count": 0,
      "spike_count": 0
    },
    {
      "freq": 852550000,
      "time": 1769708298,
      "pos": 11.04,
      "len": 3.28,
      "error_count": 0,
      "spike_count": 0
    },
    {
      "freq": 852550000,
      "time": 1769708303,
      "pos": 14.320000000000003,
      "len": 2.16,
      "error_count": 0,
      "spike_count": 0
    },
    {
      "freq": 852550000,
      "time": 1769708307,
      "pos": 16.479999999999997,
      "len": 1.6,
      "error_count": 0,
      "spike_count": 0
    },
    {
      "freq": 852550000,
      "time": 1769708310,
      "pos": 18.08,
      "len": 10.16,
      "error_count": 0,
      "spike_count": 0
    },
    {
      "freq": 852550000,
      "time": 1769708321,
      "pos": 28.24,
      "len": 4.84,
      "error_count": 0,
      "spike_count": 0
    },
    {
      "freq": 852550000,
      "time": 1769708327,
      "pos": 33.08,
      "len": 1.4,
      "error_count": 0,
      "spike_count": 0
    }
  ],
  "srcList": [
    {
      "src": 1899003,
      "time": 1769708284,
      "pos": 0.0,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    },
    {
      "src": 45410,
      "time": 1769708286,
      "pos": 1.52,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    },
    {
      "src": 45410,
      "time": 1769708298,
      "pos": 11.04,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    },
    {
      "src": 45410,
      "time": 1769708303,
      "pos": 14.320000000000003,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    },
    {
      "src": 1899003,
      "time": 1769708307,
      "pos": 16.479999999999997,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    },
    {
      "src": 45410,
      "time": 1769708310,
      "pos": 18.08,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    },
    {
      "src": 45236,
      "time": 1769708321,
      "pos": 28.24,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    },
    {
      "src": 1899003,
      "time": 1769708327,
      "pos": 33.08,
      "emergency": 0,
      "signal_system": "",
      "tag": ""
    }
  ]
...
```

