### PR TITLE
Vocoder Fix

### DIFF
--- a/lib/op25_repeater/lib/p25p1_fdma.cc
+++ b/lib/op25_repeater/lib/p25p1_fdma.cc
@@ -873,7 +873,7 @@ namespace gr {
 					}
 					double error_history_avg = error_history_total / error_history_len;
 
-					double error_history_sqrt;
+					double error_history_sqrt = 0.0;
 					for (int j=0; j<error_history_len; j++){
 						error_history_sqrt += pow((error_history[j] - error_history_avg), 2);
 					}
@@ -906,7 +906,7 @@ namespace gr {
                                 int16_t frame_vector[8];
 
                                 for (int i=0; i < 8; i++) { // Ugh. For compatibility convert imbe params from uint32_t to int16_t
-                                    frame_vector[i] = u[i];
+                                    frame_vector[i] = u[i] & 0xFFFF;
                                 }
                                 frame_vector[7] >>= 1;
                                 vocoder.imbe_decode(frame_vector, snd);

--- a/lib/op25_repeater/lib/p25p2_tdma.cc
+++ b/lib/op25_repeater/lib/p25p2_tdma.cc
@@ -394,7 +394,7 @@ void p25p2_tdma::decode_mac_msg(const uint8_t byte_buf[], const unsigned int len
 {
 	std::string s;
 	std::string pdu;
-	uint8_t b1b2, mco, op, mfid, msg_ptr, msg_len, len_remaining;
+	uint8_t b1b2, mco, op, mfid, msg_ptr, msg_len = 0, len_remaining;
     uint16_t colorcd;
 
 	colorcd = nac;
@@ -696,6 +696,7 @@ int p25p2_tdma::handle_acch_frame(const uint8_t dibits[], bool fast, bool is_lcc
 void p25p2_tdma::handle_voice_frame(const uint8_t dibits[], int slot, int voice_subframe)
 {
 	int16_t samples_buf[IMBE_SAMPLES_PER_FRAME];
+	memset(samples_buf, 0, sizeof(samples_buf));
 	packed_codeword p_cw;
     bool audio_valid = !encrypted();
 	int u[4];
@@ -704,7 +705,7 @@ void p25p2_tdma::handle_voice_frame(const uint8_t dibits[], int slot, int voice_
 	int16_t snd;
 	int K;
 	int rc = -1;
-	frame_type fr_type;
+	frame_type fr_type = FT_4V_0;
 
 	// Deinterleave and figure out frame type:
 	errs = vf.process_vcw(&errs_mp, dibits, b, u);

--- a/lib/op25_repeater/lib/vocoder_impl.cc
+++ b/lib/op25_repeater/lib/vocoder_impl.cc
@@ -118,7 +118,7 @@ vocoder_impl::general_work_decode (int noutput_items,
 
   consume_each (ninput_items[0]);
 
-  uint16_t *out = reinterpret_cast<uint16_t*>(output_items[0]);
+  int16_t *out = reinterpret_cast<int16_t*>(output_items[0]);
   const int n = std::min(static_cast<int>(output_queue_decode.size()), noutput_items);
   if(0 < n) {
      copy(output_queue_decode.begin(), output_queue_decode.begin() + n, out);


### PR DESCRIPTION
Based upon some LLM analysis, Claude did the following: Summary
#	Issue	Verdict	Action
1	Uninitialized error_history_sqrt	Real bug (High)	Fixed: initialized to 0.0 2	Uninitialized samples_buf	Real bug (High)	Fixed: added memset to zero buffer 3	uint16_t* type mismatch	Real bug (Medium)	Fixed: changed to int16_t* 4	uint32_t to int16_t truncation	Low risk, defensive	Fixed: added & 0xFFFF mask 5	Missing default in fr_type switch	Real (Medium)	Fixed: initialized fr_type = FT_4V_0 6	crc12 returns 0 on overflow	Not practical	Skipped — not an audio issue 7	msg_len uninitialized for 0x01/0x21	False positive — b1b2 is always 0 for those opcodes	Added defensive init to 0 anyway 8	Loop variable shadowing	Not a bug	Skipped — cosmetic only The two highest-impact fixes for audio quality are Issue 1 (spike detection was comparing against garbage, making error tracking unreliable) and Issue 2 (stack garbage was being pushed directly to the audio output when frames had high error rates, producing pops/noise instead of silence).