### PR TITLE
Fix P25 Control retune crash

### DIFF
--- a/trunk-recorder/monitor_systems.cc
+++ b/trunk-recorder/monitor_systems.cc
@@ -716,9 +716,6 @@ void retune_system(System *sys, gr::top_block_sptr &tb, std::vector<Source *> &s
         if (system->get_system_type() == "smartnet") {
           system->set_source(source);
           // We must lock the flow graph in order to disconnect and reconnect blocks
-          // ( We have gone back and forth on whether this should be lock/unlock or stop/wait/start.
-          //   If there are unexplained issues around control channel tuning, we should look at alternet
-          //   approaches. See PR #1090 )
           tb->lock();
           tb->disconnect(current_source->get_src_block(), 0, system->smartnet_trunking, 0);
           system->smartnet_trunking = smartnet_impl::make(control_channel_freq, source->get_center(), source->get_rate(), system->get_msg_queue(), system->get_sys_num());
@@ -728,6 +725,9 @@ void retune_system(System *sys, gr::top_block_sptr &tb, std::vector<Source *> &s
         } else if (system->get_system_type() == "p25") {
           system->set_source(source);
           // We must lock the flow graph in order to disconnect and reconnect blocks
+          // ( We have gone back and forth on whether this should be lock/unlock or stop/wait/start.
+          //   If there are unexplained issues around control channel tuning, we should look at alternet
+          //   approaches. See PR #1090 )
           tb->lock();
           tb->disconnect(current_source->get_src_block(), 0, system->p25_trunking, 0);
           system->p25_trunking = make_p25_trunking(control_channel_freq, source->get_center(), source->get_rate(), system->get_msg_queue(), system->get_qpsk_mod(), system->get_sys_num());


### PR DESCRIPTION
Change tb->stop() and tb->start() to tb->lock() and tb->unlock, as they were prior to the v5.0 commit. This appears to the cause of  crashes when returning the control channel as referenced in issues #1034 #997 #1032 #972 #980.