### PR TITLE
Prevent flowgraph shutdown hangs

### DIFF
--- a/trunk-recorder/main.cc
+++ b/trunk-recorder/main.cc
@@ -22,15 +22,19 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <condition_variable>
+#include <cstdlib>
 #include <exception>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <signal.h>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
 #include <sys/time.h>
+#include <thread>
 #include <time.h>
 #include <unistd.h>
 #include <utility>
@@ -85,6 +89,38 @@ gr::top_block_sptr tb;
 
 Config config;
 
+namespace {
+
+constexpr std::chrono::seconds flowgraph_shutdown_timeout(10);
+
+void stop_flowgraph_or_exit(gr::top_block_sptr &flowgraph, int exit_code) {
+  std::mutex shutdown_mutex;
+  std::condition_variable shutdown_condition;
+  bool shutdown_finished = false;
+
+  std::thread shutdown_watchdog([&shutdown_mutex, &shutdown_condition, &shutdown_finished, exit_code]() {
+    std::unique_lock<std::mutex> lock(shutdown_mutex);
+    if (!shutdown_condition.wait_for(lock, flowgraph_shutdown_timeout, [&shutdown_finished]() { return shutdown_finished; })) {
+      BOOST_LOG_TRIVIAL(fatal) << "Flow graph failed to stop within " << flowgraph_shutdown_timeout.count() << " seconds - forcing process exit";
+      std::_Exit(exit_code);
+    }
+  });
+
+  flowgraph->stop();
+  BOOST_LOG_TRIVIAL(info) << "flow graph stop requested - waiting for worker threads";
+  flowgraph->wait();
+  BOOST_LOG_TRIVIAL(info) << "flow graph stopped";
+
+  {
+    std::lock_guard<std::mutex> lock(shutdown_mutex);
+    shutdown_finished = true;
+  }
+  shutdown_condition.notify_one();
+  shutdown_watchdog.join();
+}
+
+} // namespace
+
 int main(int argc, char **argv) {
   // BOOST_STATIC_ASSERT(true) __attribute__((unused));
   int exit_code = EXIT_SUCCESS;
@@ -133,8 +169,7 @@ int main(int argc, char **argv) {
     // -- stop flow graph execution
     // ------------------------------------------------------------------
     BOOST_LOG_TRIVIAL(info) << "stopping flow graph" << std::endl;
-    tb->stop();
-    tb->wait();
+    stop_flowgraph_or_exit(tb, exit_code);
 
     BOOST_LOG_TRIVIAL(info) << "stopping plugins" << std::endl;
     stop_plugins();


### PR DESCRIPTION
## The issue I ran into

I had an Airspy stop delivering samples. Trunk Recorder noticed the stalled source, concluded the active calls, finished the pending uploads, and started shutting down. The last message it logged was `stopping flow graph`, though, and the process never actually exited.

That left the container alive but unable to do any useful work. Since Docker still saw a running process, its restart policy could not bring the recorder back automatically.

I traced the hang to GNU Radio flowgraph shutdown. The Airspy source block can have a worker waiting for more samples after RX has already stopped. In that state, `top_block::stop()` does not necessarily wake the worker, so `top_block::wait()` can wait forever for it to finish.

## What I changed

I wrapped flowgraph shutdown in a 10-second watchdog. Normal shutdown still follows the same graceful `stop()` and `wait()` path. If GNU Radio does not finish within the timeout, Trunk Recorder logs a fatal error and exits with the exit code it was already going to return. That lets Docker or another process supervisor restart it instead of leaving a dead recorder running indefinitely.

I also added separate log messages after the stop request and after all worker threads have stopped. If this happens with another source or block, the logs will make it clearer which part of shutdown is stuck.

## Validation

- I built Trunk Recorder and all bundled plugins successfully in a clean Ubuntu 24.04 Docker builder image.
- `git diff --check` passes.

I could not replay the original USB/SDR failure because the affected live container had already been recreated.
