### PR TITLE
Add `call_num` key/value to the `Call JSON` object.

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -749,6 +749,7 @@ static int run_upload_script_argv(const Call_Data_t &call_info) {
 
 int create_call_json(Call_Data_t &call_info) {
   nlohmann::ordered_json json_data = {
+      {"call_num",              long(call_info.call_num)},
       {"freq",                  int(call_info.freq)},
       {"freq_error",            int(call_info.freq_error)},
       {"signal",                int(call_info.signal)},


### PR DESCRIPTION
As the MQTT `call_start` and `call_end` messages contain the `call_num` key/value, this helps consumers match call events with audio.

Example new `audio` MQTT message (without encoded audio for brevity):
```
{
    "type": "audio",
    "call": {
        "audio_wav_base64": "",
        "audio_m4a_base64": "",
        "metadata": {
            "call_num": 145,
            "freq": 460162500,
            "freq_error": -11,
            "signal": -12,
            "noise": -56,
            "source_num": 0,
            "recorder_num": 0,
            "tdma_slot": 0,
            "phase2_tdma": 0,
            "start_time": 1775355557,
            "stop_time": 1775355566,
            "start_time_ms": 1775355557368,
            "stop_time_ms": 1775355566939,
            "emergency": 0,
            "priority": 0,
            "mode": 0,
            "duplex": 0,
            "encrypted": 0,
            "call_length": 10,
            "call_length_ms": 9571,
            "talkgroup": 27,
            "talkgroup_tag": "Town FD Dis",
            "talkgroup_description": "",
            "talkgroup_group_tag": "Fire Dispatch",
            "talkgroup_group": "Town Fire",
            "color_code": -1,
            "audio_type": "analog",
            "short_name": "AnyName",
            "freqList": [
                {
                    "freq": 460162500,
                    "time": 1775355557,
                    "pos": 0.0,
                    "len": 9.571,
                    "error_count": 0,
                    "spike_count": 0
                }
            ],
            "srcList": [
                {
                    "src": 551290,
                    "time": 1775355557,
                    "pos": 0.0,
                    "emergency": 0,
                    "signal_system": "",
                    "tag": "",
                    "tag_ota": ""
                }
            ]
        }
    },
    "timestamp": 1775355574,
    "instance_id": "InstanceA"
}
```