### PR TITLE
Audio path fixes

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -324,7 +324,7 @@ Each system can optionally define an `audio_postprocess` object to control clean
 ```json
 "audio_postprocess": {
 "enabled": false,
-"debug_wav": false,
+"outputRawAudio": false,
 "highpass_hz": 0,
 "lowpass_hz": 0,
 "bandreject_hz": 0,
@@ -343,7 +343,7 @@ Each system can optionally define an `audio_postprocess` object to control clean
 | Key                 | Required | Default Value | Type                  | Description |
 | ------------------- | :------: | ------------- | --------------------- | ----------- |
 | enabled             |          | false         | **true** / **false**  | Enables the structured cleanup filter chain. This controls `highpass_hz`, `lowpass_hz`, `bandreject_hz`, `bandreject_width_hz`, and use of `ffmpeg_filter` as the base filter chain. It does **not** control loudnorm. |
-| debug_wav           |          | false         | **true** / **false**  | When enabled, saves an additional `.debug.wav` file alongside the normal call output. This file is a verbatim concatenation of the raw transmission recordings with no filtering, resampling, or loudness normalization applied — the original sample rate and bit depth are preserved exactly. Useful for comparing the effect of post-processing settings or diagnosing audio quality issues. See **Debug WAV** below. |
+| outputRawAudio      |          | false         | **true** / **false**  | When enabled, saves an additional `.raw.wav` file alongside the normal call output. This file is a verbatim concatenation of the raw transmission recordings with no filtering, resampling, or loudness normalization applied — the original sample rate and bit depth are preserved exactly. Useful for comparing the effect of post-processing settings or diagnosing audio quality issues. See **Raw Audio Output** below. |
 | highpass_hz         |          | 0             | number                | Adds an FFmpeg highpass filter when greater than 0. |
 | lowpass_hz          |          | 0             | number                | Adds an FFmpeg lowpass filter when greater than 0. |
 | bandreject_hz       |          | 0             | number                | Adds an FFmpeg bandreject filter center frequency when greater than 0. |
@@ -405,15 +405,15 @@ If that also fails, Trunk Recorder falls back to unfiltered rendering.
 - if `ffmpeg_filter` already contains `loudnorm`, built-in loudnorm settings are skipped to avoid duplicate normalization
 - the old implicit `dynaudnorm` fallback is no longer used
 
-### Debug WAV
+### Raw Audio Output
 
-When `debug_wav` is `true`, Trunk Recorder writes an additional file named `<stem>.debug.wav` to the capture directory after each call concludes.
+When `outputRawAudio` is `true`, Trunk Recorder writes an additional file named `<stem>.raw.wav` to the capture directory after each call concludes.
 
 The debug file is produced by concatenating the raw transmission recordings using an FFmpeg stream copy — no decoding, re-encoding, filtering, resampling, or loudness normalization is applied. The audio is bit-for-bit identical to what the recorder wrote, just joined into a single file.
 
 **File retention:**
 
-- The `.debug.wav` is always kept in the capture directory, even when `audioArchive` is `false`. When the normal processed audio is deleted after upload, the debug file remains.
+- The `.raw.wav` is always kept in the capture directory, even when `audioArchive` is `false`. When the normal processed audio is deleted after upload, the raw audio file remains.
 - If a call fails all plugin retry attempts and `archiveFilesOnFailure` is also `false`, the debug file is removed along with the other call artifacts.
 
 **Typical use cases:**
@@ -457,7 +457,7 @@ The debug file is produced by concatenating the raw transmission recordings usin
 "loudnorm_tp": -0.1,
 "loudnorm_lra": 11.0,
 "ffmpeg_filter": "",
-"debug_wav": false
+"outputRawAudio": false
 }
 ```
 
