### PR TITLE
fix(smartnet): track carrier with a PLL instead of band-edge FLL

### DIFF
--- a/trunk-recorder/gr_blocks/xlat_channelizer.cc
+++ b/trunk-recorder/gr_blocks/xlat_channelizer.cc
@@ -1,8 +1,8 @@
 #include "xlat_channelizer.h"
 
-xlat_channelizer::sptr xlat_channelizer::make(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw) {
+xlat_channelizer::sptr xlat_channelizer::make(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw, bool use_fll) {
 
-  return gnuradio::get_initial_sptr(new xlat_channelizer(input_rate, samples_per_symbol, symbol_rate, bandwidth, center_freq, use_squelch, excess_bw));
+  return gnuradio::get_initial_sptr(new xlat_channelizer(input_rate, samples_per_symbol, symbol_rate, bandwidth, center_freq, use_squelch, excess_bw, use_fll));
 }
 
 const int xlat_channelizer::smartnet_samples_per_symbol;
@@ -40,7 +40,7 @@ xlat_channelizer::DecimSettings xlat_channelizer::get_decim(long speed) {
   return decim_settings;
 }
 
-xlat_channelizer::xlat_channelizer(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw=0.2)
+xlat_channelizer::xlat_channelizer(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw, bool use_fll)
     : gr::hier_block2("xlat_channelizer_ccf",
                       gr::io_signature::make(1, 1, sizeof(gr_complex)),
                       gr::io_signature::make(1, 1, sizeof(gr_complex))),
@@ -49,7 +49,8 @@ xlat_channelizer::xlat_channelizer(double input_rate, int samples_per_symbol, do
       d_bandwidth(bandwidth),
       d_samples_per_symbol(samples_per_symbol),
       d_symbol_rate(symbol_rate),
-      d_use_squelch(use_squelch) {
+      d_use_squelch(use_squelch),
+      d_use_fll(use_fll) {
 
   long channel_rate = d_symbol_rate * d_samples_per_symbol;
   // long if_rate = 12500;
@@ -120,7 +121,9 @@ xlat_channelizer::xlat_channelizer(double input_rate, int samples_per_symbol, do
   squelch = gr::analog::pwr_squelch_cc::make(squelch_db, 0.0001, 0, true);
 
   rms_agc = gr::blocks::rms_agc::make(0.45, 0.85);
-  fll_band_edge = gr::digital::fll_band_edge_cc::make(d_samples_per_symbol, excess_bw, 2 * d_samples_per_symbol + 1, (2.0 * pi) / d_samples_per_symbol / 250); // OP25 has this set to 350 instead of 250
+  if (d_use_fll) {
+    fll_band_edge = gr::digital::fll_band_edge_cc::make(d_samples_per_symbol, excess_bw, 2 * d_samples_per_symbol + 1, (2.0 * pi) / d_samples_per_symbol / 250); // OP25 has this set to 350 instead of 250
+  }
 
   connect(self(), 0, freq_xlat, 0);
   connect(freq_xlat, 0, channel_lpf, 0);
@@ -142,11 +145,21 @@ xlat_channelizer::xlat_channelizer(double input_rate, int samples_per_symbol, do
     }
   }
 
-  connect(rms_agc, 0, fll_band_edge, 0);
-  connect(fll_band_edge, 0, self(), 0);
+  if (d_use_fll) {
+    connect(rms_agc, 0, fll_band_edge, 0);
+    connect(fll_band_edge, 0, self(), 0);
+  } else {
+    // Band-edge FLL is matched to shaped (RRC) signals like P25; for SmartNet
+    // NRZ FSK it doesn't lock cleanly. Callers opting out get the AGC output
+    // directly and are expected to track the carrier downstream.
+    connect(rms_agc, 0, self(), 0);
+  }
 }
 
 int xlat_channelizer::get_freq_error() { // get frequency error from FLL and convert to Hz
+  if (!fll_band_edge) {
+    return 0;
+  }
   const float pi = M_PI;
   long if_rate = 24000;
   return int((fll_band_edge->get_frequency() / (2 * pi)) * if_rate);

--- a/trunk-recorder/gr_blocks/xlat_channelizer.h
+++ b/trunk-recorder/gr_blocks/xlat_channelizer.h
@@ -39,8 +39,8 @@ public:
   typedef std::shared_ptr<xlat_channelizer> sptr;
 #endif
 
-  static sptr make(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw=default_excess_bw);
-  xlat_channelizer(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw);
+  static sptr make(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw=default_excess_bw, bool use_fll=true);
+  xlat_channelizer(double input_rate, int samples_per_symbol, double symbol_rate, double bandwidth, double center_freq, bool use_squelch, double excess_bw, bool use_fll);
 
   struct DecimSettings {
     long decim;
@@ -78,6 +78,7 @@ private:
   double d_symbol_rate;
 
   bool d_use_squelch;
+  bool d_use_fll;
   long symbol_rate;
   double initial_rate;
   double squelch_db;

--- a/trunk-recorder/systems/smartnet_fsk2_demod.cc
+++ b/trunk-recorder/systems/smartnet_fsk2_demod.cc
@@ -19,9 +19,13 @@ smartnet_fsk2_demod::~smartnet_fsk2_demod() {
 }
 
 void smartnet_fsk2_demod::reset() {
-  // Clear stale tracking state (symbol clock, symbol spread, fine/coarse
-  // frequency correction) so reacquisition on a new control channel doesn't
-  // start from whatever state the loop ended up in while staring at noise.
+  // Clear stale tracking state on the carrier PLL and the symbol-tracking
+  // loops so reacquisition on a new control channel doesn't start from
+  // whatever state things converged to while staring at noise.
+  if (pll_demod) {
+    pll_demod->set_phase(0);
+    pll_demod->set_frequency(0);
+  }
   if (fsk4_demod) {
     fsk4_demod->reset();
   }
@@ -52,20 +56,25 @@ void smartnet_fsk2_demod::initialize() {
   // Binary slicer
   slicer = gr::digital::binary_slicer_fb::make();
 
-  // FM demod gain based on deviation
-  // SmartNet uses ±1.2kHz deviation for FSK
-  const double deviation = 1200.0;
-  float fm_demod_gain = channel_rate / (2 * pi * deviation);
-  fm_demod = gr::analog::quadrature_demod_cf::make(fm_demod_gain);
+  // Carrier-tracking PLL used as the FM frequency detector. Same
+  // configuration as the pre-#1085 SmartNet chain: a fast loop (2/sps) wide
+  // enough to track the FSK modulation, with the lock range set to ±pi/sps —
+  // ~±1800 Hz at the 18 kHz channel rate, enough headroom for the ±1.2 kHz
+  // FSK deviation plus typical receiver oscillator drift. Replaces the
+  // open-loop quadrature_demod_cf so any residual carrier offset gets pulled
+  // in rather than appearing as a DC bias on the slicer input.
+  const float loop_bw = 2.0f / samples_per_symbol;
+  const float max_freq = (float)(pi / samples_per_symbol);
+  pll_demod = gr::analog::pll_freqdet_cf::make(loop_bw, max_freq, -max_freq);
 
   // Frame assembler and null sinks
   framer = gr::op25_repeater::frame_assembler::make("smartnet", 1, 1, rx_queue, false);
   null_sink1 = gr::blocks::null_sink::make(sizeof(uint16_t));
   null_sink2 = gr::blocks::null_sink::make(sizeof(uint16_t));
 
-  // Signal flow: Input -> FM Demod -> Baseband AGC -> Symbol Filter -> FSK4 Demod -> Slicer -> Framer
-  connect(self(), 0, fm_demod, 0);
-  connect(fm_demod, 0, baseband_amp, 0);
+  // Signal flow: Input -> PLL Freq Det -> Baseband AGC -> Symbol Filter -> FSK4 Demod -> Slicer -> Framer
+  connect(self(), 0, pll_demod, 0);
+  connect(pll_demod, 0, baseband_amp, 0);
   connect(baseband_amp, 0, sym_filter, 0);
   connect(sym_filter, 0, fsk4_demod, 0);
   connect(fsk4_demod, 0, slicer, 0);

--- a/trunk-recorder/systems/smartnet_fsk2_demod.h
+++ b/trunk-recorder/systems/smartnet_fsk2_demod.h
@@ -2,7 +2,7 @@
 #define SMARTNET_FSK2_DEMOD_H
 
 #include <boost/shared_ptr.hpp>
-#include <gnuradio/analog/quadrature_demod_cf.h>
+#include <gnuradio/analog/pll_freqdet_cf.h>
 #include <gnuradio/block.h>
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/io_signature.h>
@@ -48,7 +48,7 @@ private:
   gr::msg_queue::sptr rx_queue;
   gr::msg_queue::sptr tune_queue;
   gr::filter::fir_filter_fff::sptr sym_filter;
-  gr::analog::quadrature_demod_cf::sptr fm_demod;
+  gr::analog::pll_freqdet_cf::sptr pll_demod;
   gr::op25_repeater::rmsagc_ff::sptr baseband_amp;
   gr::op25_repeater::fsk4_demod_ff::sptr fsk4_demod;
   gr::digital::binary_slicer_fb::sptr slicer;

--- a/trunk-recorder/systems/smartnet_impl.cc
+++ b/trunk-recorder/systems/smartnet_impl.cc
@@ -36,7 +36,10 @@ void smartnet_impl::initialize(double freq, double center, long s, gr::msg_queue
   this->sys_num = sys_num;
 
 
-  prefilter = xlat_channelizer::make(input_rate, xlat_channelizer::smartnet_samples_per_symbol, xlat_channelizer::smartnet_symbol_rate, xlat_channelizer::channel_bandwidth, center_freq, false, xlat_channelizer::smartnet_excess_bw);
+  // use_fll=false: band-edge FLL is matched to RRC-shaped signals and doesn't
+  // lock cleanly on SmartNet's NRZ 2FSK. The PLL inside smartnet_fsk2_demod
+  // (pll_freqdet_cf) handles carrier tracking instead.
+  prefilter = xlat_channelizer::make(input_rate, xlat_channelizer::smartnet_samples_per_symbol, xlat_channelizer::smartnet_symbol_rate, xlat_channelizer::channel_bandwidth, center_freq, false, xlat_channelizer::smartnet_excess_bw, false);
 
   double offset_amount = (center_freq - chan_freq);
   prefilter->tune_offset(offset_amount);


### PR DESCRIPTION
The OP25-based decode chain introduced in #1085 relies on xlat_channelizer's fll_band_edge_cc for carrier tracking. That block is designed for RRC-shaped digital signals (P25 4FSK, etc.) and keys off band-edge energy that NRZ 2FSK simply doesn't produce, so for SmartNet it doesn't actually lock — leaving any receiver oscillator drift to show up as a DC bias on the slicer input, which the slow fine_frequency_correction loop in fsk4_demod_ff has to chase from scratch on every reacquire.

Bring back the closed-loop carrier tracker that the pre-#1085 chain used (pll_freqdet_cf), which works for unshaped FSK:

- xlat_channelizer: add a use_fll constructor flag (default true so P25/DMR/analog callers are unchanged). When false, the band-edge FLL is skipped and rms_agc connects straight to the output; guard get_freq_error() against the now-possibly-null fll_band_edge.

- smartnet_impl: build its xlat_channelizer with use_fll=false.

- smartnet_fsk2_demod: replace quadrature_demod_cf with a pll_freqdet_cf (loop_bw = 2/sps = 0.4, lock range ±pi/sps ≈ ±1800 Hz at the 18 kHz channel rate — the same parameters the old smartnet_trunking.cc chain used, sized for the ±1.2 kHz FSK deviation plus typical oscillator offset). reset() now also clears the PLL's phase and frequency state so a retune doesn't inherit whatever the loop converged to on the previous channel.