### PR TITLE
Enable simplestream plugin in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ add_subdirectory(plugins/openmhz_uploader)
 add_subdirectory(plugins/broadcastify_uploader)
 add_subdirectory(plugins/unit_script)
 add_subdirectory(plugins/rdioscanner_uploader)
-#add_subdirectory(plugins/simplestream)
+add_subdirectory(plugins/simplestream)
 
 # Add user plugins located in /user_plugins
 # Matching: /user_plugins/${plugin_dir}/CMakeLists.txt


### PR DESCRIPTION
Re-enables the simple stream plugin being build by default in the CMake file.

Re discussion in #1107 to bring this back to default being built as well as multiple conversations in the discord.