@@ -499,16 +499,16 @@ If you include `loudnorm` directly in `ffmpeg_filter`, the built-in loudnorm set
 }
 ```
 
-#### Debug WAV alongside processed output
+#### Raw audio output alongside processed output
 
-Saves a verbatim `.debug.wav` next to the normal processed call files. All other post-processing settings still apply to the normal output.
+Saves a verbatim `.raw.wav` next to the normal processed call files. All other post-processing settings still apply to the normal output.
 
 ```json
 "audio_postprocess": {
 "enabled": true,
 "highpass_hz": 200,
 "loudnorm": true,
-"debug_wav": true
+"outputRawAudio": true
 }
 ```
 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -324,6 +324,7 @@ Each system can optionally define an `audio_postprocess` object to control clean
 ```json
 "audio_postprocess": {
 "enabled": false,
+"debug_wav": false,
 "highpass_hz": 0,
 "lowpass_hz": 0,
 "bandreject_hz": 0,
@@ -342,6 +343,7 @@ Each system can optionally define an `audio_postprocess` object to control clean
 | Key                 | Required | Default Value | Type                  | Description |
 | ------------------- | :------: | ------------- | --------------------- | ----------- |
 | enabled             |          | false         | **true** / **false**  | Enables the structured cleanup filter chain. This controls `highpass_hz`, `lowpass_hz`, `bandreject_hz`, `bandreject_width_hz`, and use of `ffmpeg_filter` as the base filter chain. It does **not** control loudnorm. |
+| debug_wav           |          | false         | **true** / **false**  | When enabled, saves an additional `.debug.wav` file alongside the normal call output. This file is a verbatim concatenation of the raw transmission recordings with no filtering, resampling, or loudness normalization applied — the original sample rate and bit depth are preserved exactly. Useful for comparing the effect of post-processing settings or diagnosing audio quality issues. See **Debug WAV** below. |
 | highpass_hz         |          | 0             | number                | Adds an FFmpeg highpass filter when greater than 0. |
 | lowpass_hz          |          | 0             | number                | Adds an FFmpeg lowpass filter when greater than 0. |
 | bandreject_hz       |          | 0             | number                | Adds an FFmpeg bandreject filter center frequency when greater than 0. |
@@ -352,6 +354,7 @@ Each system can optionally define an `audio_postprocess` object to control clean
 | loudnorm_tp         |          | -0.1          | number                | FFmpeg loudnorm true peak target. |
 | loudnorm_lra        |          | 11.0          | number                | FFmpeg loudnorm loudness range target. |
 | ffmpeg_filter       |          | ""            | string                | Optional custom FFmpeg filter chain used as the base filter chain when `enabled=true`. If this already includes `loudnorm`, built-in loudnorm settings are skipped to avoid duplicate normalization. |
+
 
 ### How it works
 
@@ -402,6 +405,23 @@ If that also fails, Trunk Recorder falls back to unfiltered rendering.
 - if `ffmpeg_filter` already contains `loudnorm`, built-in loudnorm settings are skipped to avoid duplicate normalization
 - the old implicit `dynaudnorm` fallback is no longer used
 
+### Debug WAV
+
+When `debug_wav` is `true`, Trunk Recorder writes an additional file named `<stem>.debug.wav` to the capture directory after each call concludes.
+
+The debug file is produced by concatenating the raw transmission recordings using an FFmpeg stream copy — no decoding, re-encoding, filtering, resampling, or loudness normalization is applied. The audio is bit-for-bit identical to what the recorder wrote, just joined into a single file.
+
+**File retention:**
+
+- The `.debug.wav` is always kept in the capture directory, even when `audioArchive` is `false`. When the normal processed audio is deleted after upload, the debug file remains.
+- If a call fails all plugin retry attempts and `archiveFilesOnFailure` is also `false`, the debug file is removed along with the other call artifacts.
+
+**Typical use cases:**
+
+- Comparing processed output against the unmodified source to evaluate filter or loudnorm settings.
+- Diagnosing audio artifacts introduced by post-processing.
+- Retaining a pristine archive copy while still distributing the normalized version.
+
 ### Example configurations
 
 #### Cleanup filters only
@@ -436,7 +456,8 @@ If that also fails, Trunk Recorder falls back to unfiltered rendering.
 "loudnorm_i": -16.0,
 "loudnorm_tp": -0.1,
 "loudnorm_lra": 11.0,
-"ffmpeg_filter": ""
+"ffmpeg_filter": "",
+"debug_wav": false
 }
 ```
 
@@ -475,6 +496,19 @@ If you include `loudnorm` directly in `ffmpeg_filter`, the built-in loudnorm set
 "loudnorm_tp": -0.1,
 "loudnorm_lra": 11.0,
 "ffmpeg_filter": "highpass=f=200,loudnorm=I=-16:TP=-0.1:LRA=11"
+}
+```
+
+#### Debug WAV alongside processed output
+
+Saves a verbatim `.debug.wav` next to the normal processed call files. All other post-processing settings still apply to the normal output.
+
+```json
+"audio_postprocess": {
+"enabled": true,
+"highpass_hz": 200,
+"loudnorm": true,
+"debug_wav": true
 }
 ```
 

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -549,7 +549,7 @@ static bool write_concat_list(const std::vector<std::string> &input_files,
     return false;
   }
   for (const auto &f : input_files)
-    list_file << "file '" << escape_ffmpeg_concat_path(f) << "'\n";
+    list_file << "file '" << escape_ffmpeg_concat_path(fs::path(f).filename().string()) << "'\n";
 
   list_file.flush();
   if (!list_file.good()) {
@@ -582,9 +582,9 @@ static int render_call_audio_artifacts(const Call_Data_t &call_info,
     return -1;
   }
 
-  const std::string list_filename = call_info.raw_filename.empty()
-                                        ? (call_info.filename     + ".concat.txt")
-                                        : (call_info.raw_filename + ".concat.txt");
+  const fs::path transmission_dir = fs::path(input_files[0]).parent_path();
+  const std::string list_filename = (transmission_dir /
+      (fs::path(call_info.filename).filename().string() + ".concat.txt")).string();
   if (!write_concat_list(input_files, list_filename)) return -1;
 
   const std::string loghdr =
@@ -878,10 +878,8 @@ void remove_call_files(const Call_Data_t &call_info, bool plugin_failure) {
     }
     for (const auto &t : call_info.transmission_list)
       if (checkIfFile(t.filename)) std::remove(t.filename.c_str());
-    if (checkIfFile(call_info.raw_filename))
-      std::remove(call_info.raw_filename.c_str());
   } else {
-    for (const std::string &f : {call_info.raw_filename, call_info.filename, call_info.converted})
+    for (const std::string &f : {call_info.filename, call_info.converted})
       if (checkIfFile(f)) std::remove(f.c_str());
     for (const auto &t : call_info.transmission_list)
       if (checkIfFile(t.filename)) std::remove(t.filename.c_str());
@@ -1023,7 +1021,6 @@ Call_Data_t Call_Concluder::create_base_filename(Call *call,
   }
 
   const std::string stem = base_filename + "-call_" + std::to_string(call->get_call_num());
-  call_info.raw_filename    = stem + ".raw.wav";
   call_info.filename        = stem + ".wav";
   call_info.status_filename = stem + ".json";
   call_info.converted       = stem + ".m4a";

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -560,33 +560,33 @@ static bool write_concat_list(const std::vector<std::string> &input_files,
   return true;
 }
 
-static void write_debug_wav(const Call_Data_t &call_info,
-                            const std::vector<std::string> &input_files) {
+static void write_raw_audio_output(const Call_Data_t &call_info,
+                                   const std::vector<std::string> &input_files) {
   const std::string loghdr =
       log_header(call_info.short_name, call_info.call_num, call_info.talkgroup_display, call_info.freq);
 
   const fs::path transmission_dir = fs::path(input_files[0]).parent_path();
   const std::string list_filename = (transmission_dir /
-      (fs::path(call_info.debug_filename).filename().string() + ".concat.txt")).string();
+      (fs::path(call_info.raw_audio_filename).filename().string() + ".concat.txt")).string();
 
   if (!write_concat_list(input_files, list_filename)) {
-    BOOST_LOG_TRIVIAL(warning) << loghdr << "\033[0;33mDebug WAV: failed to write concat list\033[0m";
+    BOOST_LOG_TRIVIAL(warning) << loghdr << "\033[0;33mRaw audio output: failed to write concat list\033[0m";
     return;
   }
 
   const std::vector<std::string> args = {
       "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
       "-f", "concat", "-safe", "0", "-i", list_filename,
-      "-c:a", "copy", call_info.debug_filename
+      "-c:a", "copy", call_info.raw_audio_filename
   };
 
-  const int rc = run_process_wait(args, loghdr, "ffmpeg debug wav");
+  const int rc = run_process_wait(args, loghdr, "ffmpeg raw audio output");
   std::remove(list_filename.c_str());
 
   if (rc != 0)
-    BOOST_LOG_TRIVIAL(warning) << loghdr << "\033[0;33mDebug WAV write failed; skipping\033[0m";
+    BOOST_LOG_TRIVIAL(warning) << loghdr << "\033[0;33mRaw audio output write failed; skipping\033[0m";
   else
-    BOOST_LOG_TRIVIAL(debug) << loghdr << "Debug WAV written: " << call_info.debug_filename;
+    BOOST_LOG_TRIVIAL(debug) << loghdr << "Raw audio output written: " << call_info.raw_audio_filename;
 }
 
 static void append_common_metadata_args(std::vector<std::string> &args,
@@ -913,7 +913,7 @@ void remove_call_files(const Call_Data_t &call_info, bool plugin_failure) {
     for (const auto &t : call_info.transmission_list)
       if (checkIfFile(t.filename)) std::remove(t.filename.c_str());
 
-    // Debug WAV is intentionally kept on success (audio_archive=false) — it is
+    // Raw audio output is intentionally kept on success (audio_archive=false) — it is
   }
 
   const bool keep_json = call_info.call_log || (plugin_failure && call_info.archive_files_on_failure);
@@ -974,8 +974,8 @@ Call_Data_t upload_call_worker(Call_Data_t call_info) {
       return call_info;
     }
 
-    if (call_info.audio_postprocess.debug_wav)
-      write_debug_wav(call_info, input_files);
+    if (call_info.audio_postprocess.output_raw_audio)
+      write_raw_audio_output(call_info, input_files);
 
     if (!trim_whitespace(call_info.upload_script).empty()) {
       if (run_upload_script_argv(call_info) != 0) {
@@ -1058,7 +1058,7 @@ Call_Data_t Call_Concluder::create_base_filename(Call *call,
   call_info.filename        = stem + ".wav";
   call_info.status_filename = stem + ".json";
   call_info.converted       = stem + ".m4a";
-  call_info.debug_filename  = stem + ".debug.wav";
+  call_info.raw_audio_filename = stem + ".raw.wav";
 
   return call_info;
 }
@@ -1105,7 +1105,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, const Conf
   call_info.audio_postprocess.loudnorm_tp         = sys->get_audio_loudnorm_tp();
   call_info.audio_postprocess.loudnorm_lra        = sys->get_audio_loudnorm_lra();
   call_info.audio_postprocess.ffmpeg_filter       = sys->get_audio_ffmpeg_filter();
-  call_info.audio_postprocess.debug_wav           = sys->get_audio_debug_wav();
+  call_info.audio_postprocess.output_raw_audio     = sys->get_audio_output_raw_audio();
 
   call_info.talkgroup                 = call->get_talkgroup();
   call_info.talkgroup_display         = call->get_talkgroup_display();

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -560,6 +560,35 @@ static bool write_concat_list(const std::vector<std::string> &input_files,
   return true;
 }
 
+static void write_debug_wav(const Call_Data_t &call_info,
+                            const std::vector<std::string> &input_files) {
+  const std::string loghdr =
+      log_header(call_info.short_name, call_info.call_num, call_info.talkgroup_display, call_info.freq);
+
+  const fs::path transmission_dir = fs::path(input_files[0]).parent_path();
+  const std::string list_filename = (transmission_dir /
+      (fs::path(call_info.debug_filename).filename().string() + ".concat.txt")).string();
+
+  if (!write_concat_list(input_files, list_filename)) {
+    BOOST_LOG_TRIVIAL(warning) << loghdr << "\033[0;33mDebug WAV: failed to write concat list\033[0m";
+    return;
+  }
+
+  const std::vector<std::string> args = {
+      "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+      "-f", "concat", "-safe", "0", "-i", list_filename,
+      "-c:a", "copy", call_info.debug_filename
+  };
+
+  const int rc = run_process_wait(args, loghdr, "ffmpeg debug wav");
+  std::remove(list_filename.c_str());
+
+  if (rc != 0)
+    BOOST_LOG_TRIVIAL(warning) << loghdr << "\033[0;33mDebug WAV write failed; skipping\033[0m";
+  else
+    BOOST_LOG_TRIVIAL(debug) << loghdr << "Debug WAV written: " << call_info.debug_filename;
+}
+
 static void append_common_metadata_args(std::vector<std::string> &args,
                                         const std::string &date,
                                         const std::string &short_name,
@@ -883,6 +912,8 @@ void remove_call_files(const Call_Data_t &call_info, bool plugin_failure) {
       if (checkIfFile(f)) std::remove(f.c_str());
     for (const auto &t : call_info.transmission_list)
       if (checkIfFile(t.filename)) std::remove(t.filename.c_str());
+
+    // Debug WAV is intentionally kept on success (audio_archive=false) — it is
   }
 
   const bool keep_json = call_info.call_log || (plugin_failure && call_info.archive_files_on_failure);
@@ -942,6 +973,9 @@ Call_Data_t upload_call_worker(Call_Data_t call_info) {
       call_info.status = FAILED;
       return call_info;
     }
+
+    if (call_info.audio_postprocess.debug_wav)
+      write_debug_wav(call_info, input_files);
 
     if (!trim_whitespace(call_info.upload_script).empty()) {
       if (run_upload_script_argv(call_info) != 0) {
@@ -1024,6 +1058,7 @@ Call_Data_t Call_Concluder::create_base_filename(Call *call,
   call_info.filename        = stem + ".wav";
   call_info.status_filename = stem + ".json";
   call_info.converted       = stem + ".m4a";
+  call_info.debug_filename  = stem + ".debug.wav";
 
   return call_info;
 }
@@ -1070,6 +1105,7 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, const Conf
   call_info.audio_postprocess.loudnorm_tp         = sys->get_audio_loudnorm_tp();
   call_info.audio_postprocess.loudnorm_lra        = sys->get_audio_loudnorm_lra();
   call_info.audio_postprocess.ffmpeg_filter       = sys->get_audio_ffmpeg_filter();
+  call_info.audio_postprocess.debug_wav           = sys->get_audio_debug_wav();
 
   call_info.talkgroup                 = call->get_talkgroup();
   call_info.talkgroup_display         = call->get_talkgroup_display();

--- a/trunk-recorder/call_impl.h
+++ b/trunk-recorder/call_impl.h
@@ -130,7 +130,7 @@ protected:
   std::string transmission_filename;
   std::string converted_filename;
   std::string status_filename;
-  std::string debug_filename;
+  std::string raw_audio_filename;
   std::string sigmf_filename;
   std::string path;
   bool phase2_tdma;

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -387,7 +387,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         double audio_loudnorm_tp = -0.1;
         double audio_loudnorm_lra = 11.0;
         std::string audio_ffmpeg_filter = "";
-        bool audio_debug_wav = false;
+        bool audio_output_raw_audio = false;
 
         if (element.contains("audio_postprocess") && element["audio_postprocess"].is_object()) {
           const json &audio_post = element["audio_postprocess"];
@@ -405,7 +405,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
           audio_loudnorm_lra = audio_post.value("loudnorm_lra", 11.0);
 
           audio_ffmpeg_filter = audio_post.value("ffmpeg_filter", "");
-          audio_debug_wav = audio_post.value("debug_wav", false);
+          audio_output_raw_audio = audio_post.value("outputRawAudio", false);
         }
 
         if (audio_highpass_hz < 0) {
@@ -439,7 +439,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         system->set_audio_loudnorm_tp(audio_loudnorm_tp);
         system->set_audio_loudnorm_lra(audio_loudnorm_lra);
         system->set_audio_ffmpeg_filter(audio_ffmpeg_filter);
-        system->set_audio_debug_wav(audio_debug_wav);
+        system->set_audio_output_raw_audio(audio_output_raw_audio);
 
         BOOST_LOG_TRIVIAL(info) << "Audio Postprocess Enabled: " << system->get_audio_postprocess_enabled();
         BOOST_LOG_TRIVIAL(info) << "Audio Highpass (Hz): " << system->get_audio_highpass_hz();
@@ -457,7 +457,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         } else {
           BOOST_LOG_TRIVIAL(info) << "Audio FFmpeg Filter Override: <none>";
         }
-        BOOST_LOG_TRIVIAL(info) << "Audio Debug WAV: " << system->get_audio_debug_wav();
+        BOOST_LOG_TRIVIAL(info) << "Audio Output Raw Audio: " << system->get_audio_output_raw_audio();
         system->set_unit_tags_file(element.value("unitTagsFile", ""));
         BOOST_LOG_TRIVIAL(info) << "Unit Tags File: " << system->get_unit_tags_file();
         system->set_unit_tags_ota_file(element.value("unitTagsOTA", ""));

--- a/trunk-recorder/config.cc
+++ b/trunk-recorder/config.cc
@@ -387,6 +387,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         double audio_loudnorm_tp = -0.1;
         double audio_loudnorm_lra = 11.0;
         std::string audio_ffmpeg_filter = "";
+        bool audio_debug_wav = false;
 
         if (element.contains("audio_postprocess") && element["audio_postprocess"].is_object()) {
           const json &audio_post = element["audio_postprocess"];
@@ -404,6 +405,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
           audio_loudnorm_lra = audio_post.value("loudnorm_lra", 11.0);
 
           audio_ffmpeg_filter = audio_post.value("ffmpeg_filter", "");
+          audio_debug_wav = audio_post.value("debug_wav", false);
         }
 
         if (audio_highpass_hz < 0) {
@@ -437,6 +439,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         system->set_audio_loudnorm_tp(audio_loudnorm_tp);
         system->set_audio_loudnorm_lra(audio_loudnorm_lra);
         system->set_audio_ffmpeg_filter(audio_ffmpeg_filter);
+        system->set_audio_debug_wav(audio_debug_wav);
 
         BOOST_LOG_TRIVIAL(info) << "Audio Postprocess Enabled: " << system->get_audio_postprocess_enabled();
         BOOST_LOG_TRIVIAL(info) << "Audio Highpass (Hz): " << system->get_audio_highpass_hz();
@@ -454,6 +457,7 @@ bool load_config(string config_file, Config &config, gr::top_block_sptr &tb, std
         } else {
           BOOST_LOG_TRIVIAL(info) << "Audio FFmpeg Filter Override: <none>";
         }
+        BOOST_LOG_TRIVIAL(info) << "Audio Debug WAV: " << system->get_audio_debug_wav();
         system->set_unit_tags_file(element.value("unitTagsFile", ""));
         BOOST_LOG_TRIVIAL(info) << "Unit Tags File: " << system->get_unit_tags_file();
         system->set_unit_tags_ota_file(element.value("unitTagsOTA", ""));

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -150,7 +150,6 @@ struct Call_Data_t {
   bool call_log;
   bool compress_wav;
   std::string audio_bitrate = "32k";
-  std::string raw_filename;
   std::string filename;
   std::string status_filename;
   std::string converted;

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -73,6 +73,8 @@ struct Audio_Postprocess_Config {
   double loudnorm_lra = 11.0;
 
   std::string ffmpeg_filter = "";
+
+  bool debug_wav = false;
 };
 
 struct Call_Source {
@@ -153,6 +155,7 @@ struct Call_Data_t {
   std::string filename;
   std::string status_filename;
   std::string converted;
+  std::string debug_filename;
   int min_transmissions_removed;
 
   int sys_num;

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -74,7 +74,7 @@ struct Audio_Postprocess_Config {
 
   std::string ffmpeg_filter = "";
 
-  bool debug_wav = false;
+  bool output_raw_audio = false;
 };
 
 struct Call_Source {
@@ -155,7 +155,7 @@ struct Call_Data_t {
   std::string filename;
   std::string status_filename;
   std::string converted;
-  std::string debug_filename;
+  std::string raw_audio_filename;
   int min_transmissions_removed;
 
   int sys_num;

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -89,8 +89,8 @@ public:
   virtual std::string get_audio_ffmpeg_filter() = 0;
   virtual void set_audio_ffmpeg_filter(std::string filter) = 0;
 
-  virtual bool get_audio_debug_wav() = 0;
-  virtual void set_audio_debug_wav(bool enabled) = 0;
+  virtual bool get_audio_output_raw_audio() = 0;
+  virtual void set_audio_output_raw_audio(bool enabled) = 0;
 
   virtual std::string get_api_key() = 0;
   virtual void set_api_key(std::string api_key) = 0;

--- a/trunk-recorder/systems/system.h
+++ b/trunk-recorder/systems/system.h
@@ -89,6 +89,9 @@ public:
   virtual std::string get_audio_ffmpeg_filter() = 0;
   virtual void set_audio_ffmpeg_filter(std::string filter) = 0;
 
+  virtual bool get_audio_debug_wav() = 0;
+  virtual void set_audio_debug_wav(bool enabled) = 0;
+
   virtual std::string get_api_key() = 0;
   virtual void set_api_key(std::string api_key) = 0;
   virtual std::string get_bcfy_api_key() = 0;

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -149,12 +149,12 @@ void System_impl::set_audio_ffmpeg_filter(std::string filter) {
   this->audio_ffmpeg_filter = filter;
 }
 
-bool System_impl::get_audio_debug_wav() {
-  return this->audio_debug_wav;
+bool System_impl::get_audio_output_raw_audio() {
+  return this->audio_output_raw_audio;
 }
 
-void System_impl::set_audio_debug_wav(bool enabled) {
-  this->audio_debug_wav = enabled;
+void System_impl::set_audio_output_raw_audio(bool enabled) {
+  this->audio_output_raw_audio = enabled;
 }
 
 double System_impl::get_min_duration() {
@@ -218,7 +218,7 @@ System_impl::System_impl(int sys_num) {
   audio_loudnorm_tp = -0.1;
   audio_loudnorm_lra = 11.0;
   audio_ffmpeg_filter = "";
-  audio_debug_wav = false;
+  audio_output_raw_audio = false;
 }
 
 void System_impl::set_xor_mask(unsigned long sys_id, unsigned long wacn, unsigned long nac) {

--- a/trunk-recorder/systems/system_impl.cc
+++ b/trunk-recorder/systems/system_impl.cc
@@ -149,6 +149,14 @@ void System_impl::set_audio_ffmpeg_filter(std::string filter) {
   this->audio_ffmpeg_filter = filter;
 }
 
+bool System_impl::get_audio_debug_wav() {
+  return this->audio_debug_wav;
+}
+
+void System_impl::set_audio_debug_wav(bool enabled) {
+  this->audio_debug_wav = enabled;
+}
+
 double System_impl::get_min_duration() {
   return this->min_call_duration;
 }
@@ -210,6 +218,7 @@ System_impl::System_impl(int sys_num) {
   audio_loudnorm_tp = -0.1;
   audio_loudnorm_lra = 11.0;
   audio_ffmpeg_filter = "";
+  audio_debug_wav = false;
 }
 
 void System_impl::set_xor_mask(unsigned long sys_id, unsigned long wacn, unsigned long nac) {

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -105,7 +105,7 @@ public:
   double audio_loudnorm_tp;
   double audio_loudnorm_lra;
   std::string audio_ffmpeg_filter;
-  bool audio_debug_wav;
+  bool audio_output_raw_audio;
 
   unsigned xor_mask_len;
   const char *xor_mask;
@@ -168,8 +168,8 @@ public:
   std::string get_audio_ffmpeg_filter() override;
   void set_audio_ffmpeg_filter(std::string filter) override;
 
-  bool get_audio_debug_wav() override;
-  void set_audio_debug_wav(bool enabled) override;
+  bool get_audio_output_raw_audio() override;
+  void set_audio_output_raw_audio(bool enabled) override;
 
   std::string get_api_key() override;
   void set_api_key(std::string api_key) override;

--- a/trunk-recorder/systems/system_impl.h
+++ b/trunk-recorder/systems/system_impl.h
@@ -105,6 +105,7 @@ public:
   double audio_loudnorm_tp;
   double audio_loudnorm_lra;
   std::string audio_ffmpeg_filter;
+  bool audio_debug_wav;
 
   unsigned xor_mask_len;
   const char *xor_mask;
@@ -166,6 +167,9 @@ public:
 
   std::string get_audio_ffmpeg_filter() override;
   void set_audio_ffmpeg_filter(std::string filter) override;
+
+  bool get_audio_debug_wav() override;
+  void set_audio_debug_wav(bool enabled) override;
 
   std::string get_api_key() override;
   void set_api_key(std::string api_key) override;


### PR DESCRIPTION
  fix: correct ffmpeg concat path resolution and add debug WAV option
                                                                                                                                                                                                                                   
  Summary         
                                                                                                                                                                                                                                   
  - Fix broken audio rendering for calls with relative temp directories. The ffmpeg concat demuxer resolves paths inside a concat list file relative to the concat file's own directory, not the process working directory.        
  Previously the concat file was written to the capture directory (./audio/SCPD/2026/4/10/) while the transmission filenames inside it were CWD-relative (./temp/SCPD/...), producing a chimera path like
  ./audio/SCPD/2026/4/10/./temp/SCPD/... that does not exist. The concat file is now written to the same directory as the transmission files (the temp dir), with entries as bare filenames — ffmpeg resolves them correctly in    
  place.          
  - Remove the vestigial raw_filename field. Call_Data_t::raw_filename was never written to disk by any code path; it existed only as a naming stem for the (now-relocated) concat file and as a no-op in cleanup. It has been
  removed from the struct, the assignment in create_base_filename, and both cleanup branches in remove_call_files.                                                                                                                 
  - Add audio_postprocess.debug_wav option. When enabled, a .debug.wav file is saved alongside normal call output in the capture directory. It is produced via an ffmpeg stream copy — no filtering, resampling, or loudness
  normalization — preserving the exact sample rate and bit depth of the original recordings. Useful for comparing processed output against the raw source or diagnosing post-processing artifacts. The debug file is retained even 
  when audioArchive is false; it is only removed on plugin failure when archiveFilesOnFailure is also false.
                                                                                                                                                                                                                                   
  Test plan       

  - Confirm calls with a relative tempDir (e.g. ./temp) render successfully and produce valid .wav/.m4a output — no No such file or directory errors from ffmpeg                                                                   
  - Confirm calls with an absolute tempDir (e.g. /dev/shm) are unaffected
  - Confirm no .raw.wav files appear in the capture directory                                                                                                                                                                      
  - Enable debug_wav: true and confirm a .debug.wav appears in the capture directory alongside the normal call files                                                                                                               
  - Confirm the .debug.wav is unmodified audio (correct sample rate, no filtering) compared to the source transmissions                                                                                                            
  - Confirm .debug.wav is retained when audioArchive: false                                                                                                                                                                        
  - Confirm .debug.wav is removed when a call exhausts retries with archiveFilesOnFailure: false 